### PR TITLE
chore(react): update styles and extend `UserDropdownMenu` for footer content

### DIFF
--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -18,7 +18,7 @@
 
 import {useColorScheme} from '@mui/material/styles';
 import {Mode} from '@mui/system/cssVars/useCurrentColorScheme';
-import {ChevronDownIcon, HamburgerIcon, PowerIcon} from '@oxygen-ui/react-icons';
+import {ChevronDownIcon, HamburgerIcon, PowerIcon, SunIcon} from '@oxygen-ui/react-icons';
 import clsx from 'clsx';
 import {FC, ReactElement, ReactNode} from 'react';
 import {useIsMobile} from '../../hooks/use-is-mobile';
@@ -30,6 +30,9 @@ import Avatar from '../Avatar';
 import Box from '../Box';
 import IconButton from '../IconButton';
 import Link from '../Link';
+import ListItemIcon from '../ListItemIcon/ListItemIcon';
+import ListItemText from '../ListItemText/ListItemText';
+import MenuItem from '../MenuItem/MenuItem';
 import Toolbar from '../Toolbar';
 import Typography from '../Typography';
 import UserDropdownMenu, {ModeList, UserTemplate} from '../UserDropdownMenu';
@@ -81,6 +84,10 @@ export interface UserDropdownMenuHeaderProps {
    */
   actionText?: string;
   /**
+   * Footer content.
+   */
+  footerContent?: ReactNode[];
+  /**
    * Menu items to be added to the user dropdown menu.
    */
   menuItems?: ReactNode[];
@@ -117,6 +124,28 @@ export interface BrandTemplate {
 const userDropdownMenuDefaultProps: UserDropdownMenuHeaderProps = {
   actionIcon: <PowerIcon />,
   actionText: 'Log Out',
+  footerContent: [
+    <Link variant="body3" href="/">
+      Privacy Policy &nbsp;&nbsp;
+    </Link>,
+    <Link variant="body3" href="/">
+      Terms of Service
+    </Link>,
+  ],
+  menuItems: [
+    <MenuItem color="inherit">
+      <ListItemIcon>
+        <SunIcon />
+      </ListItemIcon>
+      <ListItemText>My Account</ListItemText>
+    </MenuItem>,
+    <MenuItem color="inherit">
+      <ListItemIcon>
+        <SunIcon />
+      </ListItemIcon>
+      <ListItemText>Billing Portal</ListItemText>
+    </MenuItem>,
+  ],
   onActionClick: (): void => null,
 };
 
@@ -222,6 +251,7 @@ const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactEl
             mode={mode}
             onModeChange={onModeChange}
             menuItems={userDropdownMenuProps.menuItems}
+            footerContent={userDropdownMenu.footerContent}
           />
         </Box>
       </Toolbar>

--- a/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
+++ b/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
@@ -45,6 +45,10 @@ export interface UserDropdownMenuProps extends Omit<MenuProps, 'open' | 'anchorE
    */
   actionText?: string;
   /**
+   * Footer content.
+   */
+  footerContent?: ReactNode[];
+  /**
    * Menu items to be added to the dropdown menu.
    */
   menuItems?: ReactNode[];
@@ -116,6 +120,7 @@ const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = (
   const {
     className,
     children,
+    footerContent,
     triggerOptions,
     user,
     modes,
@@ -193,15 +198,9 @@ const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = (
             <ListItemText primary={user?.name} secondary={user?.email} />
           </ListItem>
         )}
-        {menuItems?.length > 0 ? (
-          <div>
-            <Divider />
-            {menuItems}
-          </div>
-        ) : null}
+        {menuItems?.length > 0 ? menuItems : null}
         {modes?.length > 0 && (
           <div>
-            <Divider />
             <ListSubheader>{modesHeading}</ListSubheader>
             {modes?.map((theme: ModeList) => {
               const {name, icon} = theme;
@@ -227,13 +226,16 @@ const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = (
           </div>
         )}
         {actionText && (
-          <div>
-            <Divider />
-            <MenuItem className="dropdown-menu-item" onClick={(): void => handleActionTrigger()}>
-              <ListItemIcon>{actionIcon}</ListItemIcon>
-              <ListItemText primary={actionText} />
-            </MenuItem>
-          </div>
+          <MenuItem className="dropdown-menu-item" onClick={(): void => handleActionTrigger()}>
+            <ListItemIcon>{actionIcon}</ListItemIcon>
+            <ListItemText primary={actionText} />
+          </MenuItem>
+        )}
+        {footerContent && (
+          <>
+            <Divider variant="middle" />
+            <div className="oxygen-user-dropdown-menu-footer">{footerContent}</div>
+          </>
         )}
       </Menu>
     </>

--- a/packages/react/src/components/UserDropdownMenu/user-dropdown-menu.scss
+++ b/packages/react/src/components/UserDropdownMenu/user-dropdown-menu.scss
@@ -18,7 +18,8 @@
 
 .oxygen-user-dropdown-menu {
   &-paper {
-    min-width: 230px;
+    min-width: 250px;
+    border-radius: 16px;
   }
 
   &-list-item {
@@ -29,12 +30,26 @@
 
   &-item {
     &-radio {
-      padding: 5px;
+      padding: 0;
     }
+  }
+
+  &-footer {
+    padding: 8px 16px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .oxygen-menu-item {
+    margin: 0.2rem 0.5rem;
+  }
+
+  .oxygen-menu-item:hover {
+    border-radius: 8px;
   }
 
   .oxygen-divider {
     margin-top: 0.5em;
-    margin-bottom: 0.5em;
+    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
### Purpose

Update the styles of the `UserDropdownMenu` including facilitating footer content.

Implementation (with sample prop values)

<img width="357" alt="Screenshot 2023-05-18 at 23 59 17" src="https://github.com/wso2/oxygen-ui/assets/67315176/db5e028f-b65e-4c9f-9925-239fc8c09913">

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
