### PR TITLE
chore(react): expose `generatePastelColor` and hook

### DIFF
--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -19,7 +19,7 @@
 import MuiAvatar, {AvatarProps as MuiAvatarProps} from '@mui/material/Avatar';
 import clsx from 'clsx';
 import {ElementType, FC, ReactElement, useMemo} from 'react';
-import usePastelColorGenerator from 'src/hooks/use-pastel-color-generator';
+import usePastelColorGenerator from '../../hooks/use-pastel-color-generator';
 import {WithWrapperProps} from '../../models';
 import {composeComponentDisplayName} from '../../utils';
 import './avatar.scss';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -19,7 +19,7 @@
 export * from './components';
 export * from './theme';
 export * from './hooks/use-pastel-color-generator';
-export { default } from './utils/generate-pastel-color';
+export {default} from './utils/generate-pastel-color';
 export {
   Alert,
   AlertTitle,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -19,7 +19,7 @@
 export * from './components';
 export * from './theme';
 export * from './hooks/use-pastel-color-generator';
-export {default} from './utils/generate-pastel-color';
+export { default } from './utils/generate-pastel-color';
 export {
   Alert,
   AlertTitle,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -18,6 +18,8 @@
 
 export * from './components';
 export * from './theme';
+export * from './hooks/use-pastel-color-generator';
+export {default} from './utils/generate-pastel-color';
 export {
   Alert,
   AlertTitle,


### PR DESCRIPTION
### Purpose

Expose `generatePastelColor` and `usePastelColorGenerator` hook.

### Related Issues
- https://github.com/wso2/oxygen-ui/issues/197

### Related PRs
- https://github.com/wso2/oxygen-ui/pull/196

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
