### PR TITLE
ci(github): switch build & lint step

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -53,10 +53,10 @@ jobs:
         id: install-dependencies
         run: pnpm install
 
-      - name: ⏳ Lint All Files
-        id: lint
-        run: pnpm lint
-
       - name: 🏗️ Build
         id: build
         run:  pnpm build
+
+      - name: ⏳ Lint All Files
+        id: lint
+        run: pnpm lint


### PR DESCRIPTION
### Purpose

`Builder` is failing due to having the `lint` step before the `build`

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
