### PR TITLE
chore(react): fix background-clip not working in old browsers

### DIFF
--- a/packages/react/src/components/Chip/chip.scss
+++ b/packages/react/src/components/Chip/chip.scss
@@ -17,6 +17,7 @@
  */
 
 // TODO: Remove the following comment after implementing the autoprefixer in the build process.
+// https://github.com/wso2/oxygen-ui/issues/241
 /* stylelint-disable property-no-vendor-prefix */
 
 :root {

--- a/packages/react/src/components/Chip/chip.scss
+++ b/packages/react/src/components/Chip/chip.scss
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+// TODO: Remove the following comment after implementing the autoprefixer in the build process.
 /* stylelint-disable property-no-vendor-prefix */
 
 :root {

--- a/packages/react/src/components/Chip/chip.scss
+++ b/packages/react/src/components/Chip/chip.scss
@@ -16,6 +16,10 @@
  * under the License.
  */
 
+:root {
+  --oxygen-customComponents-Chip-properties-background-clip: text;
+}
+
 .oxygen-chip {
   border-radius: var(--oxygen-customComponents-Chip-properties-border-radius);
 
@@ -46,6 +50,7 @@
 
     .MuiChip-label {
       background-clip: var(--oxygen-customComponents-Chip-properties-background-clip);
+      -webkit-background-clip: text;
       background-image: var(--oxygen-customComponents-Chip-properties-premium-text-color);
       color: var(--oxygen-customComponents-Chip-properties-text-fill-color);
       text-transform: var(--oxygen-customComponents-Chip-properties-text-transform);
@@ -70,6 +75,7 @@
 
     .MuiChip-label {
       background-clip: var(--oxygen-customComponents-Chip-properties-background-clip);
+      -webkit-background-clip: text;
       color: var(--oxygen-customComponents-Chip-properties-text-fill-color);
       background-image: var(--oxygen-customComponents-Chip-properties-new-text-color);
       text-transform: var(--oxygen-customComponents-Chip-properties-text-transform);
@@ -94,6 +100,7 @@
 
     .MuiChip-label {
       background-clip: var(--oxygen-customComponents-Chip-properties-background-clip);
+      -webkit-background-clip: text;
       color: var(--oxygen-customComponents-Chip-properties-text-fill-color);
       background-image: var(--oxygen-customComponents-Chip-properties-beta-text-color);
       text-transform: var(--oxygen-customComponents-Chip-properties-text-transform);
@@ -118,6 +125,7 @@
 
     .MuiChip-label {
       background-clip: var(--oxygen-customComponents-Chip-properties-background-clip);
+      -webkit-background-clip: text;
       color: var(--oxygen-customComponents-Chip-properties-text-fill-color);
       background-image: var(--oxygen-customComponents-Chip-properties-experimental-text-color);
       text-transform: var(--oxygen-customComponents-Chip-properties-text-transform);
@@ -142,6 +150,7 @@
 
     .MuiChip-label {
       background-clip: var(--oxygen-customComponents-Chip-properties-background-clip);
+      -webkit-background-clip: text;
       color: var(--oxygen-customComponents-Chip-properties-text-fill-color);
       background-image: var(--oxygen-customComponents-Chip-properties-coming-soon-text-color);
       text-transform: var(--oxygen-customComponents-Chip-properties-text-transform);

--- a/packages/react/src/components/Chip/chip.scss
+++ b/packages/react/src/components/Chip/chip.scss
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+/* stylelint-disable property-no-vendor-prefix */
+
 :root {
   --oxygen-customComponents-Chip-properties-background-clip: text;
 }

--- a/packages/react/src/models/theme.ts
+++ b/packages/react/src/models/theme.ts
@@ -119,7 +119,6 @@ interface CustomTheme {
     };
     Chip?: {
       properties?: {
-        'background-clip'?: string;
         'beta-background'?: string;
         'beta-border-color'?: string;
         'beta-text-color'?: string;

--- a/packages/react/src/theme/default-theme.ts
+++ b/packages/react/src/theme/default-theme.ts
@@ -176,7 +176,6 @@ export const generateDefaultThemeOptions = (baseTheme: Theme): RecursivePartial<
     Chip: {
       // TODO: Move these to color palette.
       properties: {
-        'background-clip': 'text',
         'beta-background': 'linear-gradient(131deg, rgba(143, 197, 246, 0.30) 0%, rgba(72, 141, 180, 0.30) 100%)',
         'beta-border-color': '#488DB4',
         'beta-text-color': 'linear-gradient(93deg, #488DB4 0%, #1F3D4E 100%)',


### PR DESCRIPTION
### Purpose
chore(react): fix background-clip not working in old browsers.
<img width="1512" alt="Screenshot 2024-07-26 at 11 29 49" src="https://github.com/user-attachments/assets/70d94535-e101-440f-9c7d-371e4594f6a9">

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
