### PR TITLE
fix(react): remove  deprecated `defaultProps`

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -27,9 +27,7 @@ export type AccordionProps = MuiAccordionProps;
 
 const COMPONENT_NAME: string = 'Accordion';
 
-const Accordion: FC<AccordionProps> & WithWrapperProps = (props: AccordionProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Accordion: FC<AccordionProps> & WithWrapperProps = ({className, ...rest}: AccordionProps): ReactElement => {
   const classes: string = clsx('oxygen-accordion', className);
 
   return <MuiAccordion className={classes} {...rest} />;

--- a/packages/react/src/components/AccordionDetails/AccordionDetails.tsx
+++ b/packages/react/src/components/AccordionDetails/AccordionDetails.tsx
@@ -27,9 +27,7 @@ export type AccordionDetailsProps = MuiAccordionDetailsProps;
 const COMPONENT_NAME: string = 'AccordionDetails';
 
 const AccordionDetails: ForwardRefExoticComponent<AccordionDetailsProps> & WithWrapperProps = forwardRef(
-  (props: AccordionDetailsProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: AccordionDetailsProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-accordion-details', className);
 
     return <MuiAccordionDetails className={classes} {...rest} ref={ref} />;
@@ -38,6 +36,5 @@ const AccordionDetails: ForwardRefExoticComponent<AccordionDetailsProps> & WithW
 
 AccordionDetails.displayName = composeComponentDisplayName(COMPONENT_NAME);
 AccordionDetails.muiName = COMPONENT_NAME;
-AccordionDetails.defaultProps = {};
 
 export default AccordionDetails;

--- a/packages/react/src/components/AccordionSummary/AccordionSummary.tsx
+++ b/packages/react/src/components/AccordionSummary/AccordionSummary.tsx
@@ -27,9 +27,7 @@ export type AccordionSummaryProps = MuiAccordionSummaryProps;
 const COMPONENT_NAME: string = 'AccordionSummary';
 
 const AccordionSummary: ForwardRefExoticComponent<AccordionSummaryProps> & WithWrapperProps = forwardRef(
-  (props: AccordionSummaryProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: AccordionSummaryProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-accordion-summary', className);
 
     return <MuiAccordionSummary className={classes} {...rest} ref={ref} />;
@@ -38,6 +36,5 @@ const AccordionSummary: ForwardRefExoticComponent<AccordionSummaryProps> & WithW
 
 AccordionSummary.displayName = composeComponentDisplayName(COMPONENT_NAME);
 AccordionSummary.muiName = COMPONENT_NAME;
-AccordionSummary.defaultProps = {};
 
 export default AccordionSummary;

--- a/packages/react/src/components/AccountOverview/AccountOverview.tsx
+++ b/packages/react/src/components/AccountOverview/AccountOverview.tsx
@@ -66,19 +66,17 @@ export type AccountCompletionSteps = CarouselStep;
 
 const COMPONENT_NAME: string = 'AccountOverview';
 
-const AccountOverview: FC<AccountOverviewProps> & WithWrapperProps = (props: AccountOverviewProps): ReactElement => {
-  const {
-    className,
-    title,
-    subheader,
-    accountCompletionStepsTitle,
-    accountCompletionSteps,
-    accountProgress,
-    user,
-    cardHeaderProps,
-    ...rest
-  } = props;
-
+const AccountOverview: FC<AccountOverviewProps> & WithWrapperProps = ({
+  className,
+  title,
+  subheader,
+  accountCompletionStepsTitle,
+  accountCompletionSteps,
+  accountProgress,
+  user,
+  cardHeaderProps,
+  ...rest
+}: AccountOverviewProps): ReactElement => {
   const classes: string = clsx('oxygen-account-overview', className);
 
   return (

--- a/packages/react/src/components/ActionCard/ActionCard.tsx
+++ b/packages/react/src/components/ActionCard/ActionCard.tsx
@@ -52,9 +52,15 @@ export interface ActionCardProps extends CardProps {
 
 const COMPONENT_NAME: string = 'ActionCard';
 
-const ActionCard: FC<ActionCardProps> & WithWrapperProps = (props: ActionCardProps): ReactElement => {
-  const {className, image, title, description, actionText, onActionClick, ...rest} = props;
-
+const ActionCard: FC<ActionCardProps> & WithWrapperProps = ({
+  className,
+  image,
+  title,
+  description,
+  actionText,
+  onActionClick,
+  ...rest
+}: ActionCardProps): ReactElement => {
   const classes: string = clsx('oxygen-action-card', className);
 
   return (
@@ -75,6 +81,5 @@ const ActionCard: FC<ActionCardProps> & WithWrapperProps = (props: ActionCardPro
 
 ActionCard.displayName = composeComponentDisplayName(COMPONENT_NAME);
 ActionCard.muiName = COMPONENT_NAME;
-ActionCard.defaultProps = {};
 
 export default ActionCard;

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -28,9 +28,7 @@ export type AlertProps = MuiAlertProps;
 const COMPONENT_NAME: string = 'Alert';
 
 const Alert: ForwardRefExoticComponent<AlertProps> & WithWrapperProps = forwardRef(
-  (props: AlertProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: AlertProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-alert', className);
 
     return <MuiAlert className={classes} {...rest} ref={ref} />;
@@ -39,6 +37,5 @@ const Alert: ForwardRefExoticComponent<AlertProps> & WithWrapperProps = forwardR
 
 Alert.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Alert.muiName = COMPONENT_NAME;
-Alert.defaultProps = {};
 
 export default Alert;

--- a/packages/react/src/components/AlertTitle/AlertTitle.tsx
+++ b/packages/react/src/components/AlertTitle/AlertTitle.tsx
@@ -28,9 +28,7 @@ export type AlertProps = MuiAlertProps;
 const COMPONENT_NAME: string = 'AlertTitle';
 
 const AlertTitle: ForwardRefExoticComponent<AlertProps> & WithWrapperProps = forwardRef(
-  (props: AlertProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: AlertProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-alert-title', className);
 
     return <MuiAlertTitle className={classes} {...rest} ref={ref} />;
@@ -39,6 +37,5 @@ const AlertTitle: ForwardRefExoticComponent<AlertProps> & WithWrapperProps = for
 
 AlertTitle.displayName = composeComponentDisplayName(COMPONENT_NAME);
 AlertTitle.muiName = COMPONENT_NAME;
-AlertTitle.defaultProps = {};
 
 export default AlertTitle;

--- a/packages/react/src/components/AppBar/AppBar.tsx
+++ b/packages/react/src/components/AppBar/AppBar.tsx
@@ -27,9 +27,7 @@ export type AppBarProps = MuiAppBarProps;
 
 const COMPONENT_NAME: string = 'AppBar';
 
-const AppBar: FC<AppBarProps> & WithWrapperProps = (props: AppBarProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const AppBar: FC<AppBarProps> & WithWrapperProps = ({className, ...rest}: AppBarProps): ReactElement => {
   const classes: string = clsx('oxygen-app-bar', className);
 
   return <MuiAppBar className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const AppBar: FC<AppBarProps> & WithWrapperProps = (props: AppBarProps): ReactEl
 
 AppBar.displayName = composeComponentDisplayName(COMPONENT_NAME);
 AppBar.muiName = COMPONENT_NAME;
-AppBar.defaultProps = {};
 
 export default AppBar;

--- a/packages/react/src/components/AppShell/AppShell.tsx
+++ b/packages/react/src/components/AppShell/AppShell.tsx
@@ -40,11 +40,14 @@ export interface AppShellProps extends BoxProps {
 
 const COMPONENT_NAME: string = 'AppShell';
 
-const AppShell: FC<PropsWithChildren<AppShellProps>> & WithWrapperProps = (
-  props: PropsWithChildren<AppShellProps>,
-): ReactElement => {
-  const {className, children, footer, header, navigation, ...rest} = props;
-
+const AppShell: FC<PropsWithChildren<AppShellProps>> & WithWrapperProps = ({
+  className,
+  children,
+  footer,
+  header,
+  navigation,
+  ...rest
+}: PropsWithChildren<AppShellProps>): ReactElement => {
   const classes: string = clsx('oxygen-app-shell', className);
 
   return (
@@ -65,6 +68,5 @@ const AppShell: FC<PropsWithChildren<AppShellProps>> & WithWrapperProps = (
 
 AppShell.displayName = composeComponentDisplayName(COMPONENT_NAME);
 AppShell.muiName = COMPONENT_NAME;
-AppShell.defaultProps = {};
 
 export default AppShell;

--- a/packages/react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react/src/components/Autocomplete/Autocomplete.tsx
@@ -31,9 +31,7 @@ const COMPONENT_NAME: string = 'Autocomplete';
  * @remarks `any` is used as the generic type for the props because the generic type is not used in the component.
  */
 const Autocomplete: ForwardRefExoticComponent<AutocompleteProps<any>> & WithWrapperProps = forwardRef(
-  (props: AutocompleteProps<any>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: AutocompleteProps<any>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-autocomplete', className);
 
     return <MuiAutocomplete className={classes} {...rest} ref={ref} />;
@@ -42,6 +40,5 @@ const Autocomplete: ForwardRefExoticComponent<AutocompleteProps<any>> & WithWrap
 
 Autocomplete.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Autocomplete.muiName = COMPONENT_NAME;
-Autocomplete.defaultProps = {};
 
 export default Autocomplete;

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -37,13 +37,18 @@ export type AvatarProps<C extends ElementType = ElementType> = {
    * If `true`, the background color will be randomly generated.
    */
   randomBackgroundColor?: boolean;
-} & Omit<MuiAvatarProps<C>, 'component'>;
+} & Omit<MuiAvatarProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Avatar';
 
-const Avatar: FC<AvatarProps> & WithWrapperProps = <C extends ElementType>(props: AvatarProps<C>): ReactElement => {
-  const {className, children, component, randomBackgroundColor, backgroundColorRandomizer, ...rest} = props;
-
+const Avatar: FC<AvatarProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  children,
+  component,
+  randomBackgroundColor,
+  backgroundColorRandomizer,
+  ...rest
+}: AvatarProps<C>): ReactElement => {
   const colorRandomizer: string = useMemo(() => {
     if (backgroundColorRandomizer) {
       return backgroundColorRandomizer;
@@ -74,6 +79,5 @@ const Avatar: FC<AvatarProps> & WithWrapperProps = <C extends ElementType>(props
 
 Avatar.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Avatar.muiName = COMPONENT_NAME;
-Avatar.defaultProps = {};
 
 export default Avatar;

--- a/packages/react/src/components/Backdrop/Backdrop.tsx
+++ b/packages/react/src/components/Backdrop/Backdrop.tsx
@@ -27,9 +27,7 @@ export type BackdropProps = MuiBackdropProps;
 
 const COMPONENT_NAME: string = 'Backdrop';
 
-const Backdrop: FC<BackdropProps> & WithWrapperProps = (props: BackdropProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Backdrop: FC<BackdropProps> & WithWrapperProps = ({className, ...rest}: BackdropProps): ReactElement => {
   const classes: string = clsx('oxygen-backdrop', className);
 
   return <MuiBackdrop className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const Backdrop: FC<BackdropProps> & WithWrapperProps = (props: BackdropProps): R
 
 Backdrop.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Backdrop.muiName = COMPONENT_NAME;
-Backdrop.defaultProps = {};
 
 export default Backdrop;

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -27,9 +27,7 @@ export type BadgeProps = MuiBadgeProps;
 
 const COMPONENT_NAME: string = 'Badge';
 
-const Badge: FC<BadgeProps> & WithWrapperProps = (props: BadgeProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Badge: FC<BadgeProps> & WithWrapperProps = ({className, ...rest}: BadgeProps): ReactElement => {
   const classes: string = clsx('oxygen-badge', className);
 
   return <MuiBadge className={classes} {...rest} />;

--- a/packages/react/src/components/Box/Box.tsx
+++ b/packages/react/src/components/Box/Box.tsx
@@ -24,14 +24,12 @@ import {composeComponentDisplayName} from '../../utils';
 
 export type BoxProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiBoxProps<C>, 'component'>;
+} & Omit<MuiBoxProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Box';
 
 const Box: ForwardRefExoticComponent<BoxProps> & WithWrapperProps = forwardRef(
-  <C extends ElementType>(props: BoxProps<C>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  <C extends ElementType>({className, ...rest}: BoxProps<C>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-box', className);
 
     return <MuiBox className={classes} ref={ref} {...rest} />;
@@ -40,6 +38,5 @@ const Box: ForwardRefExoticComponent<BoxProps> & WithWrapperProps = forwardRef(
 
 Box.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Box.muiName = COMPONENT_NAME;
-Box.defaultProps = {};
 
 export default Box;

--- a/packages/react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -27,9 +27,11 @@ export type BreadcrumbsProps = MuiBreadcrumbsProps;
 
 const COMPONENT_NAME: string = 'Breadcrumbs';
 
-const Breadcrumbs: FC<BreadcrumbsProps> & WithWrapperProps = (props: BreadcrumbsProps): ReactElement => {
-  const {className, children, ...rest} = props;
-
+const Breadcrumbs: FC<BreadcrumbsProps> & WithWrapperProps = ({
+  className,
+  children,
+  ...rest
+}: BreadcrumbsProps): ReactElement => {
   const classes: string = clsx('oxygen-breadcrumbs', className);
 
   return (
@@ -41,6 +43,5 @@ const Breadcrumbs: FC<BreadcrumbsProps> & WithWrapperProps = (props: Breadcrumbs
 
 Breadcrumbs.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Breadcrumbs.muiName = 'Breadcrumbs';
-Breadcrumbs.defaultProps = {};
 
 export default Breadcrumbs;

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -27,9 +27,7 @@ export type ButtonProps = MuiButtonProps;
 
 const COMPONENT_NAME: string = 'Button';
 
-const Button: FC<ButtonProps> & WithWrapperProps = (props: ButtonProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Button: FC<ButtonProps> & WithWrapperProps = ({className, ...rest}: ButtonProps): ReactElement => {
   const classes: string = clsx('oxygen-button', className);
 
   return <MuiButton className={classes} {...rest} />;

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -25,25 +25,24 @@ import './card.scss';
 
 export type CardProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiCardProps<C>, 'component'>;
+} & Omit<MuiCardProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Card';
 
 const Card: ForwardRefExoticComponent<CardProps> & WithWrapperProps = forwardRef(
-  <C extends ElementType>(props: CardProps<C>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, component, onClick, ...rest} = props;
-
+  <C extends ElementType>(
+    {className, component, onClick, elevation = 0, variant = 'outlined', ...rest}: CardProps<C>,
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-card', {'with-hover': onClick}, className);
 
-    return <MuiCard className={classes} ref={ref} onClick={onClick} {...rest} />;
+    return (
+      <MuiCard className={classes} ref={ref} onClick={onClick} elevation={elevation} variant={variant} {...rest} />
+    );
   },
 ) as ForwardRefExoticComponent<CardProps> & WithWrapperProps;
 
 Card.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Card.muiName = COMPONENT_NAME;
-Card.defaultProps = {
-  elevation: 0,
-  variant: 'outlined',
-};
 
 export default Card;

--- a/packages/react/src/components/CardActions/CardActions.tsx
+++ b/packages/react/src/components/CardActions/CardActions.tsx
@@ -27,9 +27,7 @@ export type CardActionsProps = MuiCardActionsProps;
 
 const COMPONENT_NAME: string = 'CardActions';
 
-const CardActions: FC<CardActionsProps> & WithWrapperProps = (props: CardActionsProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const CardActions: FC<CardActionsProps> & WithWrapperProps = ({className, ...rest}: CardActionsProps): ReactElement => {
   const classes: string = clsx('oxygen-card-actions', className);
 
   return <MuiCardActions className={classes} {...rest} />;

--- a/packages/react/src/components/CardContent/CardContent.tsx
+++ b/packages/react/src/components/CardContent/CardContent.tsx
@@ -28,9 +28,7 @@ export type CardContentProps = MuiCardContentProps;
 const COMPONENT_NAME: string = 'CardContent';
 
 const CardContent: ForwardRefExoticComponent<CardContentProps> & WithWrapperProps = forwardRef(
-  (props: CardContentProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: CardContentProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-card-content', className);
 
     return <MuiCardContent ref={ref} className={classes} {...rest} />;

--- a/packages/react/src/components/CardHeader/CardHeader.tsx
+++ b/packages/react/src/components/CardHeader/CardHeader.tsx
@@ -27,9 +27,7 @@ export type CardHeaderProps = MuiCardHeaderProps;
 
 const COMPONENT_NAME: string = 'CardHeader';
 
-const CardHeader: FC<CardHeaderProps> & WithWrapperProps = (props: CardHeaderProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const CardHeader: FC<CardHeaderProps> & WithWrapperProps = ({className, ...rest}: CardHeaderProps): ReactElement => {
   const classes: string = clsx('oxygen-card-header', className);
 
   return <MuiCardHeader className={classes} {...rest} />;

--- a/packages/react/src/components/Carousel/Carousel.tsx
+++ b/packages/react/src/components/Carousel/Carousel.tsx
@@ -87,8 +87,16 @@ export interface CarouselProps extends Omit<HTMLAttributes<HTMLDivElement>, 'tit
 
 const COMPONENT_NAME: string = 'Carousel';
 
-const Carousel: FC<CarouselProps> & WithWrapperProps = (props: CarouselProps): ReactElement => {
-  const {autoPlay, autoPlayInterval, className, nextButtonText, previousButtonText, steps, title, ...rest} = props;
+const Carousel: FC<CarouselProps> & WithWrapperProps = ({
+  autoPlay = false,
+  autoPlayInterval = 5000,
+  className,
+  nextButtonText = 'Next',
+  previousButtonText = 'Previous',
+  steps,
+  title,
+  ...rest
+}: CarouselProps): ReactElement => {
   const [currentStep, setCurrentStep] = useState<number>(0);
 
   const isLastStep: boolean = useMemo(() => currentStep === steps.length - 1, [steps, currentStep]);
@@ -195,11 +203,5 @@ const Carousel: FC<CarouselProps> & WithWrapperProps = (props: CarouselProps): R
 
 Carousel.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Carousel.muiName = COMPONENT_NAME;
-Carousel.defaultProps = {
-  autoPlay: false,
-  autoPlayInterval: 5000,
-  nextButtonText: 'Next',
-  previousButtonText: 'Previous',
-};
 
 export default Carousel;

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -27,9 +27,7 @@ export type CheckboxProps = MuiCheckboxProps;
 const COMPONENT_NAME: string = 'Checkbox';
 
 const Checkbox: ForwardRefExoticComponent<CheckboxProps> & WithWrapperProps = forwardRef(
-  (props: CheckboxProps, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: CheckboxProps, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
     const classes: string = clsx('oxygen-checkbox', className);
 
     return <MuiCheckbox className={classes} {...rest} ref={ref} />;
@@ -38,6 +36,5 @@ const Checkbox: ForwardRefExoticComponent<CheckboxProps> & WithWrapperProps = fo
 
 Checkbox.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Checkbox.muiName = COMPONENT_NAME;
-Checkbox.defaultProps = {};
 
 export default Checkbox;

--- a/packages/react/src/components/Chip/Chip.tsx
+++ b/packages/react/src/components/Chip/Chip.tsx
@@ -25,13 +25,14 @@ import './chip.scss';
 
 export type ChipProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiChipProps<C>, 'component'>;
+} & Omit<MuiChipProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Chip';
 
-const Chip: FC<ChipProps> & WithWrapperProps = <C extends ElementType>(props: ChipProps<C>): ReactElement => {
-  const {className, ...rest} = props;
-
+const Chip: FC<ChipProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  ...rest
+}: ChipProps<C>): ReactElement => {
   const classes: string = clsx('oxygen-chip', className);
 
   return <MuiChip className={classes} {...rest} />;
@@ -39,6 +40,5 @@ const Chip: FC<ChipProps> & WithWrapperProps = <C extends ElementType>(props: Ch
 
 Chip.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Chip.muiName = COMPONENT_NAME;
-Chip.defaultProps = {};
 
 export default Chip;

--- a/packages/react/src/components/CircularProgress/CircularProgress.tsx
+++ b/packages/react/src/components/CircularProgress/CircularProgress.tsx
@@ -27,9 +27,10 @@ export type CircularProgressProps = MuiCircularProgressProps;
 
 const COMPONENT_NAME: string = 'CircularProgress';
 
-const CircularProgress: FC<CircularProgressProps> & WithWrapperProps = (props: CircularProgressProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const CircularProgress: FC<CircularProgressProps> & WithWrapperProps = ({
+  className,
+  ...rest
+}: CircularProgressProps): ReactElement => {
   const classes: string = clsx('oxygen-circular-progress', className);
 
   return <MuiCircularProgress aria-label="progress" className={classes} {...rest} />;
@@ -37,6 +38,5 @@ const CircularProgress: FC<CircularProgressProps> & WithWrapperProps = (props: C
 
 CircularProgress.displayName = composeComponentDisplayName(COMPONENT_NAME);
 CircularProgress.muiName = COMPONENT_NAME;
-CircularProgress.defaultProps = {};
 
 export default CircularProgress;

--- a/packages/react/src/components/CircularProgressAvatar/CircularProgressAvatar.tsx
+++ b/packages/react/src/components/CircularProgressAvatar/CircularProgressAvatar.tsx
@@ -42,11 +42,13 @@ export interface CircularProgressAvatarProps extends Omit<CircularProgressProps,
 
 const COMPONENT_NAME: string = 'CircularProgressAvatar';
 
-const CircularProgressAvatar: FC<CircularProgressAvatarProps> & WithWrapperProps = (
-  props: CircularProgressAvatarProps,
-): ReactElement => {
-  const {className, progress, badgeOptions, avatarOptions, ...rest} = props;
-
+const CircularProgressAvatar: FC<CircularProgressAvatarProps> & WithWrapperProps = ({
+  className,
+  progress,
+  badgeOptions,
+  avatarOptions,
+  ...rest
+}: CircularProgressAvatarProps): ReactElement => {
   const classes: string = clsx('oxygen-circular-progress-avatar', className);
 
   return (
@@ -84,6 +86,5 @@ const CircularProgressAvatar: FC<CircularProgressAvatarProps> & WithWrapperProps
 
 CircularProgressAvatar.displayName = composeComponentDisplayName(COMPONENT_NAME);
 CircularProgressAvatar.muiName = COMPONENT_NAME;
-CircularProgressAvatar.defaultProps = {};
 
 export default CircularProgressAvatar;

--- a/packages/react/src/components/Code/Code.tsx
+++ b/packages/react/src/components/Code/Code.tsx
@@ -38,13 +38,17 @@ export type CodeProps<C extends ElementType = ElementType> = {
    * @default false
    */
   outlined?: boolean;
-} & Omit<MuiTypographyProps<C>, 'component'>;
+} & Omit<MuiTypographyProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Code';
 
-const Code: FC<CodeProps> & WithWrapperProps = <C extends ElementType>(props: CodeProps<C>): ReactElement => {
-  const {className, children, filled, outlined, ...rest} = props;
-
+const Code: FC<CodeProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  children,
+  filled = true,
+  outlined = false,
+  ...rest
+}: CodeProps<C>): ReactElement => {
   const classes: string = clsx('oxygen-code', {filled, outlined}, className);
 
   return (
@@ -56,9 +60,5 @@ const Code: FC<CodeProps> & WithWrapperProps = <C extends ElementType>(props: Co
 
 Code.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Code.muiName = COMPONENT_NAME;
-Code.defaultProps = {
-  filled: true,
-  outlined: false,
-};
 
 export default Code;

--- a/packages/react/src/components/CollapsibleNavbarItem/CollapsibleNavbarItem.tsx
+++ b/packages/react/src/components/CollapsibleNavbarItem/CollapsibleNavbarItem.tsx
@@ -47,10 +47,24 @@ export interface CollapsibleNavbarItemProps extends NavbarItemProps, Pick<Navbar
 const COMPONENT_NAME: string = 'CollapsibleNavbarItem';
 
 const CollapsibleNavbarItem: ForwardRefExoticComponent<CollapsibleNavbarItemProps> & WithWrapperProps = forwardRef(
-  (props: CollapsibleNavbarItemProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, component, expanded, fill, icon, id, open, label, onClick, items, tag, tagClassName, ...rest} =
-      props;
-
+  (
+    {
+      className,
+      component,
+      expanded,
+      fill,
+      icon,
+      id,
+      open = true,
+      label,
+      onClick,
+      items,
+      tag,
+      tagClassName,
+      ...rest
+    }: CollapsibleNavbarItemProps,
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const classes: string = clsx(
       'oxygen-collapsible-navbar-item',
       {
@@ -130,8 +144,5 @@ const CollapsibleNavbarItem: ForwardRefExoticComponent<CollapsibleNavbarItemProp
 
 CollapsibleNavbarItem.displayName = composeComponentDisplayName(COMPONENT_NAME);
 CollapsibleNavbarItem.muiName = COMPONENT_NAME;
-CollapsibleNavbarItem.defaultProps = {
-  open: true,
-};
 
 export default CollapsibleNavbarItem;

--- a/packages/react/src/components/ColorModeToggle/ColorModeToggle.tsx
+++ b/packages/react/src/components/ColorModeToggle/ColorModeToggle.tsx
@@ -66,9 +66,10 @@ const CrescentIcon = (props: PropsWithChildren<SVGProps<SVGSVGElement>>): ReactE
   </svg>
 );
 
-const ColorModeToggle: FC<ColorModeToggleProps> & WithWrapperProps = (props: ColorModeToggleProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const ColorModeToggle: FC<ColorModeToggleProps> & WithWrapperProps = ({
+  className,
+  ...rest
+}: ColorModeToggleProps): ReactElement => {
   const {mode, setMode} = useColorScheme();
 
   const classes: string = clsx('oxygen-color-mode-toggle', className);
@@ -90,6 +91,5 @@ const ColorModeToggle: FC<ColorModeToggleProps> & WithWrapperProps = (props: Col
 
 ColorModeToggle.displayName = composeComponentDisplayName(COMPONENT_NAME);
 ColorModeToggle.muiName = COMPONENT_NAME;
-ColorModeToggle.defaultProps = {};
 
 export default ColorModeToggle;

--- a/packages/react/src/components/Container/Container.tsx
+++ b/packages/react/src/components/Container/Container.tsx
@@ -25,15 +25,14 @@ import './container.scss';
 
 export type ContainerProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiContainerProps<C>, 'component'>;
+} & Omit<MuiContainerProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Container';
 
-const Container: FC<ContainerProps> & WithWrapperProps = <C extends ElementType>(
-  props: ContainerProps<C>,
-): ReactElement => {
-  const {className, ...rest} = props;
-
+const Container: FC<ContainerProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  ...rest
+}: ContainerProps<C>): ReactElement => {
   const classes: string = clsx('oxygen-container', className);
 
   return <MuiContainer className={classes} {...rest} />;
@@ -41,6 +40,5 @@ const Container: FC<ContainerProps> & WithWrapperProps = <C extends ElementType>
 
 Container.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Container.muiName = COMPONENT_NAME;
-Container.defaultProps = {};
 
 export default Container;

--- a/packages/react/src/components/CountryFlag/CountryFlag.tsx
+++ b/packages/react/src/components/CountryFlag/CountryFlag.tsx
@@ -35,16 +35,15 @@ export interface CountryFlagsProps extends React.HTMLAttributes<HTMLElement & SV
 
 const COMPONENT_NAME: string = 'Flag';
 
-const CountryFlag: FC<CountryFlagsProps> & WithWrapperProps = (props: CountryFlagsProps): ReactElement => {
-  const {countryCode, height, ...rest} = props;
-
-  return <WorldFlag code={countryCode} height={height} fallback={<Typography>{countryCode}</Typography>} {...rest} />;
-};
+const CountryFlag: FC<CountryFlagsProps> & WithWrapperProps = ({
+  countryCode,
+  height = '16',
+  ...rest
+}: CountryFlagsProps): ReactElement => (
+  <WorldFlag code={countryCode} height={height} fallback={<Typography>{countryCode}</Typography>} {...rest} />
+);
 
 CountryFlag.displayName = composeComponentDisplayName(COMPONENT_NAME);
 CountryFlag.muiName = COMPONENT_NAME;
-CountryFlag.defaultProps = {
-  height: '16',
-};
 
 export default CountryFlag;

--- a/packages/react/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react/src/components/DataGrid/DataGrid.tsx
@@ -27,9 +27,7 @@ export type DataGridProps = MuiDataGridProps;
 
 const COMPONENT_NAME: string = 'DataGrid';
 
-const DataGrid: FC<DataGridProps> & WithWrapperProps = (props: DataGridProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const DataGrid: FC<DataGridProps> & WithWrapperProps = ({className, ...rest}: DataGridProps): ReactElement => {
   const classes: string = clsx('oxygen-data-grid', className);
 
   return <MuiDataGrid className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const DataGrid: FC<DataGridProps> & WithWrapperProps = (props: DataGridProps): R
 
 DataGrid.displayName = composeComponentDisplayName(COMPONENT_NAME);
 DataGrid.muiName = COMPONENT_NAME;
-DataGrid.defaultProps = {};
 
 export default DataGrid;

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -27,9 +27,7 @@ export type DividerProps = MuiDividerProps;
 
 const COMPONENT_NAME: string = 'Divider';
 
-const Divider: FC<DividerProps> & WithWrapperProps = (props: DividerProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Divider: FC<DividerProps> & WithWrapperProps = ({className, ...rest}: DividerProps): ReactElement => {
   const classes: string = clsx('oxygen-divider', className);
 
   return <MuiDivider className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const Divider: FC<DividerProps> & WithWrapperProps = (props: DividerProps): Reac
 
 Divider.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Divider.muiName = COMPONENT_NAME;
-Divider.defaultProps = {};
 
 export default Divider;

--- a/packages/react/src/components/Drawer/Drawer.tsx
+++ b/packages/react/src/components/Drawer/Drawer.tsx
@@ -27,9 +27,7 @@ export type DrawerProps = MuiDrawerProps;
 
 const COMPONENT_NAME: string = 'Drawer';
 
-const Drawer: FC<DrawerProps> & WithWrapperProps = (props: DrawerProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Drawer: FC<DrawerProps> & WithWrapperProps = ({className, ...rest}: DrawerProps): ReactElement => {
   const classes: string = clsx('oxygen-drawer', className);
 
   return <MuiDrawer className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const Drawer: FC<DrawerProps> & WithWrapperProps = (props: DrawerProps): ReactEl
 
 Drawer.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Drawer.muiName = COMPONENT_NAME;
-Drawer.defaultProps = {};
 
 export default Drawer;

--- a/packages/react/src/components/Fab/Fab.tsx
+++ b/packages/react/src/components/Fab/Fab.tsx
@@ -24,14 +24,15 @@ import {composeComponentDisplayName} from '../../utils';
 
 export type FabProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiFabProps<C>, 'component'>;
+} & Omit<MuiFabProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Fab';
 
 const Fab: ForwardRefExoticComponent<FabProps> & WithWrapperProps = forwardRef(
-  <C extends ElementType>(props: FabProps<C>, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  <C extends ElementType>(
+    {className, ...rest}: FabProps<C>,
+    ref: MutableRefObject<HTMLButtonElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-fab', className);
 
     return <MuiFab className={classes} {...rest} ref={ref} />;
@@ -40,6 +41,5 @@ const Fab: ForwardRefExoticComponent<FabProps> & WithWrapperProps = forwardRef(
 
 Fab.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Fab.muiName = COMPONENT_NAME;
-Fab.defaultProps = {};
 
 export default Fab;

--- a/packages/react/src/components/Footer/Footer.tsx
+++ b/packages/react/src/components/Footer/Footer.tsx
@@ -44,9 +44,13 @@ export interface FooterProps extends BoxProps {
 
 const COMPONENT_NAME: string = 'Footer';
 
-const Footer: FC<FooterProps> & WithWrapperProps = (props: FooterProps): ReactElement => {
-  const {className, copyright, links, maxWidth, ...rest} = props;
-
+const Footer: FC<FooterProps> & WithWrapperProps = ({
+  className,
+  copyright,
+  links,
+  maxWidth,
+  ...rest
+}: FooterProps): ReactElement => {
   const isMobile: boolean = useIsMobile();
 
   const classes: string = clsx('oxygen-footer', {mobile: isMobile}, className);
@@ -85,6 +89,5 @@ const Footer: FC<FooterProps> & WithWrapperProps = (props: FooterProps): ReactEl
 
 Footer.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Footer.muiName = COMPONENT_NAME;
-Footer.defaultProps = {};
 
 export default Footer;

--- a/packages/react/src/components/FormControl/FormControl.tsx
+++ b/packages/react/src/components/FormControl/FormControl.tsx
@@ -25,15 +25,14 @@ import './form-control.scss';
 
 export type FormControlProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiFormControlProps<C>, 'component'>;
+} & Omit<MuiFormControlProps, 'component'>;
 
 const COMPONENT_NAME: string = 'FormControl';
 
-const FormControl: FC<FormControlProps> & WithWrapperProps = <C extends ElementType>(
-  props: FormControlProps<C>,
-): ReactElement => {
-  const {className, ...rest} = props;
-
+const FormControl: FC<FormControlProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  ...rest
+}: FormControlProps<C>): ReactElement => {
   const classes: string = clsx('oxygen-form-control', className);
 
   return <MuiFormControl className={classes} {...rest} />;
@@ -41,6 +40,5 @@ const FormControl: FC<FormControlProps> & WithWrapperProps = <C extends ElementT
 
 FormControl.displayName = composeComponentDisplayName(COMPONENT_NAME);
 FormControl.muiName = COMPONENT_NAME;
-FormControl.defaultProps = {};
 
 export default FormControl;

--- a/packages/react/src/components/FormControlLabel/FormControlLabel.tsx
+++ b/packages/react/src/components/FormControlLabel/FormControlLabel.tsx
@@ -27,9 +27,7 @@ export type FormControlLabelProps = MuiFormControlLabelProps;
 const COMPONENT_NAME: string = 'FormControlLabel';
 
 const FormControlLabel: ForwardRefExoticComponent<FormControlLabelProps> & WithWrapperProps = forwardRef(
-  (props: FormControlLabelProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: FormControlLabelProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-form-control-label', className);
 
     return <MuiFormControlLabel className={classes} {...rest} ref={ref} />;
@@ -38,6 +36,5 @@ const FormControlLabel: ForwardRefExoticComponent<FormControlLabelProps> & WithW
 
 FormControlLabel.displayName = composeComponentDisplayName(COMPONENT_NAME);
 FormControlLabel.muiName = COMPONENT_NAME;
-FormControlLabel.defaultProps = {};
 
 export default FormControlLabel;

--- a/packages/react/src/components/FormGroup/FormGroup.tsx
+++ b/packages/react/src/components/FormGroup/FormGroup.tsx
@@ -27,9 +27,7 @@ export type FormGroupProps = MuiFormGroupProps;
 const COMPONENT_NAME: string = 'FormGroup';
 
 const FormGroup: ForwardRefExoticComponent<FormGroupProps> & WithWrapperProps = forwardRef(
-  (props: FormGroupProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: FormGroupProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-form-group', className);
 
     return <MuiFormGroup className={classes} {...rest} ref={ref} />;
@@ -38,6 +36,5 @@ const FormGroup: ForwardRefExoticComponent<FormGroupProps> & WithWrapperProps = 
 
 FormGroup.displayName = composeComponentDisplayName(COMPONENT_NAME);
 FormGroup.muiName = COMPONENT_NAME;
-FormGroup.defaultProps = {};
 
 export default FormGroup;

--- a/packages/react/src/components/FormHelperText/FormHelperText.tsx
+++ b/packages/react/src/components/FormHelperText/FormHelperText.tsx
@@ -25,15 +25,14 @@ import './form-helper-text.scss';
 
 export type FormHelperTextProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiFormHelperTextProps<C>, 'component'>;
+} & Omit<MuiFormHelperTextProps, 'component'>;
 
 const COMPONENT_NAME: string = 'FormHelperText';
 
-const FormHelperText: FC<FormHelperTextProps> & WithWrapperProps = <C extends ElementType>(
-  props: FormHelperTextProps<C>,
-): ReactElement => {
-  const {className, ...rest} = props;
-
+const FormHelperText: FC<FormHelperTextProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  ...rest
+}: FormHelperTextProps<C>): ReactElement => {
   const classes: string = clsx('oxygen-form-helper-text', className);
 
   return <MuiFormHelperText className={classes} {...rest} />;
@@ -41,6 +40,5 @@ const FormHelperText: FC<FormHelperTextProps> & WithWrapperProps = <C extends El
 
 FormHelperText.displayName = composeComponentDisplayName(COMPONENT_NAME);
 FormHelperText.muiName = COMPONENT_NAME;
-FormHelperText.defaultProps = {};
 
 export default FormHelperText;

--- a/packages/react/src/components/FormLabel/FormLabel.tsx
+++ b/packages/react/src/components/FormLabel/FormLabel.tsx
@@ -24,14 +24,15 @@ import {composeComponentDisplayName} from '../../utils';
 
 export type FormLabelProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiFormLabelProps<C>, 'component'>;
+} & Omit<MuiFormLabelProps, 'component'>;
 
 const COMPONENT_NAME: string = 'FormLabel';
 
 const FormLabel: ForwardRefExoticComponent<FormLabelProps> & WithWrapperProps = forwardRef(
-  <C extends ElementType>(props: FormLabelProps<C>, ref: MutableRefObject<HTMLLabelElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  <C extends ElementType>(
+    {className, ...rest}: FormLabelProps<C>,
+    ref: MutableRefObject<HTMLLabelElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-form-label', className);
 
     return <MuiFormLabel className={classes} {...rest} ref={ref} />;
@@ -40,6 +41,5 @@ const FormLabel: ForwardRefExoticComponent<FormLabelProps> & WithWrapperProps = 
 
 FormLabel.displayName = composeComponentDisplayName(COMPONENT_NAME);
 FormLabel.muiName = COMPONENT_NAME;
-FormLabel.defaultProps = {};
 
 export default FormLabel;

--- a/packages/react/src/components/Grid/Grid.tsx
+++ b/packages/react/src/components/Grid/Grid.tsx
@@ -27,9 +27,7 @@ export type GridProps = MuiGridProps;
 
 const COMPONENT_NAME: string = 'Grid';
 
-const Grid: FC<GridProps> & WithWrapperProps = (props: GridProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Grid: FC<GridProps> & WithWrapperProps = ({className, ...rest}: GridProps): ReactElement => {
   const classes: string = clsx('oxygen-grid', className);
 
   return <MuiGrid className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const Grid: FC<GridProps> & WithWrapperProps = (props: GridProps): ReactElement 
 
 Grid.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Grid.muiName = COMPONENT_NAME;
-Grid.defaultProps = {};
 
 export default Grid;

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -132,21 +132,19 @@ const userDropdownMenuDefaultProps: UserDropdownMenuHeaderProps = {
 
 const COMPONENT_NAME: string = 'Header';
 
-const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactElement => {
-  const {
-    brand,
-    className,
-    modes,
-    showCollapsibleHamburger,
-    leftAlignedElements,
-    navbarToggleIcon,
-    onCollapsibleHamburgerClick,
-    rightAlignedElements,
-    user,
-    userDropdownMenu,
-    ...rest
-  } = props;
-
+const Header: FC<HeaderProps> & WithWrapperProps = ({
+  brand,
+  className,
+  modes,
+  showCollapsibleHamburger,
+  leftAlignedElements,
+  navbarToggleIcon = <BarsIcon />,
+  onCollapsibleHamburgerClick,
+  rightAlignedElements,
+  user,
+  userDropdownMenu = userDropdownMenuDefaultProps,
+  ...rest
+}: HeaderProps): ReactElement => {
   const userDropdownMenuProps: UserDropdownMenuHeaderProps = {...userDropdownMenuDefaultProps, ...userDropdownMenu};
 
   const {mode, setMode} = useColorScheme();
@@ -250,9 +248,5 @@ const Header: FC<HeaderProps> & WithWrapperProps = (props: HeaderProps): ReactEl
 
 Header.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Header.muiName = COMPONENT_NAME;
-Header.defaultProps = {
-  navbarToggleIcon: <BarsIcon />,
-  userDropdownMenu: userDropdownMenuDefaultProps,
-};
 
 export default Header;

--- a/packages/react/src/components/IconButton/IconButton.tsx
+++ b/packages/react/src/components/IconButton/IconButton.tsx
@@ -34,9 +34,11 @@ export interface IconButtonProps extends MuiIconButtonProps {
 
 const COMPONENT_NAME: string = 'IconButton';
 
-const IconButton: FC<IconButtonProps> & WithWrapperProps = (props: IconButtonProps): ReactElement => {
-  const {className, variant, ...rest} = props;
-
+const IconButton: FC<IconButtonProps> & WithWrapperProps = ({
+  className,
+  variant = IconButtonVariants.TEXT,
+  ...rest
+}: IconButtonProps): ReactElement => {
   const classes: string = clsx('oxygen-icon-button', className, {
     'oxygen-icon-button-contained': variant === IconButtonVariants.CONTAINED,
   });
@@ -46,8 +48,5 @@ const IconButton: FC<IconButtonProps> & WithWrapperProps = (props: IconButtonPro
 
 IconButton.displayName = composeComponentDisplayName(COMPONENT_NAME);
 IconButton.muiName = COMPONENT_NAME;
-IconButton.defaultProps = {
-  variant: IconButtonVariants.TEXT,
-};
 
 export default IconButton;

--- a/packages/react/src/components/Image/Image.tsx
+++ b/packages/react/src/components/Image/Image.tsx
@@ -29,9 +29,7 @@ const COMPONENT_NAME: string = 'Image';
  * TODO: Refer improvement issue if this Image component is required.
  * @see {@link https://github.com/wso2/oxygen-ui/issues/65}
  */
-const Image: FC<ImageProps> & WithWrapperProps = (props: ImageProps): ReactElement => {
-  const {className, alt, ...rest} = props;
-
+const Image: FC<ImageProps> & WithWrapperProps = ({className, alt, ...rest}: ImageProps): ReactElement => {
   const classes: string = clsx('oxygen-image', className);
 
   return <img className={classes} alt={alt} {...rest} />;

--- a/packages/react/src/components/Input/Input.tsx
+++ b/packages/react/src/components/Input/Input.tsx
@@ -27,9 +27,7 @@ export type InputProps = MuiInputProps;
 
 const COMPONENT_NAME: string = 'Input';
 
-const Input: FC<InputProps> & WithWrapperProps = (props: InputProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Input: FC<InputProps> & WithWrapperProps = ({className, ...rest}: InputProps): ReactElement => {
   const classes: string = clsx('oxygen-input', className);
 
   return <MuiInput className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const Input: FC<InputProps> & WithWrapperProps = (props: InputProps): ReactEleme
 
 Input.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Input.muiName = COMPONENT_NAME;
-Input.defaultProps = {};
 
 export default Input;

--- a/packages/react/src/components/InputAdornment/InputAdornment.tsx
+++ b/packages/react/src/components/InputAdornment/InputAdornment.tsx
@@ -24,15 +24,15 @@ import {composeComponentDisplayName} from '../../utils';
 
 export type InputAdornmentProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiInputAdornmentProps<C>, 'component'>;
+} & Omit<MuiInputAdornmentProps, 'component'>;
 
 const COMPONENT_NAME: string = 'InputAdornment';
 
-const InputAdornment: FC<InputAdornmentProps> & WithWrapperProps = <C extends ElementType>(
-  props: InputAdornmentProps<C>,
-): ReactElement => {
-  const {className, position, ...rest} = props;
-
+const InputAdornment: FC<InputAdornmentProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  position,
+  ...rest
+}: InputAdornmentProps<C>): ReactElement => {
   const classes: string = clsx('oxygen-input-adornment', className);
 
   return <MuiInputAdornment position={position} className={classes} {...rest} />;
@@ -40,6 +40,5 @@ const InputAdornment: FC<InputAdornmentProps> & WithWrapperProps = <C extends El
 
 InputAdornment.displayName = composeComponentDisplayName(COMPONENT_NAME);
 InputAdornment.muiName = COMPONENT_NAME;
-InputAdornment.defaultProps = {};
 
 export default InputAdornment;

--- a/packages/react/src/components/InputLabel/InputLabel.tsx
+++ b/packages/react/src/components/InputLabel/InputLabel.tsx
@@ -27,9 +27,7 @@ export type InputLabelProps = MuiInputLabelProps;
 
 const COMPONENT_NAME: string = 'InputLabel';
 
-const InputLabel: FC<InputLabelProps> & WithWrapperProps = (props: InputLabelProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const InputLabel: FC<InputLabelProps> & WithWrapperProps = ({className, ...rest}: InputLabelProps): ReactElement => {
   const classes: string = clsx('oxygen-input-label', className);
 
   return <MuiInputLabel className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const InputLabel: FC<InputLabelProps> & WithWrapperProps = (props: InputLabelPro
 
 InputLabel.displayName = composeComponentDisplayName(COMPONENT_NAME);
 InputLabel.muiName = COMPONENT_NAME;
-InputLabel.defaultProps = {};
 
 export default InputLabel;

--- a/packages/react/src/components/LinearProgress/LinearProgress.tsx
+++ b/packages/react/src/components/LinearProgress/LinearProgress.tsx
@@ -26,9 +26,10 @@ export type LinearProgressProps = MuiLinearProgressProps;
 
 const COMPONENT_NAME: string = 'LinearProgress';
 
-const LinearProgress: FC<LinearProgressProps> & WithWrapperProps = (props: LinearProgressProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const LinearProgress: FC<LinearProgressProps> & WithWrapperProps = ({
+  className,
+  ...rest
+}: LinearProgressProps): ReactElement => {
   const classes: string = clsx('oxygen-linear-progress', className);
 
   return <MuiLinearProgress aria-label="progress-bar" className={classes} {...rest} />;
@@ -36,6 +37,5 @@ const LinearProgress: FC<LinearProgressProps> & WithWrapperProps = (props: Linea
 
 LinearProgress.displayName = composeComponentDisplayName(COMPONENT_NAME);
 LinearProgress.muiName = COMPONENT_NAME;
-LinearProgress.defaultProps = {};
 
 export default LinearProgress;

--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -27,9 +27,7 @@ export type LinkProps = MuiLinkProps;
 
 const COMPONENT_NAME: string = 'Link';
 
-const Link: FC<LinkProps> & WithWrapperProps = (props: LinkProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Link: FC<LinkProps> & WithWrapperProps = ({className, ...rest}: LinkProps): ReactElement => {
   const classes: string = clsx('oxygen-link', className);
 
   return <MuiLink className={classes} underline="hover" {...rest} />;
@@ -37,6 +35,5 @@ const Link: FC<LinkProps> & WithWrapperProps = (props: LinkProps): ReactElement 
 
 Link.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Link.muiName = COMPONENT_NAME;
-Link.defaultProps = {};
 
 export default Link;

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -27,9 +27,7 @@ export type ListProps = MuiListProps;
 
 const COMPONENT_NAME: string = 'List';
 
-const List: FC<ListProps> & WithWrapperProps = (props: ListProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const List: FC<ListProps> & WithWrapperProps = ({className, ...rest}: ListProps): ReactElement => {
   const classes: string = clsx('oxygen-list', className);
 
   return <MuiList className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const List: FC<ListProps> & WithWrapperProps = (props: ListProps): ReactElement 
 
 List.displayName = composeComponentDisplayName(COMPONENT_NAME);
 List.muiName = COMPONENT_NAME;
-List.defaultProps = {};
 
 export default List;

--- a/packages/react/src/components/ListItem/ListItem.tsx
+++ b/packages/react/src/components/ListItem/ListItem.tsx
@@ -25,14 +25,15 @@ import './list-item.scss';
 
 export type ListItemProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiListItemProps<C>, 'component'>;
+} & Omit<MuiListItemProps, 'component'>;
 
 const COMPONENT_NAME: string = 'ListItem';
 
 const ListItem: ForwardRefExoticComponent<ListItemProps> & WithWrapperProps = forwardRef(
-  <C extends ElementType>(props: ListItemProps<C>, ref: MutableRefObject<HTMLLIElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  <C extends ElementType>(
+    {className, ...rest}: ListItemProps<C>,
+    ref: MutableRefObject<HTMLLIElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-list-item', className);
 
     return <MuiListItem className={classes} ref={ref} {...rest} />;
@@ -41,6 +42,5 @@ const ListItem: ForwardRefExoticComponent<ListItemProps> & WithWrapperProps = fo
 
 ListItem.displayName = composeComponentDisplayName(COMPONENT_NAME);
 ListItem.muiName = COMPONENT_NAME;
-ListItem.defaultProps = {};
 
 export default ListItem;

--- a/packages/react/src/components/ListItemAvatar/ListItemAvatar.tsx
+++ b/packages/react/src/components/ListItemAvatar/ListItemAvatar.tsx
@@ -27,9 +27,10 @@ export type ListItemAvatarProps = MuiListItemAvatarProps;
 
 const COMPONENT_NAME: string = 'ListItemAvatar';
 
-const ListItemAvatar: FC<ListItemAvatarProps> & WithWrapperProps = (props: ListItemAvatarProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const ListItemAvatar: FC<ListItemAvatarProps> & WithWrapperProps = ({
+  className,
+  ...rest
+}: ListItemAvatarProps): ReactElement => {
   const classes: string = clsx('oxygen-list-item-avatar', className);
 
   return <MuiListItemAvatar className={classes} {...rest} />;
@@ -37,6 +38,5 @@ const ListItemAvatar: FC<ListItemAvatarProps> & WithWrapperProps = (props: ListI
 
 ListItemAvatar.displayName = composeComponentDisplayName(COMPONENT_NAME);
 ListItemAvatar.muiName = COMPONENT_NAME;
-ListItemAvatar.defaultProps = {};
 
 export default ListItemAvatar;

--- a/packages/react/src/components/ListItemButton/ListItemButton.tsx
+++ b/packages/react/src/components/ListItemButton/ListItemButton.tsx
@@ -25,14 +25,12 @@ import './list-item-button.scss';
 
 export type ListItemButtonProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiListItemButtonProps<C>, 'component'>;
+} & Omit<MuiListItemButtonProps, 'component'>;
 
 const COMPONENT_NAME: string = 'ListItemButton';
 
 const ListItemButton: ForwardRefExoticComponent<ListItemButtonProps> & WithWrapperProps = forwardRef(
-  (props: ListItemButtonProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: ListItemButtonProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-list-item-button', className);
 
     return <MuiListItemButton className={classes} ref={ref} {...rest} />;
@@ -41,6 +39,5 @@ const ListItemButton: ForwardRefExoticComponent<ListItemButtonProps> & WithWrapp
 
 ListItemButton.displayName = composeComponentDisplayName(COMPONENT_NAME);
 ListItemButton.muiName = COMPONENT_NAME;
-ListItemButton.defaultProps = {};
 
 export default ListItemButton;

--- a/packages/react/src/components/ListItemIcon/ListItemIcon.tsx
+++ b/packages/react/src/components/ListItemIcon/ListItemIcon.tsx
@@ -27,9 +27,10 @@ export type ListItemIconProps = MuiListItemIconProps;
 
 const COMPONENT_NAME: string = 'ListItemIcon';
 
-const ListItemIcon: FC<ListItemIconProps> & WithWrapperProps = (props: ListItemIconProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const ListItemIcon: FC<ListItemIconProps> & WithWrapperProps = ({
+  className,
+  ...rest
+}: ListItemIconProps): ReactElement => {
   const classes: string = clsx('oxygen-list-item-icon', className);
 
   return <MuiListItemIcon className={classes} {...rest} />;
@@ -37,6 +38,5 @@ const ListItemIcon: FC<ListItemIconProps> & WithWrapperProps = (props: ListItemI
 
 ListItemIcon.displayName = composeComponentDisplayName(COMPONENT_NAME);
 ListItemIcon.muiName = COMPONENT_NAME;
-ListItemIcon.defaultProps = {};
 
 export default ListItemIcon;

--- a/packages/react/src/components/ListItemText/ListItemText.tsx
+++ b/packages/react/src/components/ListItemText/ListItemText.tsx
@@ -27,9 +27,10 @@ export type ListItemTextProps = MuiListItemTextProps;
 
 const COMPONENT_NAME: string = 'ListItemText';
 
-const ListItemText: FC<ListItemTextProps> & WithWrapperProps = (props: ListItemTextProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const ListItemText: FC<ListItemTextProps> & WithWrapperProps = ({
+  className,
+  ...rest
+}: ListItemTextProps): ReactElement => {
   const classes: string = clsx('oxygen-list-item-text', className);
 
   return <MuiListItemText className={classes} {...rest} />;
@@ -37,6 +38,5 @@ const ListItemText: FC<ListItemTextProps> & WithWrapperProps = (props: ListItemT
 
 ListItemText.displayName = composeComponentDisplayName(COMPONENT_NAME);
 ListItemText.muiName = COMPONENT_NAME;
-ListItemText.defaultProps = {};
 
 export default ListItemText;

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -27,9 +27,7 @@ export type MenuProps = MuiMenuProps;
 
 const COMPONENT_NAME: string = 'Menu';
 
-const Menu: FC<MenuProps> & WithWrapperProps = (props: MenuProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Menu: FC<MenuProps> & WithWrapperProps = ({className, ...rest}: MenuProps): ReactElement => {
   const classes: string = clsx('oxygen-menu', className);
 
   return <MuiMenu className={classes} {...rest} />;

--- a/packages/react/src/components/MenuItem/MenuItem.tsx
+++ b/packages/react/src/components/MenuItem/MenuItem.tsx
@@ -27,9 +27,7 @@ export type MenuItemProps = MuiMenuItemProps;
 
 const COMPONENT_NAME: string = 'MenuItem';
 
-const MenuItem: FC<MenuItemProps> & WithWrapperProps = (props: MenuItemProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const MenuItem: FC<MenuItemProps> & WithWrapperProps = ({className, ...rest}: MenuItemProps): ReactElement => {
   const classes: string = clsx('oxygen-menu-item', className);
 
   return <MuiMenuItem className={classes} {...rest} />;

--- a/packages/react/src/components/Navbar/Navbar.tsx
+++ b/packages/react/src/components/Navbar/Navbar.tsx
@@ -73,9 +73,17 @@ export type NavbarItems = {
 
 const COMPONENT_NAME: string = 'Navbar';
 
-const Navbar: FC<NavbarProps> & WithWrapperProps = (props: NavbarProps): ReactElement => {
-  const {className, fill, onClose, items, collapsible, open, onOpen, toggleIcon, ...rest} = props;
-
+const Navbar: FC<NavbarProps> & WithWrapperProps = ({
+  className,
+  fill,
+  onClose,
+  items,
+  collapsible = true,
+  open = true,
+  onOpen,
+  toggleIcon = <BarsIcon />,
+  ...rest
+}: NavbarProps): ReactElement => {
   const classes: string = clsx(
     'oxygen-navbar',
     {
@@ -192,10 +200,5 @@ const Navbar: FC<NavbarProps> & WithWrapperProps = (props: NavbarProps): ReactEl
 
 Navbar.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Navbar.muiName = COMPONENT_NAME;
-Navbar.defaultProps = {
-  collapsible: true,
-  open: true,
-  toggleIcon: <BarsIcon />,
-};
 
 export default Navbar;

--- a/packages/react/src/components/NavbarItem/NavbarItem.tsx
+++ b/packages/react/src/components/NavbarItem/NavbarItem.tsx
@@ -59,9 +59,25 @@ export interface NavbarItemProps extends ListItemProps, Pick<NavbarProps, 'fill'
 const COMPONENT_NAME: string = 'NavbarItem';
 
 const NavbarItem: ForwardRefExoticComponent<NavbarItemProps> & WithWrapperProps = forwardRef(
-  (props: NavbarItemProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, component, fill, icon, id, label, onClick, href, selected, tag, tagClassName, open, ...rest} =
-      props;
+  (
+    {
+      className,
+      collapsible = true,
+      component,
+      fill,
+      icon,
+      id,
+      label,
+      onClick,
+      href,
+      selected,
+      tag,
+      tagClassName,
+      open = true,
+      ...rest
+    }: NavbarItemProps,
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const classes: string = clsx(
       'oxygen-navbar-item',
       {
@@ -75,7 +91,13 @@ const NavbarItem: ForwardRefExoticComponent<NavbarItemProps> & WithWrapperProps 
     return (
       <Box ref={ref} className={classes} component={component}>
         <Tooltip ref={ref} key={id} title={!open && label} placement="right">
-          <ListItemButton selected={selected} className={clsx({selected})} onClick={onClick} {...rest}>
+          <ListItemButton
+            selected={selected}
+            className={clsx({selected})}
+            onClick={onClick}
+            collapsible={collapsible}
+            {...rest}
+          >
             <ListItemIcon>{icon}</ListItemIcon>
             <ListItemText primary={label} />
             {open && tag ? (
@@ -94,9 +116,5 @@ const NavbarItem: ForwardRefExoticComponent<NavbarItemProps> & WithWrapperProps 
 
 NavbarItem.displayName = composeComponentDisplayName(COMPONENT_NAME);
 NavbarItem.muiName = COMPONENT_NAME;
-NavbarItem.defaultProps = {
-  collapsible: true,
-  open: true,
-};
 
 export default NavbarItem;

--- a/packages/react/src/components/OutlinedInput/OutlinedInput.tsx
+++ b/packages/react/src/components/OutlinedInput/OutlinedInput.tsx
@@ -27,9 +27,10 @@ export type OutlinedInputProps = MuiOutlinedInputProps;
 
 const COMPONENT_NAME: string = 'OutlinedInput';
 
-const OutlinedInput: FC<OutlinedInputProps> & WithWrapperProps = (props: OutlinedInputProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const OutlinedInput: FC<OutlinedInputProps> & WithWrapperProps = ({
+  className,
+  ...rest
+}: OutlinedInputProps): ReactElement => {
   const classes: string = clsx('oxygen-outlined-input', className);
 
   return <MuiOutlinedInput className={classes} {...rest} />;
@@ -37,6 +38,5 @@ const OutlinedInput: FC<OutlinedInputProps> & WithWrapperProps = (props: Outline
 
 OutlinedInput.displayName = composeComponentDisplayName(COMPONENT_NAME);
 OutlinedInput.muiName = COMPONENT_NAME;
-OutlinedInput.defaultProps = {};
 
 export default OutlinedInput;

--- a/packages/react/src/components/Paper/Paper.tsx
+++ b/packages/react/src/components/Paper/Paper.tsx
@@ -24,14 +24,12 @@ import {composeComponentDisplayName} from '../../utils';
 
 export type PaperProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiPaperProps<C>, 'component'>;
+} & Omit<MuiPaperProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Paper';
 
 const Paper: ForwardRefExoticComponent<PaperProps> & WithWrapperProps = forwardRef(
-  <C extends ElementType>(props: PaperProps<C>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  <C extends ElementType>({className, ...rest}: PaperProps<C>, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-paper', className);
 
     return <MuiPaper className={classes} {...rest} ref={ref} />;
@@ -40,6 +38,5 @@ const Paper: ForwardRefExoticComponent<PaperProps> & WithWrapperProps = forwardR
 
 Paper.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Paper.muiName = COMPONENT_NAME;
-Paper.defaultProps = {};
 
 export default Paper;

--- a/packages/react/src/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/react/src/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -70,8 +70,8 @@ export interface PhoneNumberInputProps extends BoxProps {
 const COMPONENT_NAME: string = 'PhoneNumberInput';
 
 const PhoneNumberInput: ForwardRefExoticComponent<PhoneNumberInputProps> & WithWrapperProps = forwardRef(
-  (props: PhoneNumberInputProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {
+  (
+    {
       className,
       dialCodeValue,
       label,
@@ -82,8 +82,9 @@ const PhoneNumberInput: ForwardRefExoticComponent<PhoneNumberInputProps> & WithW
       placeholder,
       SelectProps,
       ...rest
-    } = props;
-
+    }: PhoneNumberInputProps,
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-phone-number-input', className);
 
     const [dialCode, setDialCode] = useState<string>(dialCodeValue ?? countries[0].dialCode);
@@ -165,6 +166,5 @@ const PhoneNumberInput: ForwardRefExoticComponent<PhoneNumberInputProps> & WithW
 
 PhoneNumberInput.displayName = composeComponentDisplayName(COMPONENT_NAME);
 PhoneNumberInput.muiName = COMPONENT_NAME;
-PhoneNumberInput.defaultProps = {};
 
 export default PhoneNumberInput;

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -27,9 +27,7 @@ export type PopoverProps = MuiPopoverProps;
 const COMPONENT_NAME: string = 'Popover';
 
 const Popover: ForwardRefExoticComponent<PopoverProps> & WithWrapperProps = forwardRef(
-  (props: PopoverProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: PopoverProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-popover', className);
 
     return <MuiPopover className={classes} {...rest} ref={ref} />;
@@ -38,6 +36,5 @@ const Popover: ForwardRefExoticComponent<PopoverProps> & WithWrapperProps = forw
 
 Popover.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Popover.muiName = COMPONENT_NAME;
-Popover.defaultProps = {};
 
 export default Popover;

--- a/packages/react/src/components/Radio/Radio.tsx
+++ b/packages/react/src/components/Radio/Radio.tsx
@@ -27,9 +27,7 @@ export type RadioProps = MuiRadioProps;
 const COMPONENT_NAME: string = 'Radio';
 
 const Radio: ForwardRefExoticComponent<RadioProps> & WithWrapperProps = forwardRef(
-  (props: RadioProps, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: RadioProps, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
     const classes: string = clsx('oxygen-radio', className);
 
     return <MuiRadio className={classes} {...rest} ref={ref} />;
@@ -38,6 +36,5 @@ const Radio: ForwardRefExoticComponent<RadioProps> & WithWrapperProps = forwardR
 
 Radio.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Radio.muiName = COMPONENT_NAME;
-Radio.defaultProps = {};
 
 export default Radio;

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -27,9 +27,7 @@ export type RadioGroupProps = MuiRadioGroupProps;
 const COMPONENT_NAME: string = 'RadioGroup';
 
 const RadioGroup: ForwardRefExoticComponent<RadioGroupProps> & WithWrapperProps = forwardRef(
-  (props: RadioGroupProps, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: RadioGroupProps, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
     const classes: string = clsx('oxygen-radio-group', className);
 
     return <MuiRadioGroup className={classes} {...rest} ref={ref} />;
@@ -38,6 +36,5 @@ const RadioGroup: ForwardRefExoticComponent<RadioGroupProps> & WithWrapperProps 
 
 RadioGroup.displayName = composeComponentDisplayName(COMPONENT_NAME);
 RadioGroup.muiName = COMPONENT_NAME;
-RadioGroup.defaultProps = {};
 
 export default RadioGroup;

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -34,9 +34,21 @@ export interface SelectProps extends MuiSelectProps {
 const COMPONENT_NAME: string = 'Select';
 
 const Select: ForwardRefExoticComponent<SelectProps> & WithWrapperProps = forwardRef(
-  (props: SelectProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, InputLabelProps, label, name, required, ...rest} = props;
-
+  (
+    {
+      className,
+      InputLabelProps = {
+        disableAnimation: true,
+        focused: false,
+        shrink: false,
+      },
+      label,
+      name,
+      required,
+      ...rest
+    }: SelectProps,
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-select', className);
 
     const labelProps: MuiInputLabelProps = {
@@ -69,12 +81,5 @@ const Select: ForwardRefExoticComponent<SelectProps> & WithWrapperProps = forwar
 
 Select.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Select.muiName = COMPONENT_NAME;
-Select.defaultProps = {
-  InputLabelProps: {
-    disableAnimation: true,
-    focused: false,
-    shrink: false,
-  },
-};
 
 export default Select;

--- a/packages/react/src/components/SignIn/SignIn.tsx
+++ b/packages/react/src/components/SignIn/SignIn.tsx
@@ -44,9 +44,13 @@ export interface SignInProps extends BoxProps {
 
 const COMPONENT_NAME: string = 'SignIn';
 
-const SignIn: FC<SignInProps> & MuiWrapperProps = (props: SignInProps): ReactElement => {
-  const {className, signUpUrl, logoUrl, signInOptions, ...rest} = props;
-
+const SignIn: FC<SignInProps> & MuiWrapperProps = ({
+  className,
+  signUpUrl,
+  logoUrl,
+  signInOptions,
+  ...rest
+}: SignInProps): ReactElement => {
   const classes: string = clsx('oxygen-sign-in', className);
 
   return (
@@ -106,6 +110,5 @@ const SignIn: FC<SignInProps> & MuiWrapperProps = (props: SignInProps): ReactEle
 
 SignIn.displayName = composeComponentDisplayName(COMPONENT_NAME);
 SignIn.muiName = 'SignIn';
-SignIn.defaultProps = {};
 
 export default SignIn;

--- a/packages/react/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.tsx
@@ -24,15 +24,14 @@ import {composeComponentDisplayName} from '../../utils';
 
 export type SkeletonProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiSkeletonProps<C>, 'component'>;
+} & Omit<MuiSkeletonProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Skeleton';
 
-const Skeleton: FC<SkeletonProps> & WithWrapperProps = <C extends ElementType>(
-  props: SkeletonProps<C>,
-): ReactElement => {
-  const {className, ...rest} = props;
-
+const Skeleton: FC<SkeletonProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  ...rest
+}: SkeletonProps<C>): ReactElement => {
   const classes: string = clsx('oxygen-skeleton', className);
 
   return <MuiSkeleton className={classes} {...rest} />;
@@ -40,6 +39,5 @@ const Skeleton: FC<SkeletonProps> & WithWrapperProps = <C extends ElementType>(
 
 Skeleton.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Skeleton.muiName = COMPONENT_NAME;
-Skeleton.defaultProps = {};
 
 export default Skeleton;

--- a/packages/react/src/components/Snackbar/Snackbar.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.tsx
@@ -28,9 +28,7 @@ export type SnackbarProps = MuiSnackbarProps;
 const COMPONENT_NAME: string = 'Snackbar';
 
 const Snackbar: ForwardRefExoticComponent<SnackbarProps> & WithWrapperProps = forwardRef(
-  (props: SnackbarProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: SnackbarProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-snackbar', className);
 
     return <MuiSnackbar className={classes} {...rest} ref={ref} />;
@@ -39,6 +37,5 @@ const Snackbar: ForwardRefExoticComponent<SnackbarProps> & WithWrapperProps = fo
 
 Snackbar.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Snackbar.muiName = COMPONENT_NAME;
-Snackbar.defaultProps = {};
 
 export default Snackbar;

--- a/packages/react/src/components/Stepper/Stepper.tsx
+++ b/packages/react/src/components/Stepper/Stepper.tsx
@@ -40,9 +40,12 @@ export interface StepperProps extends HTMLAttributes<HTMLDivElement> {
 
 const COMPONENT_NAME: string = 'Stepper';
 
-const Stepper: FC<StepperProps> & WithWrapperProps = (props: StepperProps): ReactElement => {
-  const {animateOnSlide, className, currentStep, steps} = props;
-
+const Stepper: FC<StepperProps> & WithWrapperProps = ({
+  animateOnSlide,
+  className,
+  currentStep = 0,
+  steps,
+}: StepperProps): ReactElement => {
   const [slideLeftPosition, setSlideLeftPosition] = useState<number>(0);
   const [slideContainerWidth, setSlideContainerWidth] = useState<number>(0);
 
@@ -105,8 +108,5 @@ const Stepper: FC<StepperProps> & WithWrapperProps = (props: StepperProps): Reac
 
 Stepper.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Stepper.muiName = COMPONENT_NAME;
-Stepper.defaultProps = {
-  currentStep: 0,
-};
 
 export default Stepper;

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -31,9 +31,7 @@ const COMPONENT_NAME: string = 'Switch';
  * @remarks `any` is used as the generic type for the props because the generic type is not used in the component.
  */
 const Switch: ForwardRefExoticComponent<SwitchProps> & WithWrapperProps = forwardRef(
-  (props: SwitchProps, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: SwitchProps, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
     const classes: string = clsx('oxygen-switch', className);
 
     return <MuiSwitch className={classes} {...rest} ref={ref} />;
@@ -42,6 +40,5 @@ const Switch: ForwardRefExoticComponent<SwitchProps> & WithWrapperProps = forwar
 
 Switch.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Switch.muiName = COMPONENT_NAME;
-Switch.defaultProps = {};
 
 export default Switch;

--- a/packages/react/src/components/Tab/Tab.tsx
+++ b/packages/react/src/components/Tab/Tab.tsx
@@ -28,9 +28,7 @@ export type TabProps = MuiTabProps;
 const COMPONENT_NAME: string = 'Tab';
 
 const Tab: ForwardRefExoticComponent<TabProps> & WithWrapperProps = forwardRef(
-  (props: TabProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: TabProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-tab', className);
 
     return <MuiTab className={classes} ref={ref} {...rest} />;

--- a/packages/react/src/components/TabPanel/TabPanel.tsx
+++ b/packages/react/src/components/TabPanel/TabPanel.tsx
@@ -38,9 +38,10 @@ export interface TabPanelProps extends MuiBoxProps {
 const COMPONENT_NAME: string = 'TabPanel';
 
 const TabPanel: ForwardRefExoticComponent<TabPanelProps> & WithWrapperProps = forwardRef(
-  (props: TabPanelProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, children, value, index, ...rest} = props;
-
+  (
+    {className, children, value, index, ...rest}: TabPanelProps,
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-tab-panel', className);
 
     return (

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -27,14 +27,15 @@ import './tabs.scss';
 
 export type TabsProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiTabsProps<C>, 'component'>;
+} & Omit<MuiTabsProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Tabs';
 
 const Tabs: ForwardRefExoticComponent<TabsProps> & WithWrapperProps = forwardRef(
-  <C extends ElementType>(props: TabsProps<C>, ref: MutableRefObject<HTMLButtonElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  <C extends ElementType>(
+    {className, ...rest}: TabsProps<C>,
+    ref: MutableRefObject<HTMLButtonElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-tabs', className);
 
     return (

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -51,9 +51,7 @@ export type TextFieldProps = {
 const COMPONENT_NAME: string = 'TextField';
 
 const PasswordField: ForwardRefExoticComponent<TextFieldProps> = forwardRef(
-  (props: TextFieldProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {type, ...rest} = props;
-
+  ({type, ...rest}: TextFieldProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const [showPassword, setShowPassword] = useState(false);
 
     const handleClickShowPassword = (): void => setShowPassword((show: boolean) => !show);
@@ -87,9 +85,7 @@ const PasswordField: ForwardRefExoticComponent<TextFieldProps> = forwardRef(
 ) as ForwardRefExoticComponent<TextFieldProps>;
 
 const PasswordFieldWithCriteria: ForwardRefExoticComponent<TextFieldProps> = forwardRef(
-  (props: TextFieldProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {criteria, id, type, ...rest} = props;
-
+  ({criteria, id, type, ...rest}: TextFieldProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const [openPasswordCriteriaTooltip, setOpenPasswordCriteriaTooltip] = useState<boolean>(false);
 
     const handleClick = (): void => {
@@ -144,9 +140,10 @@ const PasswordFieldWithCriteria: ForwardRefExoticComponent<TextFieldProps> = for
 ) as ForwardRefExoticComponent<TextFieldProps>;
 
 const TextField: ForwardRefExoticComponent<TextFieldProps> & WithWrapperProps = forwardRef(
-  (props: TextFieldProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, id, label, type, InputLabelProps, ...rest} = props;
-
+  (
+    {className, id, label, type, InputLabelProps, ...rest}: TextFieldProps,
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const classes: string = clsx('oxygen-text-field', className);
 
     return (
@@ -166,6 +163,5 @@ const TextField: ForwardRefExoticComponent<TextFieldProps> & WithWrapperProps = 
 
 TextField.displayName = composeComponentDisplayName(COMPONENT_NAME);
 TextField.muiName = COMPONENT_NAME;
-TextField.defaultProps = {};
 
 export default TextField;

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -27,9 +27,7 @@ export type ToolbarProps = MuiToolbarProps;
 
 const COMPONENT_NAME: string = 'Toolbar';
 
-const Toolbar: FC<ToolbarProps> & WithWrapperProps = (props: ToolbarProps): ReactElement => {
-  const {className, ...rest} = props;
-
+const Toolbar: FC<ToolbarProps> & WithWrapperProps = ({className, ...rest}: ToolbarProps): ReactElement => {
   const classes: string = clsx('oxygen-toolbar', className);
 
   return <MuiToolbar className={classes} {...rest} />;
@@ -37,6 +35,5 @@ const Toolbar: FC<ToolbarProps> & WithWrapperProps = (props: ToolbarProps): Reac
 
 Toolbar.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Toolbar.muiName = COMPONENT_NAME;
-Toolbar.defaultProps = {};
 
 export default Toolbar;

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -28,9 +28,7 @@ export type TooltipProps = MuiTooltipProps;
 const COMPONENT_NAME: string = 'Tooltip';
 
 const Tooltip: ForwardRefExoticComponent<TooltipProps> & WithWrapperProps = forwardRef(
-  (props: TooltipProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
-    const {className, ...rest} = props;
-
+  ({className, ...rest}: TooltipProps, ref: MutableRefObject<HTMLDivElement>): ReactElement => {
     const classes: string = clsx('oxygen-tooltip', className);
 
     return <MuiTooltip className={classes} ref={ref} {...rest} />;
@@ -39,6 +37,5 @@ const Tooltip: ForwardRefExoticComponent<TooltipProps> & WithWrapperProps = forw
 
 Tooltip.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Tooltip.muiName = COMPONENT_NAME;
-Tooltip.defaultProps = {};
 
 export default Tooltip;

--- a/packages/react/src/components/Typography/Typography.tsx
+++ b/packages/react/src/components/Typography/Typography.tsx
@@ -25,15 +25,14 @@ import './typography.scss';
 
 export type TypographyProps<C extends ElementType = ElementType> = {
   component?: C;
-} & Omit<MuiTypographyProps<C>, 'component'>;
+} & Omit<MuiTypographyProps, 'component'>;
 
 const COMPONENT_NAME: string = 'Typography';
 
-const Typography: FC<TypographyProps> & WithWrapperProps = <C extends ElementType>(
-  props: TypographyProps<C>,
-): ReactElement => {
-  const {className, ...rest} = props;
-
+const Typography: FC<TypographyProps> & WithWrapperProps = <C extends ElementType>({
+  className,
+  ...rest
+}: TypographyProps<C>): ReactElement => {
   const classes: string = clsx('oxygen-typography', className);
 
   return <MuiTypography className={classes} {...rest} />;
@@ -41,6 +40,5 @@ const Typography: FC<TypographyProps> & WithWrapperProps = <C extends ElementTyp
 
 Typography.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Typography.muiName = COMPONENT_NAME;
-Typography.defaultProps = {};
 
 export default Typography;

--- a/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
+++ b/packages/react/src/components/UserDropdownMenu/UserDropdownMenu.tsx
@@ -114,27 +114,23 @@ export interface UserTemplate {
 
 const COMPONENT_NAME: string = 'UserDropdownMenu';
 
-const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = (
-  props: UserDropdownMenuProps & WithWrapperProps,
-) => {
-  const {
-    className,
-    children,
-    footerContent,
-    triggerOptions,
-    user,
-    modes,
-    mode,
-    onUserProfileNavigation,
-    modesHeading,
-    actionText,
-    actionIcon,
-    onModeChange,
-    onActionTrigger,
-    menuItems,
-    ...rest
-  } = props;
-
+const UserDropdownMenu: FC<UserDropdownMenuProps> & WithWrapperProps = ({
+  className,
+  children,
+  footerContent,
+  triggerOptions,
+  user,
+  modes,
+  mode,
+  onUserProfileNavigation,
+  modesHeading,
+  actionText,
+  actionIcon,
+  onModeChange,
+  onActionTrigger,
+  menuItems,
+  ...rest
+}: UserDropdownMenuProps & WithWrapperProps) => {
   const classes: string = clsx('oxygen-user-dropdown-menu', className);
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);

--- a/packages/react/src/components/Wizard/Wizard.tsx
+++ b/packages/react/src/components/Wizard/Wizard.tsx
@@ -92,25 +92,23 @@ export interface WizardProps extends HTMLAttributes<HTMLDivElement> {
 
 const COMPONENT_NAME: string = 'Wizard';
 
-const Wizard: FC<WizardProps> & WithWrapperProps = (props: WizardProps): ReactElement => {
-  const {
-    allowBackwardNavigation,
-    allowCancel,
-    animateOnSlide,
-    className,
-    title,
-    subtitle,
-    nextButtonText,
-    previousButtonText,
-    cancelButtonText,
-    onCancelButtonClick,
-    onNextButtonClick,
-    onPreviousButtonClick,
-    onFinishButtonClick,
-    finishButtonText,
-    steps,
-  } = props;
-
+const Wizard: FC<WizardProps> & WithWrapperProps = ({
+  allowBackwardNavigation = true,
+  allowCancel = false,
+  animateOnSlide,
+  className,
+  title,
+  subtitle,
+  nextButtonText = 'Next',
+  previousButtonText = 'Previous',
+  cancelButtonText = 'Cancel',
+  onCancelButtonClick,
+  onNextButtonClick,
+  onPreviousButtonClick,
+  onFinishButtonClick,
+  finishButtonText = 'Finish',
+  steps,
+}: WizardProps): ReactElement => {
   const [currentStep, setCurrentStep] = useState<number>(0);
 
   const classes: string = clsx('oxygen-wizard', className);
@@ -190,13 +188,5 @@ const Wizard: FC<WizardProps> & WithWrapperProps = (props: WizardProps): ReactEl
 
 Wizard.displayName = composeComponentDisplayName(COMPONENT_NAME);
 Wizard.muiName = COMPONENT_NAME;
-Wizard.defaultProps = {
-  allowBackwardNavigation: true,
-  allowCancel: false,
-  cancelButtonText: 'Cancel',
-  finishButtonText: 'Finish',
-  nextButtonText: 'Next',
-  previousButtonText: 'Previous',
-};
 
 export default Wizard;

--- a/packages/react/src/theme/ThemeProvider.tsx
+++ b/packages/react/src/theme/ThemeProvider.tsx
@@ -51,21 +51,18 @@ export type ThemeProviderProps = Partial<CssVarsProviderConfig<SupportedColorSch
     | undefined;
 };
 
-const ThemeProvider = (props: PropsWithChildren<ThemeProviderProps>): ReactElement => {
-  const {children, theme, ...rest} = props;
-  return (
-    <StyledEngineProvider injectFirst>
-      <CssVarsProvider
-        modeStorageKey="oxygen-mode"
-        colorSchemeStorageKey="oxygen-color-scheme"
-        theme={theme ?? defaultTheme}
-        {...rest}
-      >
-        <CssBaseline />
-        {children}
-      </CssVarsProvider>
-    </StyledEngineProvider>
-  );
-};
+const ThemeProvider = ({children, theme, ...rest}: PropsWithChildren<ThemeProviderProps>): ReactElement => (
+  <StyledEngineProvider injectFirst>
+    <CssVarsProvider
+      modeStorageKey="oxygen-mode"
+      colorSchemeStorageKey="oxygen-color-scheme"
+      theme={theme ?? defaultTheme}
+      {...rest}
+    >
+      <CssBaseline />
+      {children}
+    </CssVarsProvider>
+  </StyledEngineProvider>
+);
 
 export default ThemeProvider;


### PR DESCRIPTION
### Purpose

`defaultProps` on functional components will be deprecated in the future.
See: https://github.com/facebook/react/pull/16210

In this PR, I've remove the usage of deprecated `defaultProps` and refactored to use ES6 syntax for declaring default values for props. 

### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/277

### Related PRs
- N/A

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran ESLint & Prettier plugins and verified?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
