### PR TITLE
feat(react): add `Autocomplete` component

### DIFF
--- a/packages/react/.storybook/story-config.ts
+++ b/packages/react/.storybook/story-config.ts
@@ -43,6 +43,7 @@ export type Stories =
   | 'AlertTitle'
   | 'AppBar'
   | 'AppShell'
+  | 'Autocomplete'
   | 'Avatar'
   | 'Backdrop'
   | 'Badge'
@@ -160,6 +161,9 @@ const StoryConfig: StorybookConfig = {
   },
   AppShell: {
     hierarchy: `${StorybookCategories.Layout}/App Shell`,
+  },
+  Autocomplete: {
+    hierarchy: `${StorybookCategories.Inputs}/Autocomplete`,
   },
   Avatar: {
     hierarchy: `${StorybookCategories.DataDisplay}/Avatar`,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,7 +79,7 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
     "@types/testing-library__jest-dom": "^5.14.5",
-    "@wso2/eslint-plugin": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?5bf60cabe9e9a2571e8b1dd16d0c3bdc76db2c4f",
+    "@wso2/eslint-plugin": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?acf69507a3f1c83401f1d4b49e4ab8813b174165",
     "@wso2/prettier-config": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?5bf60cabe9e9a2571e8b1dd16d0c3bdc76db2c4f",
     "@wso2/stylelint-config": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/stylelint-config?5bf60cabe9e9a2571e8b1dd16d0c3bdc76db2c4f",
     "babel-jest": "^29.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,7 +79,7 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
     "@types/testing-library__jest-dom": "^5.14.5",
-    "@wso2/eslint-plugin": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?acf69507a3f1c83401f1d4b49e4ab8813b174165",
+    "@wso2/eslint-plugin": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?5bf60cabe9e9a2571e8b1dd16d0c3bdc76db2c4f",
     "@wso2/prettier-config": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?5bf60cabe9e9a2571e8b1dd16d0c3bdc76db2c4f",
     "@wso2/stylelint-config": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/stylelint-config?5bf60cabe9e9a2571e8b1dd16d0c3bdc76db2c4f",
     "babel-jest": "^29.3.1",

--- a/packages/react/src/components/Autocomplete/Autocomplete.stories.mdx
+++ b/packages/react/src/components/Autocomplete/Autocomplete.stories.mdx
@@ -9,7 +9,7 @@ export const meta = {
   title: StoryConfig.Autocomplete.hierarchy,
 };
 
-<Meta title={meta.title} component={meta.component} />
+<Meta title="Inputs/Autocomplete" component={Autocomplete} />
 
 export const Template = args => <Autocomplete {...args} />;
 
@@ -26,6 +26,7 @@ Autocomplete is a conventional text input field that is improved with a panel di
 ### Combination box
 
 The textbox's value needs to be chosen from a predefined set of allowed values.
+
 <Canvas>
   <Story
     name="Combination box"
@@ -55,6 +56,7 @@ The textbox's value needs to be chosen from a predefined set of allowed values.
 ### Multiple values
 
 This is also known as tags, this allows the user to enter more than one value.
+
 <Canvas>
   <Story
     name="Multiple values"

--- a/packages/react/src/components/Autocomplete/Autocomplete.stories.mdx
+++ b/packages/react/src/components/Autocomplete/Autocomplete.stories.mdx
@@ -1,0 +1,98 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import Autocomplete from './Autocomplete.tsx';
+import TextField from '../TextField';
+
+export const meta = {
+  component: Autocomplete,
+  title: StoryConfig.Autocomplete.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => <Autocomplete {...args} />;
+
+# Autocomplete
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+Autocomplete is a conventional text input field that is improved with a panel displaying suggested choices.
+
+### Combination box
+
+The textbox's value needs to be chosen from a predefined set of allowed values.
+<Canvas>
+  <Story
+    name="Combination box"
+    args={
+        {
+            options: [
+                { label: 'The Shawshank Redemption', year: 1994 },
+                { label: 'The Godfather', year: 1972 },
+                { label: 'The Godfather: Part II', year: 1974 },
+                { label: 'The Dark Knight', year: 2008 },
+                { label: '12 Angry Men', year: 1957 },
+                { label: "Schindler's List", year: 1993 },
+                { label: 'Pulp Fiction', year: 1994 }
+            ],
+            renderInput: params  => <TextField {...params} label="Movie" />
+        }
+    }
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+#### Props
+
+<ArgsTable story="Combination box" />
+
+### Multiple values
+
+This is also known as tags, this allows the user to enter more than one value.
+<Canvas>
+  <Story
+    name="Multiple values"
+    args={
+        {
+            options: [
+                { label: 'The Shawshank Redemption', year: 1994 },
+                { label: 'The Godfather', year: 1972 },
+                { label: 'The Godfather: Part II', year: 1974 },
+                { label: 'The Dark Knight', year: 2008 },
+                { label: '12 Angry Men', year: 1957 },
+                { label: "Schindler's List", year: 1993 },
+                { label: 'Pulp Fiction', year: 1994 }
+            ],
+            renderInput: params  => <TextField {...params} label="Movie" />,
+            multiple: true,
+            defaultValue: [
+                { label: 'The Shawshank Redemption', year: 1994 },
+                { label: 'The Godfather', year: 1972 }
+            ]
+        }
+    }
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+#### Props
+
+<ArgsTable story="Multiple values" />
+
+## Usage
+
+Import and use the `Autocomplete` component in your components as follows.
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`import Autocomplete from '@oxygen-ui/react/Autocomplete';\n`}
+/>

--- a/packages/react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react/src/components/Autocomplete/Autocomplete.tsx
@@ -22,7 +22,7 @@ import {forwardRef, ForwardRefExoticComponent, ReactElement, MutableRefObject} f
 import {WithWrapperProps} from '../../models';
 import {composeComponentDisplayName} from '../../utils';
 
-type AutocompleteProps<T> = MuiAutocompleteProps<T, boolean, boolean, boolean>;
+export type AutocompleteProps<T> = MuiAutocompleteProps<T, boolean, boolean, boolean>;
 
 const COMPONENT_NAME: string = 'Autocomplete';
 

--- a/packages/react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react/src/components/Autocomplete/Autocomplete.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiAutocomplete, {AutocompleteProps as MuiAutocompleteProps} from '@mui/material/Autocomplete';
+import clsx from 'clsx';
+import {forwardRef, ForwardRefExoticComponent, ReactElement, MutableRefObject} from 'react';
+import {WithWrapperProps} from '../../models';
+import {composeComponentDisplayName} from '../../utils';
+
+export type AutocompleteProps<T> = MuiAutocompleteProps<
+  T,
+  boolean | undefined,
+  boolean | undefined,
+  boolean | undefined
+>;
+
+const COMPONENT_NAME: string = 'AutoComplete';
+type T = object;
+
+const Autocomplete: ForwardRefExoticComponent<AutocompleteProps<T>> & WithWrapperProps = forwardRef(
+  (props: AutocompleteProps<T>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
+    const {className, ...rest} = props;
+
+    const classes: string = clsx('oxygen-autocomplete', className);
+
+    return <MuiAutocomplete className={classes} {...rest} ref={ref} />;
+  },
+) as ForwardRefExoticComponent<AutocompleteProps<T>> & WithWrapperProps;
+
+Autocomplete.displayName = composeComponentDisplayName(COMPONENT_NAME);
+Autocomplete.muiName = COMPONENT_NAME;
+Autocomplete.defaultProps = {};
+
+export default Autocomplete;

--- a/packages/react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react/src/components/Autocomplete/Autocomplete.tsx
@@ -22,25 +22,20 @@ import {forwardRef, ForwardRefExoticComponent, ReactElement, MutableRefObject} f
 import {WithWrapperProps} from '../../models';
 import {composeComponentDisplayName} from '../../utils';
 
-export type AutocompleteProps<T> = MuiAutocompleteProps<
-  T,
-  boolean | undefined,
-  boolean | undefined,
-  boolean | undefined
->;
+type AutocompleteProps<T> = MuiAutocompleteProps<T, boolean, boolean, boolean>;
 
-const COMPONENT_NAME: string = 'AutoComplete';
-type T = object;
+const COMPONENT_NAME: string = 'Autocomplete';
 
-const Autocomplete: ForwardRefExoticComponent<AutocompleteProps<T>> & WithWrapperProps = forwardRef(
-  (props: AutocompleteProps<T>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
+const Autocomplete: ForwardRefExoticComponent<AutocompleteProps<Record<string, unknown>>> & WithWrapperProps =
+  forwardRef(
+    (props: AutocompleteProps<Record<string, unknown>>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
+      const {className, ...rest} = props;
 
-    const classes: string = clsx('oxygen-autocomplete', className);
+      const classes: string = clsx('oxygen-autocomplete', className);
 
-    return <MuiAutocomplete className={classes} {...rest} ref={ref} />;
-  },
-) as ForwardRefExoticComponent<AutocompleteProps<T>> & WithWrapperProps;
+      return <MuiAutocomplete className={classes} {...rest} ref={ref} />;
+    },
+  ) as ForwardRefExoticComponent<AutocompleteProps<Record<string, unknown>>> & WithWrapperProps;
 
 Autocomplete.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Autocomplete.muiName = COMPONENT_NAME;

--- a/packages/react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react/src/components/Autocomplete/Autocomplete.tsx
@@ -21,6 +21,7 @@ import clsx from 'clsx';
 import {forwardRef, ForwardRefExoticComponent, ReactElement, MutableRefObject} from 'react';
 import {WithWrapperProps} from '../../models';
 import {composeComponentDisplayName} from '../../utils';
+import './autocomplete.scss';
 
 export type AutocompleteProps<T> = MuiAutocompleteProps<T, boolean, boolean, boolean>;
 

--- a/packages/react/src/components/Autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/react/src/components/Autocomplete/__tests__/Autocomplete.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {AutocompleteRenderInputParams} from '@mui/material/Autocomplete/Autocomplete';
+import {render} from '@unit-testing';
+import {ReactNode} from 'react';
+import TextField from '../../TextField';
+import Autocomplete from '../Autocomplete';
+
+describe('Alert', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <Autocomplete
+        disablePortal
+        options={[
+          {label: 'The Shawshank Redemption', year: 1994},
+          {label: 'The Godfather', year: 1972},
+          {label: 'The Godfather: Part II', year: 1974},
+          {label: 'The Dark Knight', year: 2008},
+          {label: '12 Angry Men', year: 1957},
+          {label: "Schindler's List", year: 1993},
+          {label: 'Pulp Fiction', year: 1994},
+        ]}
+        renderInput={(params: AutocompleteRenderInputParams): ReactNode => <TextField {...params} label="Movie" />}
+      />,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <Autocomplete
+        disablePortal
+        options={[
+          {label: 'The Shawshank Redemption', year: 1994},
+          {label: 'The Godfather', year: 1972},
+          {label: 'The Godfather: Part II', year: 1974},
+          {label: 'The Dark Knight', year: 2008},
+          {label: '12 Angry Men', year: 1957},
+          {label: "Schindler's List", year: 1993},
+          {label: 'Pulp Fiction', year: 1994},
+        ]}
+        renderInput={(params: AutocompleteRenderInputParams): ReactNode => <TextField {...params} label="Movie" />}
+      />,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/Autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/components/Autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alert should match the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon oxygen-autocomplete css-l3ln04-MuiAutocomplete-root"
+    >
+      <div
+        class="oxygen-text-field"
+      >
+        <label
+          aria-describedby=":r2:"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated oxygen-input-label css-f3834g-MuiFormLabel-root-MuiInputLabel-root"
+          for=":r2:"
+          id=":r2:-label"
+        >
+          Movie
+        </label>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-115mmlx-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-invalid="false"
+              autocapitalize="none"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-11fn00k-MuiInputBase-input-MuiOutlinedInput-input"
+              id=":r2:"
+              role="combobox"
+              spellcheck="false"
+              type="text"
+              value=""
+            />
+            <div
+              class="MuiAutocomplete-endAdornment css-1q60rmi-MuiAutocomplete-endAdornment"
+            >
+              <button
+                aria-label="Open"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-1n4oo3i-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                tabindex="-1"
+                title="Open"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="ArrowDropDownIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-116asjz-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ihdtdm"
+              >
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/Autocomplete/autocomplete.scss
+++ b/packages/react/src/components/Autocomplete/autocomplete.scss
@@ -17,6 +17,6 @@
  */
 
 .oxygen-autocomplete {
-    padding-top: 16px;
-    padding-bottom: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
 }

--- a/packages/react/src/components/Autocomplete/autocomplete.scss
+++ b/packages/react/src/components/Autocomplete/autocomplete.scss
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.oxygen-autocomplete {
+    padding-top: 16px;
+    padding-bottom: 16px;
+}

--- a/packages/react/src/components/Autocomplete/autocomplete.scss
+++ b/packages/react/src/components/Autocomplete/autocomplete.scss
@@ -17,6 +17,6 @@
  */
 
 .oxygen-autocomplete {
-  padding-top: 16px;
-  padding-bottom: 16px;
+  padding-top: 14px;
+  padding-bottom: 14px;
 }

--- a/packages/react/src/components/Autocomplete/autocomplete.scss
+++ b/packages/react/src/components/Autocomplete/autocomplete.scss
@@ -19,7 +19,7 @@
 .oxygen-autocomplete {
   padding-top: 14px !important;
   padding-bottom: 14px !important;
-  
+
   .MuiButtonBase-root {
     height: 32px !important;
   }

--- a/packages/react/src/components/Autocomplete/autocomplete.scss
+++ b/packages/react/src/components/Autocomplete/autocomplete.scss
@@ -19,6 +19,7 @@
 .oxygen-autocomplete {
   padding-top: 14px !important;
   padding-bottom: 14px !important;
+  
   .MuiButtonBase-root {
     height: 32px !important;
   }

--- a/packages/react/src/components/Autocomplete/autocomplete.scss
+++ b/packages/react/src/components/Autocomplete/autocomplete.scss
@@ -17,6 +17,9 @@
  */
 
 .oxygen-autocomplete {
-  padding-top: 14px;
-  padding-bottom: 14px;
+  padding-top: 14px !important;
+  padding-bottom: 14px !important;
+  .MuiButtonBase-root {
+    height: 32px !important;
+  }
 }

--- a/packages/react/src/components/Autocomplete/index.ts
+++ b/packages/react/src/components/Autocomplete/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './Autocomplete';
+export type {AutocompleteProps} from './Autocomplete';

--- a/packages/react/src/components/Chip/chip.scss
+++ b/packages/react/src/components/Chip/chip.scss
@@ -17,8 +17,9 @@
  */
 
 .oxygen-chip {
-  font-size: 0.85714286rem !important;
+  font-size: 0.8571rem !important;
   padding: 7px 3px !important;
+  
   &-premium {
     background: var(--oxygen-customComponents-Chip-properties-premium-background);
     color: var(--oxygen-customComponents-Chip-properties-premium-text-color);

--- a/packages/react/src/components/Chip/chip.scss
+++ b/packages/react/src/components/Chip/chip.scss
@@ -19,7 +19,7 @@
 .oxygen-chip {
   font-size: 0.8571rem !important;
   padding: 7px 3px !important;
-  
+
   &-premium {
     background: var(--oxygen-customComponents-Chip-properties-premium-background);
     color: var(--oxygen-customComponents-Chip-properties-premium-text-color);

--- a/packages/react/src/components/Chip/chip.scss
+++ b/packages/react/src/components/Chip/chip.scss
@@ -17,6 +17,8 @@
  */
 
 .oxygen-chip {
+  font-size: 0.85714286rem !important;
+  padding: 7px 3px !important;
   &-premium {
     background: var(--oxygen-customComponents-Chip-properties-premium-background);
     color: var(--oxygen-customComponents-Chip-properties-premium-text-color);

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -34,6 +34,9 @@ export * from './AppBar';
 export {default as AppShell} from './AppShell';
 export * from './AppShell';
 
+export {default as Autocomplete} from './Autocomplete';
+export * from './Autocomplete';
+
 export {default as Avatar} from './Avatar';
 export * from './Avatar';
 


### PR DESCRIPTION
### Purpose
Wrap Autocomplete component from MUI.

### Related Issues
- https://github.com/wso2/oxygen-ui/issues/2

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
