### PR TITLE
chore(react): allow menu items to be added to UserDropdownMenu

### DIFF
--- a/packages/react/src/components/Header/Header.stories.mdx
+++ b/packages/react/src/components/Header/Header.stories.mdx
@@ -3,7 +3,7 @@ import dedent from 'ts-dedent';
 import StoryConfig from '../../../.storybook/story-config.ts';
 import {withDesign} from '../../../.storybook/utils.ts';
 import Header from './Header.tsx';
-import {LanguagesIcon, LogsIcon, SunIcon, CresentBrightIcon} from '@oxygen-ui/react-icons';
+import {LanguagesIcon, LogsIcon, SunIcon, CrescentBrightIcon} from '@oxygen-ui/react-icons';
 import Button from "../Button";
 
 export const meta = {
@@ -48,7 +48,7 @@ export const basicHeaderVariationOptions = {
     },
     {
       name: 'dark',
-      icon: <CresentBrightIcon />,
+      icon: <CrescentBrightIcon />,
     },
   ],
   buttons: [

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -75,6 +75,10 @@ export interface UserDropdownMenuHeaderProps {
    */
   actionText?: string;
   /**
+   * Menu items to be added to the user dropdown menu.
+   */
+  menuItems?: ReactNode[];
+  /**
    * Callback to be called on clicking on the action button.
    */
   onActionClick?: () => void;
@@ -207,6 +211,7 @@ const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactEl
             actionIcon={userDropdownMenuProps.actionIcon}
             mode={mode}
             onModeChange={onModeChange}
+            menuItems={userDropdownMenuProps.menuItems}
           />
         </Box>
       </Toolbar>

--- a/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
+++ b/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
@@ -45,6 +45,10 @@ export interface UserDropdownMenuProps extends Omit<MenuProps, 'open' | 'anchorE
    */
   actionText?: string;
   /**
+   * Menu items to be added to teh dropdown menu.
+   */
+  menuItems?: ReactNode[];
+  /**
    * Current mode.
    */
   mode?: string;
@@ -122,6 +126,7 @@ const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = (
     actionIcon,
     onModeChange,
     onActionTrigger,
+    menuItems,
     ...rest
   } = props;
 
@@ -187,6 +192,12 @@ const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = (
             <ListItemText primary={user?.name} secondary={user?.email} />
           </ListItem>
         )}
+        {menuItems?.length > 0 ? (
+          <>
+            <Divider />
+            {menuItems}
+          </>
+        ) : null}
         {modes?.length > 0 && (
           <>
             <Divider />


### PR DESCRIPTION
### Purpose
<img width="271" alt="image" src="https://user-images.githubusercontent.com/20745428/231149036-3bc2a7d9-0ac3-43df-b1b7-84dbe0a4fa06.png">
This PR allows additional menu items to be added to the UserDropdownMenu component.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
