### PR TITLE
chore(react): revert custom box shadow style for `Paper`

### DIFF
--- a/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Accordion should match the snapshot 1`] = `
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters oxygen-accordion css-1qe2qtl-MuiPaper-root-MuiAccordion-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters oxygen-accordion css-j3x5vy-MuiPaper-root-MuiAccordion-root"
     >
       <p>
         test accordion

--- a/packages/react/src/components/ActionCard/ActionCard.stories.mdx
+++ b/packages/react/src/components/ActionCard/ActionCard.stories.mdx
@@ -28,7 +28,8 @@ Action cards can be used in overview pages or dashboards.
     description: "Configure additional authentications to sign in easily or to add an extra layer of security to your account.",
     actionText: "Setup MFA",
     onActionClick:() => {alert("Action clicked")},
-    image: <img src="/assets/images/action-card-image.svg" alt="action card" />
+    image: <img src="/assets/images/action-card-image.svg" alt="action card" />,
+    variant: "outlined"
   }}>
     {Template.bind({})}
   </Story>
@@ -50,9 +51,9 @@ import ActionCard from '@oxygen-ui/react/ActionCard';\n
 function Demo() {
   return (
     <ActionCard
-      title="Secure your account by adding an extra layer of security"
-      description="Configure additional authentications to sign in easily or to add an extra layer of security to your account."
-      actionText="Setup MFA"
+      title="Action Card Title"
+      description="Action Card Description."
+      actionText="Action Card Action Text"
       onActionClick={() => {alert("Action clicked")}}
       image={<img src="/assets/images/action-card-image.svg" alt="action card" />}
     />

--- a/packages/react/src/components/ActionCard/ActionCard.tsx
+++ b/packages/react/src/components/ActionCard/ActionCard.tsx
@@ -58,7 +58,7 @@ const ActionCard: FC<ActionCardProps> & WithWrapperProps = (props: ActionCardPro
   const classes: string = clsx('oxygen-action-card', className);
 
   return (
-    <Card className={classes} {...rest} elevation={1}>
+    <Card className={classes} {...rest}>
       <CardContent>
         {image}
         <Typography variant="subtitle1">{title}</Typography>

--- a/packages/react/src/components/ActionCard/__tests__/__snapshots__/ActionCard.test.tsx.snap
+++ b/packages/react/src/components/ActionCard/__tests__/__snapshots__/ActionCard.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ActionCard should match the snapshot 1`] = `
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root oxygen-card oxygen-action-card css-mzb5us-MuiPaper-root-MuiCard-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root oxygen-card oxygen-action-card css-1vzmcwq-MuiPaper-root-MuiCard-root"
     >
       <div
         class="MuiCardContent-root oxygen-card-content css-46bh2p-MuiCardContent-root"

--- a/packages/react/src/components/Alert/__tests__/__snapshots__/Alert.test.tsx.snap
+++ b/packages/react/src/components/Alert/__tests__/__snapshots__/Alert.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Alert should match the snapshot 1`] = `
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardSuccess MuiAlert-standard oxygen-alert css-r11jwr-MuiPaper-root-MuiAlert-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardSuccess MuiAlert-standard oxygen-alert css-pi3gqw-MuiPaper-root-MuiAlert-root"
       role="alert"
     >
       <div

--- a/packages/react/src/components/AppBar/__tests__/__snapshots__/AppBar.test.tsx.snap
+++ b/packages/react/src/components/AppBar/__tests__/__snapshots__/AppBar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AppBar should match the snapshot 1`] = `
 <body>
   <div>
     <header
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed oxygen-app-bar mui-fixed css-h3h9u3-MuiPaper-root-MuiAppBar-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionFixed oxygen-app-bar mui-fixed css-w4c90w-MuiPaper-root-MuiAppBar-root"
     />
   </div>
 </body>

--- a/packages/react/src/components/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/packages/react/src/components/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Card should match the snapshot 1`] = `
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root oxygen-card css-mzb5us-MuiPaper-root-MuiCard-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root oxygen-card css-1vzmcwq-MuiPaper-root-MuiCard-root"
     />
   </div>
 </body>

--- a/packages/react/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/packages/react/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Header should match the snapshot 1`] = `
 <body>
   <div>
     <header
-      class="MuiPaper-root MuiPaper-outlined MuiAppBar-root MuiAppBar-colorDefault MuiAppBar-positionStatic oxygen-app-bar oxygen-header css-xqw32o-MuiPaper-root-MuiAppBar-root"
+      class="MuiPaper-root MuiPaper-outlined MuiAppBar-root MuiAppBar-colorDefault MuiAppBar-positionStatic oxygen-app-bar oxygen-header css-jfx6ty-MuiPaper-root-MuiAppBar-root"
       role="banner"
     >
       <div

--- a/packages/react/src/components/Navbar/__tests__/__snapshots__/Navbar.test.tsx.snap
+++ b/packages/react/src/components/Navbar/__tests__/__snapshots__/Navbar.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Navbar should match the snapshot 1`] = `
       class="MuiDrawer-root MuiDrawer-docked oxygen-drawer oxygen-navbar collapsible css-7ik032-MuiDrawer-docked"
     >
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-7wcstg-MuiPaper-root-MuiDrawer-paper"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-1ldhiwi-MuiPaper-root-MuiDrawer-paper"
       >
         <div
           class="oxygen-navbar-collapsible-hamburger"

--- a/packages/react/src/components/SignIn/__tests__/__snapshots__/SignIn.test.tsx.snap
+++ b/packages/react/src/components/SignIn/__tests__/__snapshots__/SignIn.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SignIn should match the snapshot 1`] = `
         src="#"
       />
       <div
-        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded oxygen-sign-in-box css-l7nmq7-MuiPaper-root"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded oxygen-sign-in-box css-1fbvlaf-MuiPaper-root"
       >
         <h5
           class="MuiTypography-root MuiTypography-h5 oxygen-sign-in-header css-ngjtbp-MuiTypography-root"

--- a/packages/react/src/theme/default-theme.ts
+++ b/packages/react/src/theme/default-theme.ts
@@ -134,13 +134,6 @@ export const generateDefaultThemeOptions = (baseTheme: Theme): RecursivePartial<
         },
       },
     },
-    MuiPaper: {
-      styleOverrides: {
-        elevation1: {
-          boxShadow: 'var(--oxygen-shadows-0)',
-        },
-      },
-    },
     MuiTypography: {
       defaultProps: {
         variantMapping: {


### PR DESCRIPTION
### Purpose
Remove custom box shadow style added to the `Paper` component from the default theme.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
