### PR TITLE
chore(react): extend functionality of `Header` to add left and right aligned elements

### DIFF
--- a/packages/primitives/src/icons/comment-16.svg
+++ b/packages/primitives/src/icons/comment-16.svg
@@ -1,0 +1,21 @@
+<!--
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15.9948 3.80796C15.8951 1.96428 14.3686 0.5 12.5 0.5H3.5L3.30796 0.505179C1.46428 0.604874 0 2.13144 0 4V14.1L0.00792224 14.2688C0.0552149 14.7713 0.312075 15.2341 0.72 15.54L0.855483 15.6324L0.996242 15.7109C1.63875 16.0324 1.70518 15.9373 2.02646 15.4774C2.08681 15.3911 2.15616 15.2918 2.24 15.18L4.25 12.5H12.5L12.692 12.4948C14.5357 12.3951 16 10.8686 16 9V4L15.9948 3.80796ZM3.5 1.5H12.5L12.6644 1.50532C13.9685 1.58996 15 2.67452 15 4V9L14.9947 9.16438C14.91 10.4685 13.8255 11.5 12.5 11.5H3.75L1.44 14.58L1.36715 14.6643C1.34176 14.6899 1.32454 14.7134 1.31384 14.735L1.28351 14.7139L1.21587 14.6538C1.0871 14.5209 1 14.3158 1 14.1V4L1.00532 3.83562C1.08996 2.53154 2.17452 1.5 3.5 1.5ZM1.38117 14.7817L1.31384 14.735C1.21552 14.9328 1.66748 14.9587 1.38117 14.7817ZM4 5C4 4.72386 4.22386 4.5 4.5 4.5H11.5C11.7761 4.5 12 4.72386 12 5C12 5.27614 11.7761 5.5 11.5 5.5H4.5C4.22386 5.5 4 5.27614 4 5ZM4.5 8C4.22386 8 4 8.22386 4 8.5C4 8.77614 4.22386 9 4.5 9H8.5C8.77614 9 9 8.77614 9 8.5C9 8.22386 8.77614 8 8.5 8H4.5Z" fill="#40404B"/>
+</svg>

--- a/packages/primitives/src/icons/magnifying-glass-16.svg
+++ b/packages/primitives/src/icons/magnifying-glass-16.svg
@@ -1,0 +1,21 @@
+<!--
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6.5 0C2.91015 0 0 2.91015 0 6.5C0 10.0899 2.91015 13 6.5 13C8.11495 13 9.59234 12.411 10.7291 11.4362L14.1464 14.8536L14.2157 14.9114C14.4106 15.0464 14.68 15.0271 14.8536 14.8536C15.0488 14.6583 15.0488 14.3417 14.8536 14.1464L11.4362 10.7291C12.411 9.59234 13 8.11495 13 6.5C13 2.91015 10.0899 0 6.5 0ZM6.5 1C9.53757 1 12 3.46243 12 6.5C12 9.53757 9.53757 12 6.5 12C3.46243 12 1 9.53757 1 6.5C1 3.46243 3.46243 1 6.5 1Z" fill="#40404B"/>
+</svg>

--- a/packages/react/src/components/Header/Header.stories.mdx
+++ b/packages/react/src/components/Header/Header.stories.mdx
@@ -3,7 +3,7 @@ import dedent from 'ts-dedent';
 import StoryConfig from '../../../.storybook/story-config.ts';
 import {withDesign} from '../../../.storybook/utils.ts';
 import Header from './Header.tsx';
-import {LanguagesIcon, LogsIcon, SunIcon, CrescentBrightIcon} from '@oxygen-ui/react-icons';
+import {LanguagesIcon, LogsIcon, SunIcon, CrescentBrightIcon, CommentIcon, MagnifyingGlassIcon} from '@oxygen-ui/react-icons';
 import Button from "../Button";
 
 export const meta = {
@@ -54,18 +54,20 @@ export const basicHeaderVariationOptions = {
   ],
 };
 
