### PR TITLE
Add pastel color as bg to Header Avatar where image is not provided

### DIFF
--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -220,7 +220,13 @@ const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactEl
               color: 'inherit',
               endIcon: <ChevronDownIcon />,
               startIcon: (
-                <Avatar className="image" alt="User Image" src={user?.image}>
+                <Avatar
+                  className="image"
+                  alt="User Image"
+                  src={user?.image}
+                  randomBackgroundColor={!user?.image}
+                  backgroundColorRandomizer={user?.name}
+                >
                   {user?.name?.split('')[0]}
                 </Avatar>
               ),


### PR DESCRIPTION
### Purpose

Oxygen UI Avatar gives the capability of having pastel color as Avatar bg, but that support does not extend to Header Avatar. This PR is to provide that capability. 
<img width="543" alt="image" src="https://github.com/user-attachments/assets/8a89855c-d697-4142-a844-62da685258eb">


### Related Issues
- https://github.com/wso2/oxygen-ui/issues/264

### Related PRs
- (None)

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
