### PR TITLE
chore(primitives): enable error messages on builds

### DIFF
--- a/packages/primitives/scripts/build.js
+++ b/packages/primitives/scripts/build.js
@@ -30,10 +30,10 @@ logger.log();
 logger.log('                         💅  Building Style Dictionary  💅                         ');
 logger.log();
 
-cp.fork(path.resolve(__dirname, 'build-sd.js'));
+cp.execSync(`node ${path.resolve(__dirname, 'build-sd.js')}`, { stdio: 'inherit' });
 
 logger.log();
 logger.log('                          💅  Building the SVG Icons  💅                           ');
 logger.log();
 
-cp.fork(path.resolve(__dirname, 'build-icons.js'));
+cp.execSync(`node ${path.resolve(__dirname, 'build-icons.js')}`, { stdio: 'inherit' });


### PR DESCRIPTION
### Purpose
- Enable displaying error messages in the Console for `primitives` on builds.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
