### PR TITLE
chore(react): allow Navbar dividers without heading

### DIFF
--- a/packages/react/src/components/Navbar/Navbar.tsx
+++ b/packages/react/src/components/Navbar/Navbar.tsx
@@ -147,7 +147,7 @@ const Navbar: FC<NavbarProps> & WithWrapperProps = (props: NavbarProps): ReactEl
           const navBarListClass: string = clsx('oxygen-navbar-list', {'no-heading': !itemSet.heading});
           return (
             <Fragment key={itemSet.id}>
-              {itemSet.heading ? <div>{renderDivider(itemSetIndex, itemSet.heading)}</div> : null}
+              <div>{renderDivider(itemSetIndex, itemSet.heading)}</div>
               <List className={navBarListClass}>
                 {itemSet?.items?.map(({icon, id, selected, name, onClick, ...otherItemProps}: NavbarItem['item']) => (
                   <Tooltip className="oxygen-navbar-list-item-tooltip" key={id} title={!open && name} placement="right">


### PR DESCRIPTION
### Purpose

> This PR allows `Navbar` `Divider`s to not have heading names.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
