### PR TITLE
feat(primitives): add arrow loop right user icon

### DIFF
--- a/packages/primitives/src/icons/arrow-loop-right-user-16.svg
+++ b/packages/primitives/src/icons/arrow-loop-right-user-16.svg
@@ -1,0 +1,23 @@
+<!--
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10.0481 5C8.66741 5 7.54812 3.88071 7.54812 2.5C7.54812 1.11929 8.66741 0 10.0481 0C11.4288 0 12.5481 1.11929 12.5481 2.5C12.5481 3.88071 11.4288 5 10.0481 5ZM10.0481 4C9.21969 4 8.54812 3.32843 8.54812 2.5C8.54812 1.67157 9.21969 1 10.0481 1C10.8765 1 11.5481 1.67157 11.5481 2.5C11.5481 3.32843 10.8765 4 10.0481 4Z" fill="black"/>
+<path d="M15.9895 11.5381C15.5796 8.25514 13.0914 6 10.0487 6C9.77255 6 9.54869 6.22386 9.54869 6.5C9.54869 6.77614 9.77255 7 10.0487 7C12.5476 7 14.6447 8.83933 14.9973 11.662C15.0165 11.8159 14.8886 12 14.6469 12L11.0022 11.9998C10.7261 11.9998 10.5022 12.2236 10.5022 12.4997C10.5022 12.7759 10.7261 12.9998 11.0022 12.9998L14.6468 13C15.4017 13 16.0938 12.3731 15.9895 11.5381Z" fill="black"/>
+<path d="M6.35355 6.64645C6.15829 6.45118 5.84171 6.45118 5.64645 6.64645C5.45118 6.84171 5.45118 7.15829 5.64645 7.35355L7.79289 9.5H3.25C1.45507 9.5 0 10.9551 0 12.75C0 14.5449 1.45507 16 3.25 16H4.5C4.77614 16 5 15.7761 5 15.5C5 15.2239 4.77614 15 4.5 15H3.25C2.00736 15 1 13.9926 1 12.75C1 11.5074 2.00736 10.5 3.25 10.5H7.79289L5.64645 12.6464C5.45118 12.8417 5.45118 13.1583 5.64645 13.3536C5.84171 13.5488 6.15829 13.5488 6.35355 13.3536L9.70711 10L6.35355 6.64645Z" fill="black"/>
+</svg>


### PR DESCRIPTION
### Purpose

Add the new arrow loop right user icon
![Screenshot from 2023-09-13 15-13-59](https://github.com/wso2/oxygen-ui/assets/36092400/11acfbd9-1e79-4326-aad7-2b70826a82ce)


### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/19230

### Related PRs
- none

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
