### PR TITLE
fix(react): make the `Avatar` letter uppercase by default

### DIFF
--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -221,7 +221,7 @@ const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactEl
               endIcon: <ChevronDownIcon />,
               startIcon: (
                 <Avatar className="image" alt="User Image" src={user?.image}>
-                  {user?.name?.split('')[0]}
+                  {user?.name?.split('')[0].toUpperCase()}
                 </Avatar>
               ),
               ...userDropdownMenuProps.triggerOptions,

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -221,7 +221,7 @@ const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactEl
               endIcon: <ChevronDownIcon />,
               startIcon: (
                 <Avatar className="image" alt="User Image" src={user?.image}>
-                  {user?.name?.split('')[0].toUpperCase()}
+                  {user?.name?.split('')[0].toLocaleUpperCase()}
                 </Avatar>
               ),
               ...userDropdownMenuProps.triggerOptions,


### PR DESCRIPTION
### Purpose

$subject

<img width="1047" alt="Screenshot 2023-10-26 at 02 09 16" src="https://github.com/wso2/oxygen-ui/assets/25959096/242f25c2-2d2d-450b-97da-ef09578049fd">

### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/173

### Related PRs
- N/A

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
