### PR TITLE
chore(react): update `Switch` default styles

### DIFF
--- a/packages/react/src/components/Switch/Switch.stories.mdx
+++ b/packages/react/src/components/Switch/Switch.stories.mdx
@@ -22,6 +22,8 @@ export const Template = (args) => {
 - [Overview](#overview)
 - [Props](#props)
 - [Usage](#usage)
+- [Variants](#variants)
+ - [Size](#size)
 
 ## Overview
 

--- a/packages/react/src/components/Switch/Switch.stories.mdx
+++ b/packages/react/src/components/Switch/Switch.stories.mdx
@@ -54,3 +54,14 @@ function Demo() {
   return <FormControlLabel control={<Switch />} label="Off" />;
 }`}
 />
+
+## Variants
+
+### Size
+
+Use the `size` prop to change the size of the switch.
+
+<Canvas>
+  <Story name="Small" args={{defaultChecked: true, size: 'small'}} />
+  <Story name="Medium" args={{defaultChecked: true, size: 'medium'}} />
+</Canvas>

--- a/packages/react/src/components/Switch/switch.scss
+++ b/packages/react/src/components/Switch/switch.scss
@@ -16,15 +16,87 @@
  * under the License.
  */
 
+:root {
+  --oxygen-switch-width: 3.9rem;
+  --oxygen-switch-height: 2.5rem;
+  --oxygen-switch-track-height: 1rem;
+  --oxygen-switch-track-width: 2rem;
+  --oxygen-switch-thumb-height: 1.5rem;
+  --oxygen-switch-thumb-width: 1.5rem;
+  --oxygen-switch-small-width: 2.8rem;
+  --oxygen-switch-small-height: 1.8rem;
+  --oxygen-switch-small-track-height: 0.8rem;
+  --oxygen-switch-small-track-width: 1.5rem;
+  --oxygen-switch-small-thumb-height: 1.2rem;
+  --oxygen-switch-small-thumb-width: 1.2rem;
+}
+
 .oxygen-switch {
-  /* Add styles */
+  width: var(--oxygen-switch-width);
+  height: var(--oxygen-switch-height);
+
   .MuiSwitch-thumb {
-    color: lightgray;
+    background: var(--oxygen-palette-common-white);
+    transition-property: transform;
+    transition-duration: 200ms;
+    border-radius: inherit;
+    width: var(--oxygen-switch-thumb-width);
+    height: var(--oxygen-switch-thumb-width);
+    border-width: 0.125rem;
+    border-style: solid;
+    border-image: initial;
+    border-color: var(--oxygen-palette-divider);
+  }
+
+  .MuiSwitch-track {
+    height: var(--oxygen-switch-track-height);
+    width: var(--oxygen-switch-track-width);
+    opacity: 0.25;
+    margin-top: 1px;
   }
 
   .Mui-checked {
+    &.MuiSwitch-switchBase {
+      --transform-x-thumb-offset: calc(var(--oxygen-switch-thumb-width)/2);
+      --transform-x-offset: calc(var(--oxygen-switch-track-width) + var(--transform-x-thumb-offset));
+
+      transform: translateX(calc(var(--oxygen-switch-width) - var(--transform-x-offset)));
+    }
+
     .MuiSwitch-thumb {
-      color: var(--oxygen-palette-primary-main);
+      box-shadow: var(--oxygen-shadows-3);
+      background: var(--oxygen-palette-primary-main);
+      border-color: var(--oxygen-palette-common-white);
+    }
+  }
+
+  &.MuiSwitch-sizeSmall {
+    width: var(--oxygen-switch-small-width);
+    height: var(--oxygen-switch-small-height);
+
+    .MuiSwitch-thumb {
+      width: var(--oxygen-switch-small-thumb-width);
+      height: var(--oxygen-switch-small-thumb-height);
+    }
+
+    .MuiSwitch-track {
+      height: var(--oxygen-switch-small-track-height);
+      width: var(--oxygen-switch-small-track-width);
+    }
+
+    .Mui-checked {
+      &.MuiSwitch-switchBase {
+        --transform-x-thumb-offset: calc(var(--oxygen-switch-small-thumb-width)/2);
+        --transform-x-offset: calc(var(--oxygen-switch-small-track-width) + var(--transform-x-thumb-offset));
+
+        transform: translateX(calc(var(--oxygen-switch-small-width) - var(--transform-x-offset)));
+      }
+    }
+  }
+
+  :not(.Mui-checked) {
+    .MuiSwitch-track {
+      opacity: 0.08;
     }
   }
 }


### PR DESCRIPTION
### Purpose

Update `Switch` styles to a more stylish look.

<img width="164" alt="Screenshot 2023-11-24 at 06 41 33" src="https://github.com/wso2/oxygen-ui/assets/25959096/279e82b5-1a52-4aee-a294-e4986295fae7">

### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/194

### Related PRs
- N/A

### Checklist
- [x] UX/UI review done on the final implementation.
- [x] Story provided. (Add screenshots)
- [x] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [x] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
