### PR TITLE
chore(react): change default chip variant colors

### DIFF
--- a/packages/react/src/theme/default-theme.ts
+++ b/packages/react/src/theme/default-theme.ts
@@ -165,15 +165,15 @@ export const generateDefaultThemeOptions = (baseTheme: Theme): RecursivePartial<
     Chip: {
       // TODO: Move these to color palette.
       properties: {
-        'beta-background': '#57725D',
+        'beta-background': '#2ab1da',
         'beta-text-color': 'var(--oxygen-palette-primary-contrastText)',
         'default-background': 'var(--oxygen-palette-primary-main)',
         'default-text-color': 'var(--oxygen-palette-primary-contrastText)',
-        'experimental-background': '#474747',
+        'experimental-background': '#a73fe3',
         'experimental-text-color': 'var(--oxygen-palette-primary-contrastText)',
-        'new-background': '#a333c8',
+        'new-background': '#3fb81f',
         'new-text-color': 'var(--oxygen-palette-primary-contrastText)',
-        'premium-background': 'linear-gradient(270deg, #ff9d4d, #ff7300)',
+        'premium-background': '#d2a600',
         'premium-text-color': 'var(--oxygen-palette-primary-contrastText)',
       },
     },


### PR DESCRIPTION
### Purpose

>The chip variants have been set to the following color:
Premium: `#d2a600`
Beta: `#2ab1da`
New: `#3fb81f`
Experimental: `#a73fe3`

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
