### PR TITLE
fix(react): deprecate troublesome enums

### DIFF
--- a/packages/react/src/components/CountryFlag/CountryFlag.tsx
+++ b/packages/react/src/components/CountryFlag/CountryFlag.tsx
@@ -36,6 +36,7 @@ export type CountryFlagProps = {
 
 /**
  * @deprecated Use the {@link CountryFlagProps} instead.
+ * This will be removed in the next major release (v2.0.0).
  */
 export type CountryFlagsProps = CountryFlagProps;
 

--- a/packages/react/src/components/IconButton/IconButton.tsx
+++ b/packages/react/src/components/IconButton/IconButton.tsx
@@ -26,6 +26,10 @@ import type {WithWrapperProps} from '../../models/component';
 import composeComponentDisplayName from '../../utils/compose-component-display-name';
 import './icon-button.scss';
 
+/**
+ * @deprecated Use the string literal i.e. "contained" or "text" instead.
+ * This will be removed in the next major release (v2.0.0).
+ */
 export enum IconButtonVariants {
   CONTAINED = 'contained',
   TEXT = 'text',
@@ -43,7 +47,7 @@ export type IconButtonProps<
   /**
    * The variant of the icon button.
    */
-  variant?: IconButtonVariants;
+  variant?: IconButtonVariants | 'contained' | 'text';
 } & Omit<MuiIconButtonProps<D, P>, 'component'>;
 
 const COMPONENT_NAME: string = 'IconButton';

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -36,6 +36,10 @@ import ListItemText from '../ListItemText';
 import Tooltip from '../Tooltip';
 import './text-field.scss';
 
+/**
+ * @deprecated Use the string literal i.e. "password" or "text" instead.
+ * This will be removed in the next major release (v2.0.0).
+ */
 export enum TextFieldInputTypes {
   INPUT_PASSWORD = 'password',
   INPUT_TEXT = 'text',
@@ -70,7 +74,7 @@ const PasswordField: ForwardRefExoticComponent<TextFieldProps> & WithWrapperProp
     return (
       <MuiTextField
         ref={ref}
-        type={showPassword ? TextFieldInputTypes.INPUT_TEXT : TextFieldInputTypes.INPUT_PASSWORD}
+        type={showPassword ? 'text' : 'password'}
         InputProps={{
           endAdornment: (
             <InputAdornment position="end">


### PR DESCRIPTION
### Purpose

Deprecated `IconButtonVariants` & `TextFieldInputTypes` enums.

### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/286

### Related PRs
- N/A

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran ESLint & Prettier plugins and verified?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
