### PR TITLE
Fix footer warning when using links

### DIFF
--- a/packages/react/src/components/Footer/Footer.tsx
+++ b/packages/react/src/components/Footer/Footer.tsx
@@ -58,6 +58,7 @@ const Footer: FC<FooterProps> & WithWrapperProps = (props: FooterProps): ReactEl
           <Box className="oxygen-footer-links" fontSize="body2.fontSize">
             {links.map((link: LinkProps) => (
               <Link
+                key={link.id}
                 className="oxygen-footer-link"
                 underline="none"
                 target="_blank"


### PR DESCRIPTION
### Purpose

Fix below warning
![image](https://github.com/user-attachments/assets/d1f8aa21-4888-40c0-9021-50a28e704911)


### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/266

### Related PRs
- (None)

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
