### PR TITLE
fix(react): remove important property from Autocomplete component

### DIFF
--- a/packages/react/src/components/Autocomplete/autocomplete.scss
+++ b/packages/react/src/components/Autocomplete/autocomplete.scss
@@ -17,10 +17,10 @@
  */
 
 .oxygen-autocomplete {
-  padding-top: 14px !important;
-  padding-bottom: 14px !important;
+  padding-top: 14px;
+  padding-bottom: 14px;
 
   .MuiButtonBase-root {
-    height: 32px !important;
+    height: 32px;
   }
 }


### PR DESCRIPTION
### Purpose

$subject

When the component styles are made `!important` from the library, it is not possible to override those styles from the application. This PR is to remove `!important` from the autocomplete styles.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [x] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
