### PR TITLE
chore(react): fix user icon inconsistency in user dropdown

### DIFF
--- a/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
+++ b/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
@@ -193,7 +193,9 @@ const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = (
             onClick={(): void => handleUserProfileNavigation()}
           >
             <ListItemAvatar>
-              <Avatar src={user?.image} alt="User" />
+              <Avatar src={user?.image} alt="User">
+                {user?.name?.split('')[0]}
+              </Avatar>
             </ListItemAvatar>
             <ListItemText primary={user?.name} secondary={user?.email} />
           </ListItem>


### PR DESCRIPTION
### Purpose

This fix makes the Avatar in the dropdown also show the initial letter of the username, instead of showing a user icon.

<img width="266" alt="Screenshot 2024-10-03 at 11 34 14" src="https://github.com/user-attachments/assets/ee4b76c8-c15c-4a61-a6f6-6c68094815bb">

### Related Issues
- https://github.com/wso2/oxygen-ui/issues/261

### Related PRs
- N/A

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [x] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
