### PR TITLE
fix(react): ignore `storybook-static` from transpilation

### DIFF
--- a/packages/react/scripts/build-components.js
+++ b/packages/react/scripts/build-components.js
@@ -27,7 +27,7 @@ const outputDir = path.resolve(__dirname, '..', 'dist', 'transpiled');
 
 logger.log('💅 Transpiling components...');
 execSync(
-  `npx tsc --project tsconfig.lib.json --declarationDir ${outputDir} --emitDeclarationOnly false --outDir ${outputDir}`,
+  `npx tsc --project ${path.resolve(path.join(__dirname, '..', 'tsconfig.lib.json'))} --declarationDir ${outputDir} --emitDeclarationOnly false --outDir ${outputDir}`,
 );
 logger.log('💅 Components transpiled! 🎉🎉🎉');
 

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -20,6 +20,7 @@
     "**/*.spec.jsx",
     "**/*.test.jsx",
     "scripts",
+    "storybook-static",
     "dist"
   ],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "rollup.config.cjs"]


### PR DESCRIPTION
### Purpose

Build is failing when there's a `storybook-static` folder in `packages/react`.

### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/82

### Related PRs
- https://github.com/wso2/oxygen-ui/pull/67

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