-export const linksVariationOptions = {
+export const leftAlignedElementsVariationOptions = {
   ...basicHeaderVariationOptions,
-  buttons: [
+  leftAlignedElements: [
+    <Button color="inherit" startIcon={<MagnifyingGlassIcon />} href="/">Search</Button>, 
+    <Button color="inherit" startIcon={<CommentIcon />} href="/">Info</Button>]
+};
+
+export const rightAlignedElementsVariationOptions = {
+  ...basicHeaderVariationOptions,
+  rightAlignedElements: [
     <Button color="inherit" startIcon={<LogsIcon />} href="/">Console</Button>,
     <Button color="inherit" startIcon={<LanguagesIcon />} href="/">Language</Button>
   ],
 }
-
-export const leftAlignedElementsVariationOptions = {
-  ...basicHeaderVariationOptions,
-  leftAlignedElements: <div style={{padding: '0rem 1rem'}}>Left aligned header elements</div>
-};
 
 <Canvas>
   <Story
@@ -94,27 +96,27 @@ Import and use the `Header` component in your components as follows.
 
 ## Variants
 
-### Header Links
-
-Add links to the header by passing an array of link buttons or similar components to the `buttons` prop.
-
-<Canvas>
-  <Story
-    name="Header Links"
-    args={linksVariationOptions}
-  >
-    {Template.bind({})}
-  </Story>
-</Canvas>
-
 ### Left Aligned Elements
 
-Add left aligned elements to the header by passing a `ReactNode` to the `leftAlignedElements` prop.
+Add left aligned elements to the header by passing an array of `ReactNode`s to the `leftAlignedElements` prop.
 
 <Canvas>
   <Story
     name="Left Aligned Elements"
     args={leftAlignedElementsVariationOptions}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Right Aligned Elements
+
+Add right aligned elements to the header by passing an array of `ReactNode`s to the `rightAlignedElements` prop.
+
+<Canvas>
+  <Story
+    name="Right Aligned Elements"
+    args={rightAlignedElementsVariationOptions}
   >
     {Template.bind({})}
   </Story>

--- a/packages/react/src/components/Header/Header.stories.mdx
+++ b/packages/react/src/components/Header/Header.stories.mdx
@@ -20,6 +20,7 @@ export const Template = args => <Header {...args} />;
 - [Overview](#overview)
 - [Props](#props)
 - [Usage](#usage)
+- [Variants](#variants)
 
 ## Overview
 
@@ -51,10 +52,19 @@ export const basicHeaderVariationOptions = {
       icon: <CrescentBrightIcon />,
     },
   ],
+};
+
+export const linksVariationOptions = {
+  ...basicHeaderVariationOptions,
   buttons: [
     <Button color="inherit" startIcon={<LogsIcon />} href="/">Console</Button>,
     <Button color="inherit" startIcon={<LanguagesIcon />} href="/">Language</Button>
   ],
+}
+
+export const leftAlignedElementsVariationOptions = {
+  ...basicHeaderVariationOptions,
+  leftAlignedElements: <div style={{padding: '0rem 1rem'}}>Left aligned header elements</div>
 };
 
 <Canvas>
@@ -81,3 +91,31 @@ Import and use the `Header` component in your components as follows.
   format
   code={dedent`import Header from '@oxygen-ui/react/Header';\n`}
 />
+
+## Variants
+
+### Header Links
+
+Add links to the header by passing an array of link buttons or similar components to the `buttons` prop.
+
+<Canvas>
+  <Story
+    name="Header Links"
+    args={linksVariationOptions}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Left Aligned Elements
+
+Add left aligned elements to the header by passing a `ReactNode` to the `leftAlignedElements` prop.
+
+<Canvas>
+  <Story
+    name="Left Aligned Elements"
+    args={leftAlignedElementsVariationOptions}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -40,14 +40,10 @@ export interface HeaderProps extends AppBarProps {
    */
   brand?: BrandTemplate;
   /**
-   * Buttons available on the header.
-   */
-  buttons?: ReactNode[];
-  /**
    * Left aligned elements to be rendered.
    * @remarks This will be rendered on the left side of the header following the brand section.
    */
-  leftAlignedElements?: ReactNode;
+  leftAlignedElements?: ReactNode[];
   /**
    * List of modes.
    */
@@ -56,6 +52,11 @@ export interface HeaderProps extends AppBarProps {
    * Function to handle the collapsible hamburger click.
    */
   onCollapsibleHamburgerClick?: () => void;
+  /**
+   * Right aligned elements to be rendered.
+   * @remarks This will be rendered on the right side of the header preceding the user dropdown section.
+   */
+  rightAlignedElements?: ReactNode[];
   /**
    * Should show the collapsible hamburger icon?
    */
@@ -120,13 +121,12 @@ const COMPONENT_NAME: string = 'Header';
 const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactElement => {
   const {
     brand,
-    buttons,
     className,
-    children,
     modes,
     showCollapsibleHamburger,
     leftAlignedElements,
     onCollapsibleHamburgerClick,
+    rightAlignedElements,
     user,
     userDropdownMenu,
     ...rest
@@ -187,13 +187,16 @@ const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactEl
             </Typography>
           </Box>
         )}
-        {leftAlignedElements}
-        <Box className="oxygen-header-links-section">
-          <>
-            {children}
-            {buttons?.length > 0 && <Box className="oxygen-header-links">{buttons} </Box>}
-          </>
-        </Box>
+        {(leftAlignedElements || rightAlignedElements) && (
+          <Box className="oxygen-header-elements">
+            {leftAlignedElements?.length > 0 && (
+              <Box className="oxygen-header-elements-left">{leftAlignedElements}</Box>
+            )}
+            {rightAlignedElements?.length > 0 && (
+              <Box className="oxygen-header-elements-right">{rightAlignedElements}</Box>
+            )}
+          </Box>
+        )}
         <Box className="oxygen-header-user-dropdown-menu">
           <UserDropdownMenu
             user={user}

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -44,6 +44,11 @@ export interface HeaderProps extends AppBarProps {
    */
   buttons?: ReactNode[];
   /**
+   * Left aligned elements to be rendered.
+   * @remarks This will be rendered on the left side of the header following the brand section.
+   */
+  leftAlignedElements?: ReactNode;
+  /**
    * List of modes.
    */
   modes?: ModeList[];
@@ -114,14 +119,15 @@ const COMPONENT_NAME: string = 'Header';
 
 const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactElement => {
   const {
+    brand,
+    buttons,
     className,
     children,
-    showCollapsibleHamburger,
-    brand,
-    user,
-    buttons,
     modes,
+    showCollapsibleHamburger,
+    leftAlignedElements,
     onCollapsibleHamburgerClick,
+    user,
     userDropdownMenu,
     ...rest
   } = props;
@@ -181,7 +187,8 @@ const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactEl
             </Typography>
           </Box>
         )}
-        <Box className="oxygen-header-mid-section">
+        {leftAlignedElements}
+        <Box className="oxygen-header-links-section">
           <>
             {children}
             {buttons?.length > 0 && <Box className="oxygen-header-links">{buttons} </Box>}

--- a/packages/react/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/packages/react/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Header should match the snapshot 1`] = `
         class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular oxygen-toolbar oxygen-header-toolbar css-hyum1k-MuiToolbar-root"
       >
         <div
-          class="oxygen-box oxygen-header-mid-section MuiBox-root css-0"
+          class="oxygen-box oxygen-header-links-section MuiBox-root css-0"
         />
         <div
           class="oxygen-box oxygen-header-user-dropdown-menu MuiBox-root css-0"

--- a/packages/react/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/packages/react/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -11,9 +11,6 @@ exports[`Header should match the snapshot 1`] = `
         class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular oxygen-toolbar oxygen-header-toolbar css-hyum1k-MuiToolbar-root"
       >
         <div
-          class="oxygen-box oxygen-header-links-section MuiBox-root css-0"
-        />
-        <div
           class="oxygen-box oxygen-header-user-dropdown-menu MuiBox-root css-0"
         >
           <button

--- a/packages/react/src/components/Header/header.scss
+++ b/packages/react/src/components/Header/header.scss
@@ -59,21 +59,25 @@
     }
   }
 
-  &-links-section {
-    flex: 1;
-  }
-
-  &-links {
+  &-elements {
     display: flex;
-    justify-content: end;
-    margin-right: 1rem;
+    flex: 1;
 
-    & > * {
-      margin-right: 1rem;
+    &-left,
+    &-right {
+      & > * {
+        margin-right: 0.5rem;
+      }
+    }
+
+    &-right {
+      margin-left: auto;
     }
   }
 
   &-user-dropdown-menu {
+    margin-left: auto;
+
     .image {
       width: 2.2rem;
       height: 2.2rem;

--- a/packages/react/src/components/Header/header.scss
+++ b/packages/react/src/components/Header/header.scss
@@ -33,8 +33,9 @@
     display: flex;
     align-items: center;
 
-    .oxygen-brand-logo {
+    &-logo {
       height: 40px;
+      max-width: 100px;
       display: flex;
       margin-right: 0.5rem;
     }
@@ -58,7 +59,7 @@
     }
   }
 
-  &-mid-section {
+  &-links-section {
     flex: 1;
   }
 


### PR DESCRIPTION
### Purpose

Introduce `leftAlignedElements` and `rightAlignedElements` props to the `Header` component. 

- Implementation

<img width="1792" alt="Screenshot 2023-04-12 at 16 41 04" src="https://user-images.githubusercontent.com/67315176/231440376-622573f7-3833-412f-b021-ecb012e43632.png">

<img width="1792" alt="Screenshot 2023-04-12 at 16 41 42" src="https://user-images.githubusercontent.com/67315176/231440495-eefa8791-bbf9-49d0-870a-231e750fda40.png">

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
