### PR TITLE
feat(react): add `AccountOverview` component

### DIFF
--- a/packages/react/.storybook/story-config.ts
+++ b/packages/react/.storybook/story-config.ts
@@ -32,6 +32,7 @@ enum StorybookCategories {
 }
 
 export type Stories =
+  | 'AccountOverview'
   | 'ActionCard'
   | 'AppBar'
   | 'AppShell'
@@ -105,6 +106,9 @@ export type StorybookConfig = Record<
 >;
 
 const StoryConfig: StorybookConfig = {
+  AccountOverview: {
+    hierarchy: `${StorybookCategories.Patterns}/Account Overview`,
+  },
   ActionCard: {
     hierarchy: `${StorybookCategories.Surfaces}/Action Card`,
   },

--- a/packages/react/src/components/AccountOverview/AccountOverview.stories.mdx
+++ b/packages/react/src/components/AccountOverview/AccountOverview.stories.mdx
@@ -6,7 +6,6 @@ import StoryConfig from '../../../.storybook/story-config.ts';
 import {withDesign} from '../../../.storybook/utils.ts';
 import Typography from '../Typography';
 
-
 export const meta = {
   component: AccountOverview,
   title: StoryConfig.AccountOverview.hierarchy,
@@ -16,7 +15,7 @@ export const meta = {
 
 export const Template = args => <AccountOverview {...args} />;
 
-# Menu
+# AccountOverview
 
 - [Overview](#overview)
 - [Props](#props)
@@ -27,7 +26,7 @@ export const Template = args => <AccountOverview {...args} />;
 
 ## Overview
 
-Menu.
+This component is used to display the user's account overview. It includes the user's profile picture, name, email, account progress and account completion steps.
 
 <Canvas>
   <Story
@@ -81,7 +80,7 @@ Import and use the `Button` component in your components as follows.
   dark
   format
   code={dedent`
-import Button from '@oxygen-ui/react/AccountOverview';\n
+import AccountOverview from '@oxygen-ui/react/AccountOverview';\n
 function Demo() {
   return <AccountOverview
             user={{
@@ -157,4 +156,5 @@ function Demo() {
     }}
   >
     {Template.bind({})}
-  </Story></Canvas>
+  </Story>
+</Canvas>

--- a/packages/react/src/components/AccountOverview/AccountOverview.stories.mdx
+++ b/packages/react/src/components/AccountOverview/AccountOverview.stories.mdx
@@ -1,0 +1,160 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import AccountOverview from './AccountOverview.tsx';
+import Button from '../Button';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import {withDesign} from '../../../.storybook/utils.ts';
+import Typography from '../Typography';
+
+
+export const meta = {
+  component: AccountOverview,
+  title: StoryConfig.AccountOverview.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => <AccountOverview {...args} />;
+
+# Menu
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+- [Variants](#variants)
+  - [Incomplete](#incomplete)
+  - [Complete](#complete)
+
+## Overview
+
+Menu.
+
+<Canvas>
+  <Story
+    name="Overview"
+    args={{
+      title: <Typography variant="h5">Welcome Mathew</Typography>,
+      subheader: <Typography variant="body2">Manage your personal information, account security and privacy settings.</Typography>, 
+      user:{
+        image: '/assets/images/avatar-john.svg',
+        name: 'Matthew',
+        email: 'matthew@wso2.com'
+      },
+      accountProgress: 60,
+      accountCompletionStepsTitle: "Complete your Profile. It's at 60%",
+      accountCompletionSteps: [
+        {
+          title: 'Add your email address',
+          description: 'You can add your email address to your profile to receive notifications and updates from us.',
+          illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
+          action: <Button variant="outlined">Add Email</Button>
+        },
+        {
+          title: 'Add your phone number',
+          description: 'You can add your phone number to your profile to receive notifications and updates from us.',
+          illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
+          action: <Button variant="outlined">Add Phone</Button>
+        },
+        {
+          title: 'Add your address',
+          description: 'You can add your address to your profile to receive notifications and updates from us.',
+          illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
+          action: <Button variant="outlined">Add Address</Button>
+        }
+      ],
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `Button` component in your components as follows.
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import Button from '@oxygen-ui/react/AccountOverview';\n
+function Demo() {
+  return <AccountOverview
+            user={{
+              image: '/assets/images/avatar-john.svg',
+              name: 'Matthew',
+              email: 'matthew@wso2.com',
+            }}
+            title={<Typography variant="h5">Welcome Mathew</Typography>}
+            accountProgress={60}
+          />
+}`}
+/>
+
+## Variants
+
+### Incomplete
+
+<Canvas>
+  <Story
+    name="Incomplete"
+    args={{
+      title: <Typography variant="h5">Welcome Mathew</Typography>,
+      subheader: <Typography variant="body2">Manage your personal information, account security and privacy settings.</Typography>, 
+      user:{
+        image: '/assets/images/avatar-john.svg',
+        name: 'Matthew',
+        email: 'matthew@wso2.com'
+      },
+      accountProgress: 60,
+      accountCompletionStepsTitle: "Complete your Profile. It's at 60%",
+      accountCompletionSteps: [
+        {
+          title: 'Add your email address',
+          description: 'You can add your email address to your profile to receive notifications and updates from us.',
+          illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
+          action: <Button variant="outlined">Add Email</Button>
+        },
+        {
+          title: 'Add your phone number',
+          description: 'You can add your phone number to your profile to receive notifications and updates from us.',
+          illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
+          action: <Button variant="outlined">Add Phone</Button>
+        },
+        {
+          title: 'Add your address',
+          description: 'You can add your address to your profile to receive notifications and updates from us.',
+          illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
+          action: <Button variant="outlined">Add Address</Button>
+        }
+      ],
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+  </Canvas>
+
+### Complete
+
+<Canvas>
+  <Story
+    name="Complete"
+    args={{
+      title: <Typography variant="h5">Welcome Mathew</Typography>,
+      subheader: <Typography variant="body2">Manage your personal information, account security and privacy settings.</Typography>, 
+      user:{
+        image: '/assets/images/avatar-john.svg',
+        name: 'Matthew',
+        email: 'matthew@wso2.com'
+      },
+      accountCompletionStepsTitle: "Complete your Profile. It's at 60%",
+      accountProgress: 100, 
+      illustration: <img src="/assets/images/action-card-image.svg" alt="image" /> 
+    }}
+  >
+    {Template.bind({})}
+  </Story></Canvas>

--- a/packages/react/src/components/AccountOverview/AccountOverview.stories.mdx
+++ b/packages/react/src/components/AccountOverview/AccountOverview.stories.mdx
@@ -73,7 +73,7 @@ This component is used to display the user's account overview. It includes the u
 
 ## Usage
 
-Import and use the `Button` component in your components as follows.
+Import and use the `AccountOverview` component in your components as follows.
 
 <Source
   language="jsx"

--- a/packages/react/src/components/AccountOverview/AccountOverview.tsx
+++ b/packages/react/src/components/AccountOverview/AccountOverview.tsx
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import clsx from 'clsx';
+import {FC, ReactElement, ReactNode} from 'react';
+import {WithWrapperProps} from '../../models';
+import {composeComponentDisplayName} from '../../utils';
+import Box from '../Box';
+import Card, {CardProps} from '../Card';
+import CardHeader, {CardHeaderProps} from '../CardHeader';
+import {Carousel, CarouselStep} from '../Carousel';
+import CircularProgressAvatar from '../CircularProgressAvatar';
+import Divider from '../Divider';
+import {UserTemplate} from '../UserDropdownMenu';
+import './account-overview.scss';
+
+export interface AccountOverviewProps extends Omit<CardProps, 'title'> {
+  /**
+   * Account completion steps.
+   */
+  accountCompletionSteps?: AccountCompletionSteps[];
+  /**
+   * Account completion steps title.
+   */
+  accountCompletionStepsTitle?: string;
+  /**
+   * Account progress.
+   */
+  accountProgress: number;
+  /**
+   * Card header props.
+   */
+  cardHeaderProps?: CardHeaderProps;
+  /**
+   * Card Subheader.
+   * @example <span>subheader</span>
+   */
+  subheader?: ReactNode;
+  /**
+   * Card Title.
+   * @example <span>title</span>
+   */
+  title: ReactNode;
+  /**
+   * Logged user information.
+   */
+  user: UserTemplate;
+}
+
+export type AccountCompletionSteps = CarouselStep;
+
+const COMPONENT_NAME: string = 'AccountOverview';
+
+const AccountOverview: FC<AccountOverviewProps> & WithWrapperProps = (props: AccountOverviewProps): ReactElement => {
+  const {
+    className,
+    title,
+    subheader,
+    accountCompletionStepsTitle,
+    accountCompletionSteps,
+    accountProgress,
+    user,
+    cardHeaderProps,
+    ...rest
+  } = props;
+
+  const classes: string = clsx('oxygen-account-overview', className);
+
+  return (
+    <Card className={classes} elevation={0} variant="outlined" {...rest}>
+      <CardHeader
+        avatar={
+          <CircularProgressAvatar
+            color={accountProgress < 100 ? 'warning' : 'success'}
+            progress={accountProgress}
+            avatarOptions={{alt: "User's avatar", src: user?.image}}
+            badgeOptions={{badgeContent: `${accountProgress}%`, color: accountProgress < 100 ? 'warning' : 'success'}}
+          />
+        }
+        title={title}
+        subheader={subheader}
+        {...cardHeaderProps}
+      />
+      {accountCompletionSteps && (
+        <Box className="oxygen-account-completion-steps-box">
+          <Divider />
+          <Carousel title={accountCompletionStepsTitle} steps={accountCompletionSteps} />
+        </Box>
+      )}
+    </Card>
+  );
+};
+
+AccountOverview.displayName = composeComponentDisplayName(COMPONENT_NAME);
+AccountOverview.muiName = COMPONENT_NAME;
+
+export default AccountOverview;

--- a/packages/react/src/components/AccountOverview/account-overview.scss
+++ b/packages/react/src/components/AccountOverview/account-overview.scss
@@ -16,6 +16,15 @@
  * under the License.
  */
 
-export {default as Carousel} from './Carousel';
-export type {CarouselProps} from './Carousel';
-export type {CarouselStep} from './Carousel';
+.oxygen-account-overview {
+  padding: 0.8rem 1rem;
+
+  .oxygen-card-header {
+    padding: 1rem 0;
+    padding-bottom: 1.5rem;
+  }
+
+  .oxygen-account-completion-steps-box {
+    padding: 0.5rem;
+  }
+}

--- a/packages/react/src/components/AccountOverview/index.ts
+++ b/packages/react/src/components/AccountOverview/index.ts
@@ -16,6 +16,5 @@
  * under the License.
  */
 
-export {default as Carousel} from './Carousel';
-export type {CarouselProps} from './Carousel';
-export type {CarouselStep} from './Carousel';
+export {default} from './AccountOverview';
+export type {AccountOverviewProps} from './AccountOverview';

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -30,7 +30,7 @@ const COMPONENT_NAME: string = 'Avatar';
 const Avatar: FC<AvatarProps> & WithWrapperProps = (props: AvatarProps): ReactElement => {
   const {className, ...rest} = props;
 
-  const classes: string = clsx('oxygen-ui-avatar', className);
+  const classes: string = clsx('oxygen-avatar', className);
 
   return <MuiAvatar className={classes} {...rest} />;
 };

--- a/packages/react/src/components/Avatar/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/react/src/components/Avatar/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Avatar should match the snapshot 1`] = `
 <body>
   <div>
     <div
-      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault oxygen-ui-avatar css-woe6xp-MuiAvatar-root"
+      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault oxygen-avatar css-woe6xp-MuiAvatar-root"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/Carousel/Carousel.stories.mdx
+++ b/packages/react/src/components/Carousel/Carousel.stories.mdx
@@ -1,8 +1,9 @@
 import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import Button from '../Button';
 import Carousel from './Carousel.tsx';
 import dedent from 'ts-dedent';
-import Typography from '../Typography';
 import StoryConfig from '../../../.storybook/story-config.ts';
+import Typography from '../Typography';
 
 export const meta = {
   component: Carousel,
@@ -29,21 +30,19 @@ Carousel can be used to slide through content.
     args={{
         steps: [
             {
+              action: <Button variant="outlined" onClick={()=>{}}>Add First Name</Button>,
               title: "What is your first name?",
               description: "Start theming journey with Oxygen UI",
               illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
-              buttonText: "Add first name",
-              onButtonClick: ()=>{}
             },
             {
+              action: <Button variant="outlined" onClick={()=>{}}>Add Last Name</Button>,
               title: "What is your last name?",
               description: "Start theming journey with Oxygen UI",
               illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
-              buttonText: "Add last name",
-              onButtonClick: ()=>{}
             }
       ],
-      title: "Complete your profile. It’s at 60%"
+      title: <Typography>Complete your Profile. It’s at 60%</Typography> 
     }}
   >
     {Template.bind({})}
@@ -69,11 +68,10 @@ function Demo() {
     <Carousel
         steps={[
             {
+              action: <Button variant="outlined" color="primary" onClick={()=>{}}>Add Last Name</Button>,
               title: "What is your first name?",
               description: "Start theming journey with Oxygen UI",
               illustration: <img src="/assets/images/carousel-illustration.svg" alt="carousel illustration" />,
-              buttonText: "Add first name",
-              onButtonClick: ()=>{}
             }
         ]}
     />

--- a/packages/react/src/components/Carousel/Carousel.tsx
+++ b/packages/react/src/components/Carousel/Carousel.tsx
@@ -147,49 +147,44 @@ const Carousel: FC<CarouselProps> & WithWrapperProps = (props: CarouselProps): R
     <Box className={classes} {...rest}>
       <Box className="oxygen-carousel-top-bar">
         <Box className="oxygen-carousel-title">{title}</Box>
-        {isMobile ? (
-          <Box className="oxygen-carousel-mobile-buttons">
-            <IconButton
-              className="oxygen-carousel-mobile-button-left"
-              variant={IconButtonVariants.CONTAINED}
-              color="secondary"
-              disabled={isFirstStep}
-              onClick={handlePreviousButtonClick}
-            >
-              <ChevronLeftIcon />
-            </IconButton>
-            <IconButton
-              className="oxygen-carousel-mobile-button-right"
-              variant={IconButtonVariants.CONTAINED}
-              color="secondary"
-              disabled={isLastStep}
-              onClick={handleNextButtonClick}
-            >
-              <ChevronRightIcon />
-            </IconButton>
-          </Box>
-        ) : (
-          <Box className="oxygen-carousel-button-group">
-            <Button
-              variant="text"
-              color="secondary"
-              disabled={isFirstStep}
-              onClick={handlePreviousButtonClick}
-              startIcon={<ChevronLeftIcon />}
-            >
-              {previousButtonText}
-            </Button>
-            <Button
-              variant="text"
-              color="secondary"
-              disabled={isLastStep}
-              onClick={handleNextButtonClick}
-              endIcon={<ChevronRightIcon />}
-            >
-              {nextButtonText}
-            </Button>
-          </Box>
-        )}
+        <Box className="oxygen-carousel-mobile-buttons">
+          <IconButton
+            variant={IconButtonVariants.CONTAINED}
+            color="secondary"
+            disabled={isFirstStep}
+            onClick={handlePreviousButtonClick}
+          >
+            <ChevronLeftIcon />
+          </IconButton>
+          <IconButton
+            variant={IconButtonVariants.CONTAINED}
+            color="secondary"
+            disabled={isLastStep}
+            onClick={handleNextButtonClick}
+          >
+            <ChevronRightIcon />
+          </IconButton>
+        </Box>
+        <Box className="oxygen-carousel-button-group">
+          <Button
+            variant="text"
+            color="secondary"
+            disabled={isFirstStep}
+            onClick={handlePreviousButtonClick}
+            startIcon={<ChevronLeftIcon />}
+          >
+            {previousButtonText}
+          </Button>
+          <Button
+            variant="text"
+            color="secondary"
+            disabled={isLastStep}
+            onClick={handleNextButtonClick}
+            endIcon={<ChevronRightIcon />}
+          >
+            {nextButtonText}
+          </Button>
+        </Box>
       </Box>
       <Box>
         <Stepper animateOnSlide steps={generateCarouselSteps()} currentStep={currentStep} />

--- a/packages/react/src/components/Carousel/Carousel.tsx
+++ b/packages/react/src/components/Carousel/Carousel.tsx
@@ -18,7 +18,7 @@
 
 import {ChevronLeftIcon, ChevronRightIcon} from '@oxygen-ui/react-icons';
 import clsx from 'clsx';
-import {FC, HTMLAttributes, ReactElement, useEffect, useMemo, useState} from 'react';
+import {FC, HTMLAttributes, ReactElement, ReactNode, useEffect, useMemo, useState} from 'react';
 import {useIsMobile} from '../../hooks';
 import {WithWrapperProps} from '../../models';
 import {composeComponentDisplayName} from '../../utils';
@@ -28,34 +28,36 @@ import Card from '../Card';
 import CardContent from '../CardContent';
 import IconButton from '../IconButton';
 import {IconButtonVariants} from '../IconButton/IconButton';
+import ListItem from '../ListItem';
+import ListItemIcon from '../ListItemIcon';
+import ListItemText from '../ListItemText';
 import {Stepper} from '../Stepper';
-import Typography from '../Typography';
 import './carousel.scss';
 
-interface CarouselStep {
+export interface CarouselStep {
   /**
-   * The text to be displayed in the button.
+   * Action to be performed on the step.
+   * @example <Button onClick={() => {}}>Action Button</Button>
    */
-  buttonText: string;
+  action?: ReactNode;
   /**
    * The description of the step.
+   * @example <span>description</span>
    */
-  description: string;
+  description?: ReactNode;
   /**
    * The illustration to be displayed in the step.
+   * @example <img src="https://example.com/image.png" alt="icon" />
    */
-  illustration: ReactElement;
-  /**
-   * Callback method to be called when the button is clicked.
-   */
-  onButtonClick: () => void;
+  illustration?: ReactElement;
   /**
    * The title of the step.
+   * @example <span>title</span>
    */
-  title: string;
+  title: ReactNode;
 }
 
-export interface CarouselProps extends HTMLAttributes<HTMLDivElement> {
+export interface CarouselProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /**
    * Specifies whether to auto play the carousel.
    */
@@ -78,8 +80,9 @@ export interface CarouselProps extends HTMLAttributes<HTMLDivElement> {
   steps: CarouselStep[];
   /**
    * The title of the carousel.
+   * @example <span>title</span>
    */
-  title?: string;
+  title?: ReactNode;
 }
 
 const COMPONENT_NAME: string = 'Carousel';
@@ -125,36 +128,29 @@ const Carousel: FC<CarouselProps> & WithWrapperProps = (props: CarouselProps): R
   };
 
   const generateCarouselSteps = (): ReactElement[] =>
-    steps.map((step: CarouselStep) => (
-      <Box key={`${step?.title}-${step.description}`}>
-        <Card variant="outlined" className="oxygen-carousel-step-card">
-          <CardContent className="oxygen-carousel-step-card-content">
-            <Box>{step.illustration}</Box>
-            <Box>
-              <Box>
-                <Typography variant="subtitle2">{step.title}</Typography>
-              </Box>
-              <Box>
-                <Typography variant="body2">{step.description}</Typography>
-              </Box>
-            </Box>
-          </CardContent>
-        </Card>
-        <Box className="oxygen-carousel-step-button-bar">
-          <Button variant="outlined" color="primary" onClick={step.onButtonClick}>
-            {step.buttonText}
-          </Button>
+    steps?.map((step: CarouselStep) => {
+      const {title: stepTitle, description, illustration, action} = step;
+      return (
+        <Box key={`${stepTitle}-${description}`} className="oxygen-carousel-step">
+          <Card elevation={0} variant="outlined" className="oxygen-carousel-step-card">
+            <ListItem component={CardContent}>
+              {illustration && <ListItemIcon>{illustration}</ListItemIcon>}
+              <ListItemText primary={stepTitle} secondary={description ?? null} />
+            </ListItem>
+          </Card>
+          {action && <Box className="oxygen-carousel-step-button-bar">{action}</Box>}
         </Box>
-      </Box>
-    ));
+      );
+    });
 
   return (
     <Box className={classes} {...rest}>
       <Box className="oxygen-carousel-top-bar">
-        <Box className="oxygen-carousel-title">{title && <Typography variant="body1">{title}</Typography>}</Box>
+        <Box className="oxygen-carousel-title">{title}</Box>
         {isMobile ? (
           <Box className="oxygen-carousel-mobile-buttons">
             <IconButton
+              className="oxygen-carousel-mobile-button-left"
               variant={IconButtonVariants.CONTAINED}
               color="secondary"
               disabled={isFirstStep}
@@ -163,6 +159,7 @@ const Carousel: FC<CarouselProps> & WithWrapperProps = (props: CarouselProps): R
               <ChevronLeftIcon />
             </IconButton>
             <IconButton
+              className="oxygen-carousel-mobile-button-right"
               variant={IconButtonVariants.CONTAINED}
               color="secondary"
               disabled={isLastStep}

--- a/packages/react/src/components/Carousel/carousel.scss
+++ b/packages/react/src/components/Carousel/carousel.scss
@@ -18,7 +18,6 @@
 
 .oxygen-carousel {
   position: relative;
-  width: 100%;
 
   .oxygen-carousel-top-bar {
     display: flex;
@@ -28,6 +27,7 @@
       flex-grow: 1;
       align-items: center;
       display: flex;
+      padding: 1rem 0;
     }
 
     .oxygen-carousel-button-group {
@@ -38,20 +38,20 @@
     }
   }
 
-  .oxygen-carousel-step-card {
-    padding: 0;
-  }
+  .oxygen-carousel-step {
+    .oxygen-card {
+      padding: 0.5rem 1rem;
 
-  .oxygen-carousel-step-card-content {
-    display: flex;
-    justify-content: flex-start;
-    gap: 1.5em;
-  }
+      .oxygen-list-item {
+        gap: 1rem;
+      }
+    }
 
-  .oxygen-carousel-step-button-bar {
-    display: flex;
-    justify-content: flex-end;
-    padding-top: 1em;
+    .oxygen-carousel-step-button-bar {
+      padding-top: 1rem;
+      display: flex;
+      justify-content: flex-end;
+    }
   }
 
   .oxygen-carousel-mobile-buttons {
@@ -60,6 +60,15 @@
     z-index: 1;
     position: absolute;
     width: 100%;
-    bottom: calc(42px + 1em);
+    // TODO: Review this.
+    top: 50%;
+
+    .oxygen-carousel-mobile-button-left {
+      right: 15px;
+    }
+
+    .oxygen-carousel-mobile-button-right {
+      left: 15px;
+    }
   }
 }

--- a/packages/react/src/components/Carousel/carousel.scss
+++ b/packages/react/src/components/Carousel/carousel.scss
@@ -22,6 +22,7 @@
   .oxygen-carousel-top-bar {
     display: flex;
     justify-content: space-between;
+    align-items: center;
 
     .oxygen-carousel-title {
       flex-grow: 1;
@@ -55,20 +56,17 @@
   }
 
   .oxygen-carousel-mobile-buttons {
-    display: flex;
-    justify-content: space-between;
-    z-index: 1;
-    position: absolute;
-    width: 100%;
-    // TODO: Review this.
-    top: 50%;
+    display: none;
+  }
 
-    .oxygen-carousel-mobile-button-left {
-      right: 15px;
+  &.mobile {
+    .oxygen-carousel-button-group {
+      display: none;
     }
 
-    .oxygen-carousel-mobile-button-right {
-      left: 15px;
+    .oxygen-carousel-mobile-buttons {
+      display: flex;
+      gap: 1rem;
     }
   }
 }

--- a/packages/react/src/components/CircularProgressAvatar/CircularProgressAvatar.tsx
+++ b/packages/react/src/components/CircularProgressAvatar/CircularProgressAvatar.tsx
@@ -52,7 +52,6 @@ const CircularProgressAvatar: FC<CircularProgressAvatarProps> & WithWrapperProps
   return (
     <Box className={classes} role="presentation">
       <Badge
-        showZero
         className="oxygen-badge"
         overlap="circular"
         anchorOrigin={{

--- a/packages/react/src/components/CircularProgressAvatar/__tests__/__snapshots__/CircularProgressAvatar.test.tsx.snap
+++ b/packages/react/src/components/CircularProgressAvatar/__tests__/__snapshots__/CircularProgressAvatar.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`CircularProgressAvatar should match the snapshot 1`] = `
         class="MuiBadge-root oxygen-badge MuiBadge-root css-1c32n2y-MuiBadge-root"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault oxygen-ui-avatar css-woe6xp-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault oxygen-avatar css-woe6xp-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"

--- a/packages/react/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/packages/react/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Header should match the snapshot 1`] = `
               class="MuiButton-startIcon MuiButton-iconSizeMedium css-gcc2o7-MuiButton-startIcon"
             >
               <div
-                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault oxygen-ui-avatar image css-woe6xp-MuiAvatar-root"
+                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault oxygen-avatar image css-woe6xp-MuiAvatar-root"
               >
                 <svg
                   aria-hidden="true"

--- a/packages/react/src/components/ListItem/ListItem.tsx
+++ b/packages/react/src/components/ListItem/ListItem.tsx
@@ -18,22 +18,26 @@
 
 import MuiListItem, {ListItemProps as MuiListItemProps} from '@mui/material/ListItem';
 import clsx from 'clsx';
-import {FC, ReactElement} from 'react';
+import {ElementType, forwardRef, ForwardRefExoticComponent, MutableRefObject, ReactElement} from 'react';
 import {WithWrapperProps} from '../../models';
 import {composeComponentDisplayName} from '../../utils';
 import './list-item.scss';
 
-export type ListItemProps = MuiListItemProps;
+export type ListItemProps<C extends ElementType = ElementType> = {
+  component?: C;
+} & Omit<MuiListItemProps<C>, 'component'>;
 
 const COMPONENT_NAME: string = 'ListItem';
 
-const ListItem: FC<ListItemProps> & WithWrapperProps = (props: ListItemProps): ReactElement => {
-  const {className, ...rest} = props;
+const ListItem: ForwardRefExoticComponent<ListItemProps> & WithWrapperProps = forwardRef(
+  <C extends ElementType>(props: ListItemProps<C>, ref: MutableRefObject<HTMLLIElement>): ReactElement => {
+    const {className, ...rest} = props;
 
-  const classes: string = clsx('oxygen-list-item', className);
+    const classes: string = clsx('oxygen-list-item', className);
 
-  return <MuiListItem className={classes} {...rest} />;
-};
+    return <MuiListItem className={classes} ref={ref} {...rest} />;
+  },
+) as ForwardRefExoticComponent<ListItemProps> & WithWrapperProps;
 
 ListItem.displayName = composeComponentDisplayName(COMPONENT_NAME);
 ListItem.muiName = COMPONENT_NAME;

--- a/packages/react/src/components/ListItemAvatar/__tests__/__snapshots__/ListItemAvatar.test.tsx.snap
+++ b/packages/react/src/components/ListItemAvatar/__tests__/__snapshots__/ListItemAvatar.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ListItemAvatar should match the snapshot 1`] = `
       class="MuiListItemAvatar-root oxygen-list-item-avatar css-1e9lk82-MuiListItemAvatar-root"
     >
       <div
-        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault oxygen-ui-avatar css-woe6xp-MuiAvatar-root"
+        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault oxygen-avatar css-woe6xp-MuiAvatar-root"
       >
         U
       </div>


### PR DESCRIPTION
### Purpose

- Add `AccountOverview` card

Desktop

<img width="858" alt="Screenshot 2023-03-07 at 00 30 31" src="https://user-images.githubusercontent.com/67315176/223205440-678face7-3bc0-4149-9295-260ac624d3a5.png">

Mobile

<img width="374" alt="Screenshot 2023-03-07 at 00 31 10" src="https://user-images.githubusercontent.com/67315176/223205551-2a091c77-6af0-45cb-a6d1-a8c264ea27f6.png">


### Related Issues
- https://github.com/wso2/oxygen-ui/issues/2

### Related PRs
- None

### Checklist
- [ ] UX/UI review done on the final implementation.
- [x] Story provided. (Add screenshots)
- [x] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
