### PR TITLE
chore(react): update `Tab` styles

### DIFF
--- a/packages/react/src/components/Tab/tab.scss
+++ b/packages/react/src/components/Tab/tab.scss
@@ -17,5 +17,10 @@
  */
 
 .oxygen-tab {
-  /** Add Styles */
+  font-size: 1rem;
+  font-weight: 400;
+
+  &:not(.Mui-selected) {
+    color: var(--oxygen-palette-text-primary);
+  }
 }


### PR DESCRIPTION
### Purpose

The bold look of the Oxygen UI tabs appears bulky.

**Before**

<img width="754" alt="Screenshot 2023-11-14 at 13 33 32" src="https://github.com/wso2/oxygen-ui/assets/25959096/cd1b57bd-459e-4b2b-9158-d39c3cfb321e">


**After**

<img width="781" alt="Screenshot 2023-11-14 at 13 33 21" src="https://github.com/wso2/oxygen-ui/assets/25959096/6eeb268d-ac18-4406-b6ae-deccf271a17f">

### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/188

### Related PRs
- N/A

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

