### PR TITLE
chore(react): set Carousel container width to 100%

### DIFF
--- a/packages/react/src/components/Carousel/carousel.scss
+++ b/packages/react/src/components/Carousel/carousel.scss
@@ -18,6 +18,7 @@
 
 .oxygen-carousel {
   position: relative;
+  width: 100%;
 
   .oxygen-carousel-top-bar {
     display: flex;


### PR DESCRIPTION
### Purpose
This PR fixes the issue of the Carousel component overflowing the width of the containing component. 

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
