### PR TITLE
chore(react): add floating buttons to Carousel in the mobile view

### DIFF
--- a/packages/react/src/components/Carousel/Carousel.tsx
+++ b/packages/react/src/components/Carousel/Carousel.tsx
@@ -16,15 +16,18 @@
  * under the License.
  */
 
+import {useMediaQuery} from '@mui/material';
 import {ChevronLeftIcon, ChevronRightIcon} from '@oxygen-ui/react-icons';
 import clsx from 'clsx';
 import {FC, HTMLAttributes, ReactElement, useEffect, useMemo, useState} from 'react';
-import {WithWrapperProps} from '../../models';
+import {Theme, WithWrapperProps} from '../../models';
 import {composeComponentDisplayName} from '../../utils';
 import Box from '../Box';
 import Button from '../Button';
 import Card from '../Card';
 import CardContent from '../CardContent';
+import IconButton from '../IconButton';
+import {IconButtonVariants} from '../IconButton/IconButton';
 import {Stepper} from '../Stepper';
 import Typography from '../Typography';
 import './carousel.scss';
@@ -87,8 +90,9 @@ const Carousel: FC<CarouselProps> & WithWrapperProps = (props: CarouselProps): R
 
   const isLastStep: boolean = useMemo(() => currentStep === steps.length - 1, [steps, currentStep]);
   const isFirstStep: boolean = useMemo(() => currentStep === 0, [currentStep]);
+  const isMobile: boolean = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
-  const classes: string = clsx('oxygen-carousel', className);
+  const classes: string = clsx('oxygen-carousel', {mobile: isMobile}, className);
 
   useEffect(() => {
     if (!autoPlay) {
@@ -148,26 +152,47 @@ const Carousel: FC<CarouselProps> & WithWrapperProps = (props: CarouselProps): R
     <Box className={classes} {...rest}>
       <Box className="oxygen-carousel-top-bar">
         <Box className="oxygen-carousel-title">{title && <Typography variant="body1">{title}</Typography>}</Box>
-        <Box className="oxygen-carousel-button-group">
-          <Button
-            variant="text"
-            color="secondary"
-            disabled={isFirstStep}
-            onClick={handlePreviousButtonClick}
-            startIcon={<ChevronLeftIcon />}
-          >
-            {previousButtonText}
-          </Button>
-          <Button
-            variant="text"
-            color="secondary"
-            disabled={isLastStep}
-            onClick={handleNextButtonClick}
-            endIcon={<ChevronRightIcon />}
-          >
-            {nextButtonText}
-          </Button>
-        </Box>
+        {isMobile ? (
+          <Box className="oxygen-carousel-mobile-buttons">
+            <IconButton
+              variant={IconButtonVariants.CONTAINED}
+              color="secondary"
+              disabled={isFirstStep}
+              onClick={handlePreviousButtonClick}
+            >
+              <ChevronLeftIcon />
+            </IconButton>
+            <IconButton
+              variant={IconButtonVariants.CONTAINED}
+              color="secondary"
+              disabled={isLastStep}
+              onClick={handleNextButtonClick}
+            >
+              <ChevronRightIcon />
+            </IconButton>
+          </Box>
+        ) : (
+          <Box className="oxygen-carousel-button-group">
+            <Button
+              variant="text"
+              color="secondary"
+              disabled={isFirstStep}
+              onClick={handlePreviousButtonClick}
+              startIcon={<ChevronLeftIcon />}
+            >
+              {previousButtonText}
+            </Button>
+            <Button
+              variant="text"
+              color="secondary"
+              disabled={isLastStep}
+              onClick={handleNextButtonClick}
+              endIcon={<ChevronRightIcon />}
+            >
+              {nextButtonText}
+            </Button>
+          </Box>
+        )}
       </Box>
       <Box>
         <Stepper animateOnSlide steps={generateCarouselSteps()} currentStep={currentStep} />

--- a/packages/react/src/components/Carousel/carousel.scss
+++ b/packages/react/src/components/Carousel/carousel.scss
@@ -17,6 +17,8 @@
  */
 
 .oxygen-carousel {
+  position: relative;
+
   .oxygen-carousel-top-bar {
     display: flex;
     justify-content: space-between;
@@ -49,5 +51,14 @@
     display: flex;
     justify-content: flex-end;
     padding-top: 1em;
+  }
+
+  .oxygen-carousel-mobile-buttons {
+    display: flex;
+    justify-content: space-between;
+    z-index: 1;
+    position: absolute;
+    width: 100%;
+    bottom: calc(42px + 1em);
   }
 }


### PR DESCRIPTION
### Purpose
<img width="454" alt="image" src="https://user-images.githubusercontent.com/20745428/221491111-d1d7d399-336e-4a22-af0e-3d6bed6767e9.png">
This replaces the static navigation buttons with floating ones in the mobile view in the `Carousel` component. 

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
