### PR TITLE
feat(primitives): add plus and pen-to-circle icons

### DIFF
--- a/packages/primitives/src/icons/pen-to-circle-16.svg
+++ b/packages/primitives/src/icons/pen-to-circle-16.svg
@@ -1,0 +1,21 @@
+<!--
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.7645 1.55603L7.33957 6.36762L6.62291 9.90938L10.0375 9.06944L14.4727 4.28047C15.195 3.50051 15.1683 2.28812 14.4122 1.54077C13.6769 0.813827 12.4914 0.820659 11.7645 1.55603ZM13.7888 2.34072C14.0813 2.71052 14.0673 3.24647 13.739 3.60098L9.4947 8.18199L7.7747 8.65999L8.2447 6.85999L12.482 2.25254C12.8143 1.91645 13.3666 1.91326 13.7092 2.25194L13.7888 2.34072ZM8.5 1.5C8.5 1.22386 8.27614 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15C11.866 15 15 11.866 15 8C15 7.72386 14.7761 7.5 14.5 7.5C14.2239 7.5 14 7.72386 14 8C14 11.3137 11.3137 14 8 14C4.68629 14 2 11.3137 2 8C2 4.68629 4.68629 2 8 2C8.27614 2 8.5 1.77614 8.5 1.5Z" fill="black"/>
+</svg>

--- a/packages/primitives/src/icons/plus-16.svg
+++ b/packages/primitives/src/icons/plus-16.svg
@@ -1,0 +1,21 @@
+<!--
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.5 0.5C7.5 0.223858 7.72386 0 8 0C8.27614 0 8.5 0.223858 8.5 0.5V7.5H15.5C15.7761 7.5 16 7.72386 16 8C16 8.27614 15.7761 8.5 15.5 8.5H8.5V15.5C8.5 15.7761 8.27614 16 8 16C7.72386 16 7.5 15.7761 7.5 15.5V8.5H0.5C0.223858 8.5 0 8.27614 0 8C0 7.72386 0.223858 7.5 0.5 7.5H7.5V0.5Z" fill="black"/>
+</svg>

--- a/packages/react/.storybook/content/Icons/icons.scss
+++ b/packages/react/.storybook/content/Icons/icons.scss
@@ -1,6 +1,4 @@
 .docblock-icongallery {
-    justify-content: space-between;
-
     .css-ngu85f {
         min-width: 240px;
     }


### PR DESCRIPTION
### Purpose
Add icons
- plus
- pen to circle (edit)

<img width="65" alt="Screenshot 2023-06-20 at 11 20 20" src="https://github.com/wso2/oxygen-ui/assets/67315176/3e54ac70-3ed7-4c97-8e13-d17719931523">
<img width="65" alt="Screenshot 2023-06-20 at 11 20 26" src="https://github.com/wso2/oxygen-ui/assets/67315176/f88aec0c-36e9-40df-8dc0-d5c1fc624ddb">

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
