### PR TITLE
Add pastel color as bg to Header's DropDown Avatar where image is not provided

### DIFF
--- a/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
+++ b/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
@@ -193,7 +193,12 @@ const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = (
             onClick={(): void => handleUserProfileNavigation()}
           >
             <ListItemAvatar>
-              <Avatar src={user?.image} alt="User">
+              <Avatar
+                src={user?.image}
+                alt="User"
+                randomBackgroundColor={!user?.image}
+                backgroundColorRandomizer={user?.name}
+              >
                 {user?.name?.split('')[0]}
               </Avatar>
             </ListItemAvatar>


### PR DESCRIPTION
### Purpose

<img width="237" alt="image" src="https://github.com/user-attachments/assets/a4aabe17-0872-4c39-bcdb-cc7f9ed5a3f5">

Oxygen UI Avatar gives the capability of having pastel color as Avatar bg, but that support does not extend to Header's DropDown Avatar. This PR is to provide that capability as below.
<img width="334" alt="image" src="https://github.com/user-attachments/assets/92b05317-5bfb-4776-8a2d-c5716717b5c8">

### Related Issues
- https://github.com/wso2/oxygen-ui/issues/268

### Related PRs
- (None)

### Checklist
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
