### PR TITLE
feat(react): add `StepLabel`, `StepContent`, `Step` and `Stepper` components

### DIFF
--- a/packages/react/.storybook/story-config.ts
+++ b/packages/react/.storybook/story-config.ts
@@ -116,6 +116,7 @@ export type Stories =
   | 'Tab'
   | 'TabPanel'
   | 'Tabs'
+  | 'TransitionStepper'
   | 'TextField'
   | 'Toolbar'
   | 'Tooltip'
@@ -396,6 +397,9 @@ const StoryConfig: StorybookConfig = {
   },
   Tabs: {
     hierarchy: `${StorybookCategories.Navigation}/Tabs`,
+  },
+  TransitionStepper: {
+    hierarchy: `${StorybookCategories.Navigation}/Transition Stepper`,
   },
   TextField: {
     hierarchy: `${StorybookCategories.Inputs}/Text Field`,

--- a/packages/react/.storybook/story-config.ts
+++ b/packages/react/.storybook/story-config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2022-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -108,6 +108,9 @@ export type Stories =
   | 'Skeleton'
   | 'Snackbar'
   | 'Stack'
+  | 'Step'
+  | 'StepContent'
+  | 'StepLabel'
   | 'Stepper'
   | 'Switch'
   | 'Tab'
@@ -370,8 +373,17 @@ const StoryConfig: StorybookConfig = {
   Stack: {
     hierarchy: `${StorybookCategories.Layout}/Stack`,
   },
+  Step: {
+    hierarchy: `${StorybookCategories.Navigation}/Step`,
+  },
+  StepContent: {
+    hierarchy: `${StorybookCategories.Navigation}/Step Content`,
+  },
+  StepLabel: {
+    hierarchy: `${StorybookCategories.Navigation}/Step Label`,
+  },
   Stepper: {
-    hierarchy: `${StorybookCategories.Surfaces}/Stepper`,
+    hierarchy: `${StorybookCategories.Navigation}/Stepper`,
   },
   Switch: {
     hierarchy:  `${StorybookCategories.Inputs}/Switch`,

--- a/packages/react/src/components/Carousel/Carousel.tsx
+++ b/packages/react/src/components/Carousel/Carousel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -31,7 +31,7 @@ import IconButton, {IconButtonVariants} from '../IconButton';
 import ListItem from '../ListItem';
 import ListItemIcon from '../ListItemIcon';
 import ListItemText from '../ListItemText';
-import Stepper from '../Stepper';
+import TransitionStepper from '../TransitionStepper';
 import './carousel.scss';
 
 export type CarouselStep = {
@@ -223,7 +223,7 @@ const Carousel: OverridableComponent<BoxTypeMap<CarouselProps>> = forwardRef(
           </Box>
         </Box>
         <Box>
-          <Stepper animateOnSlide steps={generateCarouselSteps()} currentStep={currentStep} />
+          <TransitionStepper animateOnSlide steps={generateCarouselSteps()} currentStep={currentStep} />
         </Box>
       </Box>
     );

--- a/packages/react/src/components/Step/Step.stories.mdx
+++ b/packages/react/src/components/Step/Step.stories.mdx
@@ -1,0 +1,89 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import Step from './Step.tsx';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import Button from '../Button/Button.tsx';
+import StepContent from '../StepContent/StepContent.tsx';
+import StepLabel from '../StepLabel/StepLabel.tsx';
+import Typography from '../Typography/Typography.tsx';
+
+export const meta = {
+  component: Step,
+  title: StoryConfig.Step.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => <Step {...args} />;
+
+# Step
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+Step component can be used with Stepper component.
+
+<Canvas>
+  <Story
+    name="Overview"
+    args={{
+      children: (
+        <>
+          <StepLabel optional={<Typography variant="caption">Sample Step Description</Typography>}>
+            Sample Step Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Sample Step Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </>
+      ),
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `Step` component in your components as follows.
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import Step from '@oxygen-ui/react/Step';
+import StepLabel from '@oxygen-ui/react/StepLabel';
+import StepContent from '@oxygen-ui/react/StepContent';
+import Button from '@oxygen-ui/react/Button';
+import Typography from '@oxygen-ui/react/Typography';\n
+function Demo() {
+  return (
+    <Step>
+      <StepLabel
+        optional={ <Typography variant="caption">Sample Step Description</Typography> }
+      >
+        Sample Step Label
+      </StepLabel>
+      <StepContent>
+        <Typography>Sample Step Content</Typography>
+        <Button
+          sx={{ mt: 1, mr: 1 }}
+        >
+          Next
+        </Button>
+      </StepContent>
+    </Step>
+  );
+}`}
+/>

--- a/packages/react/src/components/Step/Step.tsx
+++ b/packages/react/src/components/Step/Step.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiStep from '@mui/material/Step';
+import type {StepTypeMap, MuiStepLabelProps as MuiStepProps} from '@mui/material/Step';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ElementType, Ref, ReactElement, ForwardRefExoticComponent} from 'react';
+import './step.scss';
+
+export type StepProps<
+  C extends ElementType = ElementType,
+  D extends ElementType = StepTypeMap['defaultComponent'],
+  P = {},
+> = {
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   */
+  component?: C;
+} & Omit<MuiStepProps<D, P>, 'component'>;
+
+/**
+ * The Step component is used to create a step in a sequence of steps.
+ *
+ * Demos:
+ *
+ * - [Stepper (Oxygen UI)](https://wso2.github.io/oxygen-ui/react/?path=/docs/navigation-stepper)
+ * - [Stepper (MUI)](https://mui.com/material-ui/react-stepper/)
+ *
+ * API:
+ *
+ * - [Tab API](https://mui.com/material-ui/api/step/)
+ *
+ * @remarks
+ * - ✔️ Props of the native component are also available.
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the Step component.
+ * @param ref - The ref to be forwarded to the MuiStep component.
+ * @returns The rendered Step component.
+ */
+const Step: ForwardRefExoticComponent<StepProps> = forwardRef(
+  ({className, ...rest}: StepProps, ref: Ref<HTMLDivElement>): ReactElement => {
+    const classes: string = clsx('oxygen-step-content', className);
+
+    return <MuiStep ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<StepProps>;
+
+export default Step;

--- a/packages/react/src/components/Step/Step.tsx
+++ b/packages/react/src/components/Step/Step.tsx
@@ -17,7 +17,7 @@
  */
 
 import MuiStep from '@mui/material/Step';
-import type {StepTypeMap, MuiStepLabelProps as MuiStepProps} from '@mui/material/Step';
+import type {StepTypeMap, StepProps as MuiStepProps} from '@mui/material/Step';
 import clsx from 'clsx';
 import {forwardRef} from 'react';
 import type {ElementType, Ref, ReactElement, ForwardRefExoticComponent} from 'react';

--- a/packages/react/src/components/Step/__tests__/Step.test.tsx
+++ b/packages/react/src/components/Step/__tests__/Step.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import Button from '../../Button/Button';
+import StepContent from '../../StepContent/StepContent';
+import StepLabel from '../../StepLabel/StepLabel';
+import Typography from '../../Typography';
+import Step from '../Step';
+
+describe('Step', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <Step>
+        <StepLabel optional={<Typography variant="caption">Sample Step Description</Typography>}>
+          Sample Step Label
+        </StepLabel>
+        <StepContent>
+          <Typography>Sample Step Content</Typography>
+          <Button sx={{mr: 1, mt: 1}}>Next</Button>
+        </StepContent>
+      </Step>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <Step>
+        <StepLabel optional={<Typography variant="caption">Sample Step Description</Typography>}>
+          Sample Step Label
+        </StepLabel>
+        <StepContent>
+          <Typography>Sample Step Content</Typography>
+          <Button sx={{mr: 1, mt: 1}}>Next</Button>
+        </StepContent>
+      </Step>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/Step/__tests__/__snapshots__/Step.test.tsx.snap
+++ b/packages/react/src/components/Step/__tests__/__snapshots__/Step.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Step should match the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiStep-root oxygen-step-content css-8wcvy5-MuiStep-root"
+    >
+      <span
+        class="MuiStepLabel-root oxygen-step-label css-ascpo7-MuiStepLabel-root"
+      >
+        <span
+          class="MuiStepLabel-labelContainer css-1c0m6we-MuiStepLabel-labelContainer"
+        >
+          <span
+            class="MuiStepLabel-label Mui-active css-s5iety-MuiStepLabel-label"
+          >
+            Sample Step Label
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-caption oxygen-typography css-1f4niku-MuiTypography-root"
+          >
+            Sample Step Description
+          </span>
+        </span>
+      </span>
+      <div
+        class="MuiStepContent-root oxygen-step-content css-kdy6ax-MuiStepContent-root"
+      >
+        <div
+          class="MuiCollapse-root MuiCollapse-vertical MuiStepContent-transition MuiCollapse-entered css-1rw7nzj-MuiCollapse-root-MuiStepContent-transition"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 oxygen-typography css-1qp7oek-MuiTypography-root"
+              >
+                Sample Step Content
+              </p>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation oxygen-button css-htuxbw-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+                id=":r1:"
+                tabindex="0"
+                type="button"
+              >
+                Next
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/Step/index.ts
+++ b/packages/react/src/components/Step/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,5 @@
  * under the License.
  */
 
-.oxygen-stepper {
-  /* Add Styles */
-}
+export {default} from './Step';
+export * from './Step';

--- a/packages/react/src/components/Step/step.scss
+++ b/packages/react/src/components/Step/step.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,6 @@
  * under the License.
  */
 
-.oxygen-stepper {
+.oxygen-step {
   /* Add Styles */
 }

--- a/packages/react/src/components/StepContent/StepContent.stories.mdx
+++ b/packages/react/src/components/StepContent/StepContent.stories.mdx
@@ -1,0 +1,53 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StepContent from './StepContent.tsx';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import Typography from '../Typography/Typography.tsx';
+
+export const meta = {
+  component: StepContent,
+  title: StoryConfig.StepContent.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => <StepContent {...args} />;
+
+# StepContent
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+The StepContent component is used to display the content for each step in a stepper.
+
+<Canvas>
+  <Story name="Overview" args={{children: <Typography>Sample Step Description</Typography>}}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `StepContent` component in your components as follows.
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import StepContent from '@oxygen-ui/react/StepContent';\n
+function Demo() {
+  return (
+    <StepContent>
+      Sample Step Content
+    </StepContent>
+  );
+}`}
+/>

--- a/packages/react/src/components/StepContent/StepContent.tsx
+++ b/packages/react/src/components/StepContent/StepContent.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiStepContent from '@mui/material/StepContent';
+import type {StepContentProps as MuiStepContentProps} from '@mui/material/StepContent';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+
+export type StepContentProps = MuiStepContentProps;
+
+/**
+ * The StepContent component is used to display the content for each step in a vertical stepper.
+ *
+ * Demos:
+ *
+ * - [Stepper (Oxygen UI)](https://wso2.github.io/oxygen-ui/react/?path=/docs/navigation-stepper)
+ * - [Stepper (MUI)](https://mui.com/material-ui/react-stepper/)
+ *
+ * API:
+ *
+ * - [StepContent API](https://mui.com/material-ui/api/step-content/)
+ *
+ * @remarks
+ * - ✔️ Props of the native component are also available.
+ * - ❌ `component` prop is not supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @param props - The props for the StepContent component.
+ * @param ref - The ref to be forwarded to the MuiStepContent component.
+ * @returns The rendered StepContent component.
+ */
+const StepContent: ForwardRefExoticComponent<StepContentProps> = forwardRef(
+  ({className, ...rest}: StepContentProps, ref: Ref<HTMLDivElement>): ReactElement => {
+    const classes: string = clsx('oxygen-step-content', className);
+
+    return <MuiStepContent ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<StepContentProps>;
+
+export default StepContent;

--- a/packages/react/src/components/StepContent/__tests__/StepContent.test.tsx
+++ b/packages/react/src/components/StepContent/__tests__/StepContent.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,17 @@
  * under the License.
  */
 
-.oxygen-stepper {
-  /* Add Styles */
-}
+import {render} from '@unit-testing';
+import StepContent from '../StepContent';
+
+describe('StepContent', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(<StepContent>Sample Step Content</StepContent>);
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(<StepContent>Sample Step Content</StepContent>);
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/StepContent/__tests__/__snapshots__/StepContent.test.tsx.snap
+++ b/packages/react/src/components/StepContent/__tests__/__snapshots__/StepContent.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StepContent should match the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiStepContent-root oxygen-step-content css-kdy6ax-MuiStepContent-root"
+    />
+  </div>
+</body>
+`;

--- a/packages/react/src/components/StepContent/index.ts
+++ b/packages/react/src/components/StepContent/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,5 @@
  * under the License.
  */
 
-.oxygen-stepper {
-  /* Add Styles */
-}
+export {default} from './StepContent';
+export * from './StepContent';

--- a/packages/react/src/components/StepContent/step-content.scss
+++ b/packages/react/src/components/StepContent/step-content.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,6 @@
  * under the License.
  */
 
-.oxygen-stepper {
+.oxygen-step-content {
   /* Add Styles */
 }

--- a/packages/react/src/components/StepLabel/StepLabel.stories.mdx
+++ b/packages/react/src/components/StepLabel/StepLabel.stories.mdx
@@ -1,0 +1,57 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StepLabel from './StepLabel.tsx';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import Typography from '../Typography/Typography.tsx';
+
+export const meta = {
+  component: StepLabel,
+  title: StoryConfig.StepLabel.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => <StepLabel {...args} />;
+
+# StepLabel
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+The StepLabel component can be used within the Stepper to display a label for each step.
+
+<Canvas>
+  <Story
+    name="Overview"
+    args={{children: 'Sample Step Label', optional: <Typography variant="caption">Sample Step Description</Typography>}}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `StepLabel` component in your components as follows.
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import StepLabel from '@oxygen-ui/react/StepLabel';\n
+import Typography from '@oxygen-ui/react/Typography';\n
+function Demo() {
+  return (
+    <StepLabel optional={<Typography variant="caption">Last step</Typography>}>
+      Sample Step Label
+    </StepLabel>
+  );
+}`}
+/>

--- a/packages/react/src/components/StepLabel/StepLabel.tsx
+++ b/packages/react/src/components/StepLabel/StepLabel.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiStepLabel from '@mui/material/StepLabel';
+import type {StepLabelProps as MuiStepLabelProps} from '@mui/material/StepLabel';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+
+export type StepLabelProps = MuiStepLabelProps;
+
+/**
+ * The StepLabel component is used to display a label for each step in a stepper.
+ *
+ * Demos:
+ *
+ * - [Stepper (Oxygen UI)](https://wso2.github.io/oxygen-ui/react/?path=/docs/navigation-stepper)
+ * - [Stepper (MUI)](https://mui.com/material-ui/react-stepper/)
+ *
+ * API:
+ *
+ * - [StepLabel API](https://mui.com/material-ui/api/step-label/)
+ *
+ * @remarks
+ * - ✔️ Props of the native component are also available.
+ * - ❌ `component` prop is not supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @param props - The props for the StepLabel component.
+ * @param ref - The ref to be forwarded to the MuiStepLabel component.
+ * @returns The rendered StepLabel component.
+ */
+const StepLabel: ForwardRefExoticComponent<StepLabelProps> = forwardRef(
+  ({className, ...rest}: StepLabelProps, ref: Ref<HTMLDivElement>): ReactElement => {
+    const classes: string = clsx('oxygen-step-label', className);
+
+    return <MuiStepLabel ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<StepLabelProps>;
+
+export default StepLabel;

--- a/packages/react/src/components/StepLabel/__tests__/StepLabel.test.tsx
+++ b/packages/react/src/components/StepLabel/__tests__/StepLabel.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import Typography from '../../Typography';
+import StepLabel from '../StepLabel';
+
+describe('StepLabel', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <StepLabel optional={<Typography variant="caption">Last step</Typography>}>Sample Step Label</StepLabel>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <StepLabel optional={<Typography variant="caption">Last step</Typography>}>Sample Step Label</StepLabel>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/StepLabel/__tests__/__snapshots__/StepLabel.test.tsx.snap
+++ b/packages/react/src/components/StepLabel/__tests__/__snapshots__/StepLabel.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StepLabel should match the snapshot 1`] = `
+<body>
+  <div>
+    <span
+      class="MuiStepLabel-root oxygen-step-label css-ascpo7-MuiStepLabel-root"
+    >
+      <span
+        class="MuiStepLabel-labelContainer css-1c0m6we-MuiStepLabel-labelContainer"
+      >
+        <span
+          class="MuiStepLabel-label css-s5iety-MuiStepLabel-label"
+        >
+          Sample Step Label
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-caption oxygen-typography css-1f4niku-MuiTypography-root"
+        >
+          Last step
+        </span>
+      </span>
+    </span>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/StepLabel/index.ts
+++ b/packages/react/src/components/StepLabel/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,5 @@
  * under the License.
  */
 
-.oxygen-stepper {
-  /* Add Styles */
-}
+export {default} from './StepLabel';
+export * from './StepLabel';

--- a/packages/react/src/components/StepLabel/step-label.scss
+++ b/packages/react/src/components/StepLabel/step-label.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,6 @@
  * under the License.
  */
 
-.oxygen-stepper {
+.oxygen-step-label {
   /* Add Styles */
 }

--- a/packages/react/src/components/Stepper/Stepper.stories.mdx
+++ b/packages/react/src/components/Stepper/Stepper.stories.mdx
@@ -1,8 +1,12 @@
 import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
-import Stepper from './Stepper.tsx';
 import dedent from 'ts-dedent';
-import Typography from '../Typography';
+import Stepper from './Stepper.tsx';
 import StoryConfig from '../../../.storybook/story-config.ts';
+import Button from '../Button/Button.tsx';
+import Step from '../Step/Step.tsx';
+import StepContent from '../StepContent/StepContent.tsx';
+import StepLabel from '../StepLabel/StepLabel.tsx';
+import Typography from '../Typography/Typography.tsx';
 
 export const meta = {
   component: Stepper,
@@ -18,6 +22,7 @@ export const Template = args => <Stepper {...args} />;
 - [Overview](#overview)
 - [Props](#props)
 - [Usage](#usage)
+- [Orientations](#orientations)
 
 ## Overview
 
@@ -27,40 +32,42 @@ Stepper can be used to compose wizards and carousels.
   <Story
     name="Overview"
     args={{
-      currentStep: 0,
-      steps: [
-        <Typography>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor porttitor dolor eget tristique. Nam
-          elementum, quam vel varius porttitor, purus est vestibulum augue, sed suscipit ligula metus at nibh. Donec
-          eleifend suscipit nisi mollis sollicitudin. Vestibulum fermentum odio at maximus lacinia. Phasellus leo ipsum,
-          vestibulum hendrerit enim vitae, ullamcorper tincidunt erat. Sed quam nulla, pharetra non mattis non,
-          fringilla non massa. Donec maximus finibus dui et suscipit. Suspendisse potenti. In imperdiet hendrerit
-          accumsan. Vivamus lacus nunc, mollis ut elementum eget, tempus vitae lectus. Ut molestie ante quis quam
-          aliquam pretium. Vestibulum dignissim, odio vel volutpat porta, enim nisl auctor turpis, vel imperdiet nisl
-          lorem id ligula. Proin varius scelerisque ligula ac consequat.
-        </Typography>,
-        <Typography>
-          Aliquam vel ex tortor. Proin sed ullamcorper massa. Sed eu fringilla risus, a faucibus tortor. Duis euismod
-          enim sit amet nunc condimentum, eget tristique ex ultricies. Suspendisse potenti. Phasellus risus ligula,
-          imperdiet in imperdiet ac, hendrerit eu quam. Aliquam leo risus, vulputate nec auctor viverra, dictum a elit.
-          Curabitur a accumsan lorem. Cras nec metus sed diam vehicula luctus nec sit amet dolor. Donec ac nibh finibus,
-          varius arcu sit amet, dapibus neque. Morbi orci augue, commodo vitae tincidunt vel, tincidunt at justo.
-          Quisque sem mauris, consectetur sit amet lobortis vel, consectetur sit amet massa.
-        </Typography>,
-        <Typography>
-          Praesent varius porta tellus, ac mattis quam blandit at. Vestibulum in nisi at est rhoncus posuere ac vitae
-          ligula. Phasellus molestie purus ac nulla vestibulum gravida. Morbi lacinia vehicula aliquam. Praesent mollis
-          mollis arcu eu finibus. Morbi at nunc quam. Aliquam sed urna quis erat elementum bibendum vitae eu massa.
-        </Typography>,
-        <Typography>
-          Sed placerat molestie tristique. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-          turpis egestas. Vestibulum at libero bibendum, tempor nunc vel, luctus ipsum. Aenean ut diam ligula. Ut
-          auctor, justo a tincidunt fermentum, nibh dui consectetur massa, eu congue sapien eros ut nisl. Nam nec
-          fringilla sem. Pellentesque facilisis fermentum nibh, in volutpat ipsum porttitor ut. Quisque auctor lorem et
-          dolor suscipit, nec rhoncus justo aliquam. Praesent elit sapien, tempor id mi et, fermentum accumsan justo. Ut
-          a justo tortor. Proin in nisl vel arcu congue tristique. Proin mattis condimentum orci, quis accumsan neque
-          auctor vel.
-        </Typography>,
+      activeStep: 0,
+      children: [
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step One Description</Typography>}>
+            Step One Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Typography>
+            <Typography>Aenean eleifend tortor lorem, at mollis mauris euismod in.</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>,
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Two Description</Typography>}>
+            Step Two Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Two Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>,
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Three Description</Typography>}>
+            Step Three Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Three Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Done
+            </Button>
+          </StepContent>
+        </Step>,
       ],
     }}
   >
@@ -81,48 +88,158 @@ Import and use the `Stepper` component in your components as follows.
   dark
   format
   code={dedent`
-import Stepper from '@oxygen-ui/react/Stepper';\n
+import Stepper from '@oxygen-ui/react/Stepper';
+import Step from '@oxygen-ui/react/Step';
+import StepLabel from '@oxygen-ui/react/StepLabel';
+import StepContent from '@oxygen-ui/react/StepContent';
+import Button from '@oxygen-ui/react/Button';
+import Typography from '@oxygen-ui/react/Typography';\n
 function Demo() {
   return (
     <Stepper
-      currentStep={0}
-      steps={
-        [
-          <Typography>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor porttitor dolor eget tristique. Nam
-            elementum, quam vel varius porttitor, purus est vestibulum augue, sed suscipit ligula metus at nibh. Donec
-            eleifend suscipit nisi mollis sollicitudin. Vestibulum fermentum odio at maximus lacinia. Phasellus leo ipsum,
-            vestibulum hendrerit enim vitae, ullamcorper tincidunt erat. Sed quam nulla, pharetra non mattis non,
-            fringilla non massa. Donec maximus finibus dui et suscipit. Suspendisse potenti. In imperdiet hendrerit
-            accumsan. Vivamus lacus nunc, mollis ut elementum eget, tempus vitae lectus. Ut molestie ante quis quam
-            aliquam pretium. Vestibulum dignissim, odio vel volutpat porta, enim nisl auctor turpis, vel imperdiet nisl
-            lorem id ligula. Proin varius scelerisque ligula ac consequat.
-          </Typography>,
-          <Typography>
-            Aliquam vel ex tortor. Proin sed ullamcorper massa. Sed eu fringilla risus, a faucibus tortor. Duis euismod
-            enim sit amet nunc condimentum, eget tristique ex ultricies. Suspendisse potenti. Phasellus risus ligula,
-            imperdiet in imperdiet ac, hendrerit eu quam. Aliquam leo risus, vulputate nec auctor viverra, dictum a elit.
-            Curabitur a accumsan lorem. Cras nec metus sed diam vehicula luctus nec sit amet dolor. Donec ac nibh finibus,
-            varius arcu sit amet, dapibus neque. Morbi orci augue, commodo vitae tincidunt vel, tincidunt at justo.
-            Quisque sem mauris, consectetur sit amet lobortis vel, consectetur sit amet massa.
-          </Typography>,
-          <Typography>
-            Praesent varius porta tellus, ac mattis quam blandit at. Vestibulum in nisi at est rhoncus posuere ac vitae
-            ligula. Phasellus molestie purus ac nulla vestibulum gravida. Morbi lacinia vehicula aliquam. Praesent mollis
-            mollis arcu eu finibus. Morbi at nunc quam. Aliquam sed urna quis erat elementum bibendum vitae eu massa.
-          </Typography>,
-          <Typography>
-            Sed placerat molestie tristique. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-            turpis egestas. Vestibulum at libero bibendum, tempor nunc vel, luctus ipsum. Aenean ut diam ligula. Ut
-            auctor, justo a tincidunt fermentum, nibh dui consectetur massa, eu congue sapien eros ut nisl. Nam nec
-            fringilla sem. Pellentesque facilisis fermentum nibh, in volutpat ipsum porttitor ut. Quisque auctor lorem et
-            dolor suscipit, nec rhoncus justo aliquam. Praesent elit sapien, tempor id mi et, fermentum accumsan justo. Ut
-            a justo tortor. Proin in nisl vel arcu congue tristique. Proin mattis condimentum orci, quis accumsan neque
-            auctor vel.
-          </Typography>,
-        ]
-      }
+      activeStep={0}
+    >
+      <Step>
+        <StepLabel optional={<Typography variant="caption">Step One Description</Typography>}>
+          Step One Label
+        </StepLabel>
+        <StepContent>
+          <Typography>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Typography>
+          <Typography>Aenean eleifend tortor lorem, at mollis mauris euismod in.</Typography>
+          <Button sx={{mr: 1, mt: 1}} variant="contained">
+            Next
+          </Button>
+        </StepContent>
+      </Step>
+      <Step>
+        <StepLabel optional={<Typography variant="caption">Step Two Description</Typography>}>
+          Step Two Label
+        </StepLabel>
+        <StepContent>
+          <Typography>Step Two Content</Typography>
+          <Button sx={{mr: 1, mt: 1}} variant="contained">
+            Next
+          </Button>
+        </StepContent>
+      </Step>
+      <Step>
+        <StepLabel optional={<Typography variant="caption">Step Three Description</Typography>}>
+          Step Three Label
+        </StepLabel>
+        <StepContent>
+          <Typography>Step Three Content</Typography>
+          <Button sx={{mr: 1, mt: 1}} variant="contained">
+            Done
+          </Button>
+        </StepContent>
+      </Step>
     />
   );
 }`}
 />
+
+## Orientations
+
+### Horizontal Stepper
+
+Horizontal steppers are ideal when the contents of one step depend on an earlier step.
+
+<Canvas>
+  <Story
+    name="Horizontal"
+    args={{
+      activeStep: 0,
+      children: [
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step One Description</Typography>}>
+            Step One Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Typography>
+            <Typography>Aenean eleifend tortor lorem, at mollis mauris euismod in.</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>,
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Two Description</Typography>}>
+            Step Two Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Two Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>,
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Three Description</Typography>}>
+            Step Three Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Three Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Done
+            </Button>
+          </StepContent>
+        </Step>,
+      ],
+      orientation: 'horizontal',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Vertial Stepper
+
+Vertical steppers are designed for narrow screen sizes.
+
+<Canvas>
+  <Story
+    name="Vertial"
+    args={{
+      activeStep: 0,
+      children: [
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step One Description</Typography>}>
+            Step One Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Typography>
+            <Typography>Aenean eleifend tortor lorem, at mollis mauris euismod in.</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>,
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Two Description</Typography>}>
+            Step Two Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Two Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>,
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Three Description</Typography>}>
+            Step Three Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Three Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Done
+            </Button>
+          </StepContent>
+        </Step>,
+      ],
+      orientation: 'vertical',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/react/src/components/Stepper/Stepper.tsx
+++ b/packages/react/src/components/Stepper/Stepper.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,114 +17,55 @@
  */
 
 import type {OverridableComponent} from '@mui/material/OverridableComponent';
+import MuiStepper from '@mui/material/Stepper';
+import type {StepperProps as MuiStepperProps, StepperTypeMap} from '@mui/material/Stepper';
 import clsx from 'clsx';
-import {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
+import {forwardRef} from 'react';
 import type {ElementType, Ref, ReactElement} from 'react';
-import Box from '../Box';
-import type {BoxProps, BoxTypeMap} from '../Box';
 import './stepper.scss';
 
-export type StepperProps<C extends ElementType = ElementType> = BoxProps<C> & {
+export type StepperProps<
+  C extends ElementType = ElementType,
+  D extends ElementType = StepperTypeMap['defaultComponent'],
+  P = {},
+> = {
   /**
-   * Animate the slide transition.
+   * The component used for the root node. Either a string to use an HTML element or a component.
    */
-  animateOnSlide?: boolean;
-  /**
-   * Current step.
-   */
-  currentStep: number;
-  /**
-   * Steps to be rendered.
-   */
-  steps: ReactElement[];
-};
+  component?: C;
+} & Omit<MuiStepperProps<D, P>, 'component'>;
 
 /**
- * The Stepper can be used to compose wizards and carousels.
+ * The Stepper component is used to display a series of steps in a defined sequence.
  *
  * Demos:
  *
- * - [Stepper (Oxygen UI)](https://wso2.github.io/oxygen-ui/react/?path=/docs/surfaces-stepper--overview)
+ * - [Stepper (Oxygen UI)](https://wso2.github.io/oxygen-ui/react/?path=/docs/navigation-stepper)
+ * - [Stepper (MUI)](https://mui.com/material-ui/react-stepper/)
  *
  * API:
  *
- * - inherits [Box API](https://mui.com/material-ui/api/box/)
+ * - [Stepper API](https://mui.com/material-ui/api/stepper/)
  *
  * @remarks
- * - ✨ This is a custom component that is not available in the Material-UI library.
- * - ✔️ Props of the [Box](https://mui.com/material-ui/api/box/) component are also available.
+ * - ✔️ Props of the native component are also available.
  * - ✅ `component` prop is supported.
  * - ✅ The `ref` is forwarded to the root element.
  *
  * @template C - The type of the component.
  * @param props - The props for the Stepper component.
- * @param ref - The ref to be forwarded to the Box component.
+ * @param ref - The ref to be forwarded to the MuiStepper component.
  * @returns The rendered Stepper component.
  */
-const Stepper: OverridableComponent<BoxTypeMap<StepperProps>> = forwardRef(
+const Stepper: OverridableComponent<StepperTypeMap<StepperProps>> = forwardRef(
   <C extends ElementType = ElementType>(
-    {animateOnSlide, className, currentStep = 0, steps}: StepperProps<C>,
+    {className, ...rest}: StepperProps<C>,
     ref: Ref<HTMLDivElement>,
   ): ReactElement => {
-    const [slideLeftPosition, setSlideLeftPosition] = useState<number>(0);
-    const [slideContainerWidth, setSlideContainerWidth] = useState<number>(0);
-
-    const slideContainerRef: Ref<HTMLDivElement> = useRef<HTMLDivElement>(null);
-
     const classes: string = clsx('oxygen-stepper', className);
 
-    const slideContainer: (position: number) => void = useCallback(
-      (position: number): void => {
-        if (!animateOnSlide) {
-          return;
-        }
-
-        const slideBy: number = position;
-        setSlideLeftPosition(slideBy * -1 * currentStep);
-      },
-      [currentStep, animateOnSlide],
-    );
-
-    useEffect(() => {
-      if (!slideContainerRef?.current || !animateOnSlide) {
-        return () => {};
-      }
-
-      setSlideContainerWidth(slideContainerRef.current.offsetWidth);
-
-      const handleResize = (): void => {
-        const width: number = slideContainerRef.current.offsetWidth;
-        setSlideContainerWidth(width);
-        slideContainer(width);
-      };
-
-      window.addEventListener('resize', handleResize);
-
-      return (): void => {
-        window.removeEventListener('resize', handleResize);
-      };
-    }, [animateOnSlide, slideContainer]);
-
-    useEffect(() => {
-      slideContainer(slideContainerWidth);
-    }, [slideContainerWidth, slideContainer]);
-
-    if (animateOnSlide) {
-      return (
-        <Box className={classes} ref={slideContainerRef}>
-          <Box className="oxygen-stepper-container" sx={{left: `${slideLeftPosition}px`}}>
-            {steps.map((step: ReactElement) => (
-              <Box key={step.key} ref={ref} sx={{width: slideContainerWidth}}>
-                {step}
-              </Box>
-            ))}
-          </Box>
-        </Box>
-      );
-    }
-
-    return steps[currentStep];
+    return <MuiStepper className={classes} ref={ref} {...rest} />;
   },
-) as OverridableComponent<BoxTypeMap<StepperProps>>;
+) as OverridableComponent<StepperTypeMap<StepperProps>>;
 
 export default Stepper;

--- a/packages/react/src/components/Stepper/__tests__/Stepper.test.tsx
+++ b/packages/react/src/components/Stepper/__tests__/Stepper.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,25 +17,95 @@
  */
 
 import {render} from '@unit-testing';
-import {ReactElement} from 'react';
+import Button from '../../Button';
+import Step from '../../Step';
+import StepContent from '../../StepContent';
+import StepLabel from '../../StepLabel';
 import Typography from '../../Typography';
 import Stepper from '../Stepper';
 
-const steps: ReactElement[] = [
-  <Typography>Step 1</Typography>,
-  <Typography>Step 2</Typography>,
-  <Typography>Step 3</Typography>,
-  <Typography>Step 4</Typography>,
-];
-
 describe('Stepper', () => {
   it('should render successfully', () => {
-    const {baseElement} = render(<Stepper steps={steps} currentStep={0} />);
+    const {baseElement} = render(
+      <Stepper activeStep={0}>
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step One Description</Typography>}>
+            Step One Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Typography>
+            <Typography>Aenean eleifend tortor lorem, at mollis mauris euismod in.</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Two Description</Typography>}>
+            Step Two Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Two Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Three Description</Typography>}>
+            Step Three Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Three Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Done
+            </Button>
+          </StepContent>
+        </Step>
+      </Stepper>,
+    );
     expect(baseElement).toBeTruthy();
   });
 
   it('should match the snapshot', () => {
-    const {baseElement} = render(<Stepper steps={steps} currentStep={0} />);
+    const {baseElement} = render(
+      <Stepper activeStep={0}>
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step One Description</Typography>}>
+            Step One Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Typography>
+            <Typography>Aenean eleifend tortor lorem, at mollis mauris euismod in.</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Two Description</Typography>}>
+            Step Two Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Two Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Next
+            </Button>
+          </StepContent>
+        </Step>
+        <Step>
+          <StepLabel optional={<Typography variant="caption">Step Three Description</Typography>}>
+            Step Three Label
+          </StepLabel>
+          <StepContent>
+            <Typography>Step Three Content</Typography>
+            <Button sx={{mr: 1, mt: 1}} variant="contained">
+              Done
+            </Button>
+          </StepContent>
+        </Step>
+      </Stepper>,
+    );
     expect(baseElement).toMatchSnapshot();
   });
 });

--- a/packages/react/src/components/Stepper/__tests__/__snapshots__/Stepper.test.tsx.snap
+++ b/packages/react/src/components/Stepper/__tests__/__snapshots__/Stepper.test.tsx.snap
@@ -3,11 +3,209 @@
 exports[`Stepper should match the snapshot 1`] = `
 <body>
   <div>
-    <p
-      class="MuiTypography-root MuiTypography-body1 oxygen-typography css-1qp7oek-MuiTypography-root"
+    <div
+      class="MuiStepper-root MuiStepper-horizontal oxygen-stepper css-m5vj9m-MuiStepper-root"
     >
-      Step 1
-    </p>
+      <div
+        class="MuiStep-root MuiStep-horizontal oxygen-step-content css-1bw0nnu-MuiStep-root"
+      >
+        <span
+          class="MuiStepLabel-root MuiStepLabel-horizontal oxygen-step-label css-ascpo7-MuiStepLabel-root"
+        >
+          <span
+            class="MuiStepLabel-iconContainer Mui-active css-vnkopk-MuiStepLabel-iconContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiStepIcon-root Mui-active css-tx5jdg-MuiSvgIcon-root-MuiStepIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="12"
+              />
+              <text
+                class="MuiStepIcon-text css-1b011nk-MuiStepIcon-text"
+                dominant-baseline="central"
+                text-anchor="middle"
+                x="12"
+                y="12"
+              >
+                1
+              </text>
+            </svg>
+          </span>
+          <span
+            class="MuiStepLabel-labelContainer css-1c0m6we-MuiStepLabel-labelContainer"
+          >
+            <span
+              class="MuiStepLabel-label Mui-active css-s5iety-MuiStepLabel-label"
+            >
+              Step One Label
+            </span>
+            <span
+              class="MuiTypography-root MuiTypography-caption oxygen-typography css-1f4niku-MuiTypography-root"
+            >
+              Step One Description
+            </span>
+          </span>
+        </span>
+        <div
+          class="MuiStepContent-root oxygen-step-content css-kdy6ax-MuiStepContent-root"
+        >
+          <div
+            class="MuiCollapse-root MuiCollapse-vertical MuiStepContent-transition MuiCollapse-entered css-1rw7nzj-MuiCollapse-root-MuiStepContent-transition"
+            style="min-height: 0px;"
+          >
+            <div
+              class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+            >
+              <div
+                class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 oxygen-typography css-1qp7oek-MuiTypography-root"
+                >
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 oxygen-typography css-1qp7oek-MuiTypography-root"
+                >
+                  Aenean eleifend tortor lorem, at mollis mauris euismod in.
+                </p>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation oxygen-button css-1tzl05w-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+                  id=":r1:"
+                  tabindex="0"
+                  type="button"
+                >
+                  Next
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiStepConnector-root MuiStepConnector-horizontal Mui-disabled css-j5w0w9-MuiStepConnector-root"
+      >
+        <span
+          class="MuiStepConnector-line MuiStepConnector-lineHorizontal css-196fyq8-MuiStepConnector-line"
+        />
+      </div>
+      <div
+        class="MuiStep-root MuiStep-horizontal oxygen-step-content css-1bw0nnu-MuiStep-root"
+      >
+        <span
+          class="MuiStepLabel-root MuiStepLabel-horizontal Mui-disabled oxygen-step-label css-ascpo7-MuiStepLabel-root"
+        >
+          <span
+            class="MuiStepLabel-iconContainer Mui-disabled css-vnkopk-MuiStepLabel-iconContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiStepIcon-root css-tx5jdg-MuiSvgIcon-root-MuiStepIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="12"
+              />
+              <text
+                class="MuiStepIcon-text css-1b011nk-MuiStepIcon-text"
+                dominant-baseline="central"
+                text-anchor="middle"
+                x="12"
+                y="12"
+              >
+                2
+              </text>
+            </svg>
+          </span>
+          <span
+            class="MuiStepLabel-labelContainer css-1c0m6we-MuiStepLabel-labelContainer"
+          >
+            <span
+              class="MuiStepLabel-label Mui-disabled css-s5iety-MuiStepLabel-label"
+            >
+              Step Two Label
+            </span>
+            <span
+              class="MuiTypography-root MuiTypography-caption oxygen-typography css-1f4niku-MuiTypography-root"
+            >
+              Step Two Description
+            </span>
+          </span>
+        </span>
+        <div
+          class="MuiStepContent-root oxygen-step-content css-kdy6ax-MuiStepContent-root"
+        />
+      </div>
+      <div
+        class="MuiStepConnector-root MuiStepConnector-horizontal Mui-disabled css-j5w0w9-MuiStepConnector-root"
+      >
+        <span
+          class="MuiStepConnector-line MuiStepConnector-lineHorizontal css-196fyq8-MuiStepConnector-line"
+        />
+      </div>
+      <div
+        class="MuiStep-root MuiStep-horizontal oxygen-step-content css-1bw0nnu-MuiStep-root"
+      >
+        <span
+          class="MuiStepLabel-root MuiStepLabel-horizontal Mui-disabled oxygen-step-label css-ascpo7-MuiStepLabel-root"
+        >
+          <span
+            class="MuiStepLabel-iconContainer Mui-disabled css-vnkopk-MuiStepLabel-iconContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiStepIcon-root css-tx5jdg-MuiSvgIcon-root-MuiStepIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="12"
+              />
+              <text
+                class="MuiStepIcon-text css-1b011nk-MuiStepIcon-text"
+                dominant-baseline="central"
+                text-anchor="middle"
+                x="12"
+                y="12"
+              >
+                3
+              </text>
+            </svg>
+          </span>
+          <span
+            class="MuiStepLabel-labelContainer css-1c0m6we-MuiStepLabel-labelContainer"
+          >
+            <span
+              class="MuiStepLabel-label Mui-disabled css-s5iety-MuiStepLabel-label"
+            >
+              Step Three Label
+            </span>
+            <span
+              class="MuiTypography-root MuiTypography-caption oxygen-typography css-1f4niku-MuiTypography-root"
+            >
+              Step Three Description
+            </span>
+          </span>
+        </span>
+        <div
+          class="MuiStepContent-root MuiStepContent-last oxygen-step-content css-1mz1l2x-MuiStepContent-root"
+        />
+      </div>
+    </div>
   </div>
 </body>
 `;

--- a/packages/react/src/components/TransitionStepper/TransitionStepper.stories.mdx
+++ b/packages/react/src/components/TransitionStepper/TransitionStepper.stories.mdx
@@ -1,0 +1,128 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import TransitonStepper from './TransitionStepper.tsx';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import Typography from '../Typography/index.ts';
+
+export const meta = {
+  component: TransitonStepper,
+  title: StoryConfig.TransitionStepper.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => <TransitonStepper {...args} />;
+
+# TransitionStepper
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+TransitonStepper can be used to compose wizards and carousels.
+
+<Canvas>
+  <Story
+    name="Overview"
+    args={{
+      currentStep: 0,
+      steps: [
+        <Typography>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor porttitor dolor eget tristique. Nam
+          elementum, quam vel varius porttitor, purus est vestibulum augue, sed suscipit ligula metus at nibh. Donec
+          eleifend suscipit nisi mollis sollicitudin. Vestibulum fermentum odio at maximus lacinia. Phasellus leo ipsum,
+          vestibulum hendrerit enim vitae, ullamcorper tincidunt erat. Sed quam nulla, pharetra non mattis non,
+          fringilla non massa. Donec maximus finibus dui et suscipit. Suspendisse potenti. In imperdiet hendrerit
+          accumsan. Vivamus lacus nunc, mollis ut elementum eget, tempus vitae lectus. Ut molestie ante quis quam
+          aliquam pretium. Vestibulum dignissim, odio vel volutpat porta, enim nisl auctor turpis, vel imperdiet nisl
+          lorem id ligula. Proin varius scelerisque ligula ac consequat.
+        </Typography>,
+        <Typography>
+          Aliquam vel ex tortor. Proin sed ullamcorper massa. Sed eu fringilla risus, a faucibus tortor. Duis euismod
+          enim sit amet nunc condimentum, eget tristique ex ultricies. Suspendisse potenti. Phasellus risus ligula,
+          imperdiet in imperdiet ac, hendrerit eu quam. Aliquam leo risus, vulputate nec auctor viverra, dictum a elit.
+          Curabitur a accumsan lorem. Cras nec metus sed diam vehicula luctus nec sit amet dolor. Donec ac nibh finibus,
+          varius arcu sit amet, dapibus neque. Morbi orci augue, commodo vitae tincidunt vel, tincidunt at justo.
+          Quisque sem mauris, consectetur sit amet lobortis vel, consectetur sit amet massa.
+        </Typography>,
+        <Typography>
+          Praesent varius porta tellus, ac mattis quam blandit at. Vestibulum in nisi at est rhoncus posuere ac vitae
+          ligula. Phasellus molestie purus ac nulla vestibulum gravida. Morbi lacinia vehicula aliquam. Praesent mollis
+          mollis arcu eu finibus. Morbi at nunc quam. Aliquam sed urna quis erat elementum bibendum vitae eu massa.
+        </Typography>,
+        <Typography>
+          Sed placerat molestie tristique. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
+          turpis egestas. Vestibulum at libero bibendum, tempor nunc vel, luctus ipsum. Aenean ut diam ligula. Ut
+          auctor, justo a tincidunt fermentum, nibh dui consectetur massa, eu congue sapien eros ut nisl. Nam nec
+          fringilla sem. Pellentesque facilisis fermentum nibh, in volutpat ipsum porttitor ut. Quisque auctor lorem et
+          dolor suscipit, nec rhoncus justo aliquam. Praesent elit sapien, tempor id mi et, fermentum accumsan justo. Ut
+          a justo tortor. Proin in nisl vel arcu congue tristique. Proin mattis condimentum orci, quis accumsan neque
+          auctor vel.
+        </Typography>,
+      ],
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `TransitonStepper` component in your components as follows.
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import TransitonStepper from '@oxygen-ui/react/TransitonStepper';\n
+function Demo() {
+  return (
+    <TransitonStepper
+      currentStep={0}
+      steps={
+        [
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor porttitor dolor eget tristique. Nam
+            elementum, quam vel varius porttitor, purus est vestibulum augue, sed suscipit ligula metus at nibh. Donec
+            eleifend suscipit nisi mollis sollicitudin. Vestibulum fermentum odio at maximus lacinia. Phasellus leo ipsum,
+            vestibulum hendrerit enim vitae, ullamcorper tincidunt erat. Sed quam nulla, pharetra non mattis non,
+            fringilla non massa. Donec maximus finibus dui et suscipit. Suspendisse potenti. In imperdiet hendrerit
+            accumsan. Vivamus lacus nunc, mollis ut elementum eget, tempus vitae lectus. Ut molestie ante quis quam
+            aliquam pretium. Vestibulum dignissim, odio vel volutpat porta, enim nisl auctor turpis, vel imperdiet nisl
+            lorem id ligula. Proin varius scelerisque ligula ac consequat.
+          </Typography>,
+          <Typography>
+            Aliquam vel ex tortor. Proin sed ullamcorper massa. Sed eu fringilla risus, a faucibus tortor. Duis euismod
+            enim sit amet nunc condimentum, eget tristique ex ultricies. Suspendisse potenti. Phasellus risus ligula,
+            imperdiet in imperdiet ac, hendrerit eu quam. Aliquam leo risus, vulputate nec auctor viverra, dictum a elit.
+            Curabitur a accumsan lorem. Cras nec metus sed diam vehicula luctus nec sit amet dolor. Donec ac nibh finibus,
+            varius arcu sit amet, dapibus neque. Morbi orci augue, commodo vitae tincidunt vel, tincidunt at justo.
+            Quisque sem mauris, consectetur sit amet lobortis vel, consectetur sit amet massa.
+          </Typography>,
+          <Typography>
+            Praesent varius porta tellus, ac mattis quam blandit at. Vestibulum in nisi at est rhoncus posuere ac vitae
+            ligula. Phasellus molestie purus ac nulla vestibulum gravida. Morbi lacinia vehicula aliquam. Praesent mollis
+            mollis arcu eu finibus. Morbi at nunc quam. Aliquam sed urna quis erat elementum bibendum vitae eu massa.
+          </Typography>,
+          <Typography>
+            Sed placerat molestie tristique. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
+            turpis egestas. Vestibulum at libero bibendum, tempor nunc vel, luctus ipsum. Aenean ut diam ligula. Ut
+            auctor, justo a tincidunt fermentum, nibh dui consectetur massa, eu congue sapien eros ut nisl. Nam nec
+            fringilla sem. Pellentesque facilisis fermentum nibh, in volutpat ipsum porttitor ut. Quisque auctor lorem et
+            dolor suscipit, nec rhoncus justo aliquam. Praesent elit sapien, tempor id mi et, fermentum accumsan justo. Ut
+            a justo tortor. Proin in nisl vel arcu congue tristique. Proin mattis condimentum orci, quis accumsan neque
+            auctor vel.
+          </Typography>,
+        ]
+      }
+    />
+  );
+}`}
+/>

--- a/packages/react/src/components/TransitionStepper/TransitionStepper.tsx
+++ b/packages/react/src/components/TransitionStepper/TransitionStepper.tsx
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {OverridableComponent} from '@mui/material/OverridableComponent';
+import clsx from 'clsx';
+import {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
+import type {ElementType, Ref, ReactElement} from 'react';
+import Box from '../Box';
+import type {BoxProps, BoxTypeMap} from '../Box';
+import './transition-stepper.scss';
+
+export type TransitionStepperProps<C extends ElementType = ElementType> = BoxProps<C> & {
+  /**
+   * Animate the slide transition.
+   */
+  animateOnSlide?: boolean;
+  /**
+   * Current step.
+   */
+  currentStep: number;
+  /**
+   * Steps to be rendered.
+   */
+  steps: ReactElement[];
+};
+
+/**
+ * The TransitionStepper can be used to compose wizards and carousels.
+ *
+ * Demos:
+ *
+ * - [Stepper (Oxygen UI)](https://wso2.github.io/oxygen-ui/react/?path=/docs/surfaces-stepper--overview)
+ *
+ * API:
+ *
+ * - inherits [Box API](https://mui.com/material-ui/api/box/)
+ *
+ * @remarks
+ * - ✨ This is a custom component that is not available in the Material-UI library.
+ * - ✔️ Props of the [Box](https://mui.com/material-ui/api/box/) component are also available.
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the TransitionStepper component.
+ * @param ref - The ref to be forwarded to the Box component.
+ * @returns The rendered TransitionStepper component.
+ */
+const TransitionStepper: OverridableComponent<BoxTypeMap<TransitionStepperProps>> = forwardRef(
+  <C extends ElementType = ElementType>(
+    {animateOnSlide, className, currentStep = 0, steps}: TransitionStepperProps<C>,
+    ref: Ref<HTMLDivElement>,
+  ): ReactElement => {
+    const [slideLeftPosition, setSlideLeftPosition] = useState<number>(0);
+    const [slideContainerWidth, setSlideContainerWidth] = useState<number>(0);
+
+    const slideContainerRef: Ref<HTMLDivElement> = useRef<HTMLDivElement>(null);
+
+    const classes: string = clsx('oxygen-transition-stepper', className);
+
+    const slideContainer: (position: number) => void = useCallback(
+      (position: number): void => {
+        if (!animateOnSlide) {
+          return;
+        }
+
+        const slideBy: number = position;
+        setSlideLeftPosition(slideBy * -1 * currentStep);
+      },
+      [currentStep, animateOnSlide],
+    );
+
+    useEffect(() => {
+      if (!slideContainerRef?.current || !animateOnSlide) {
+        return () => {};
+      }
+
+      setSlideContainerWidth(slideContainerRef.current.offsetWidth);
+
+      const handleResize = (): void => {
+        const width: number = slideContainerRef.current.offsetWidth;
+        setSlideContainerWidth(width);
+        slideContainer(width);
+      };
+
+      window.addEventListener('resize', handleResize);
+
+      return (): void => {
+        window.removeEventListener('resize', handleResize);
+      };
+    }, [animateOnSlide, slideContainer]);
+
+    useEffect(() => {
+      slideContainer(slideContainerWidth);
+    }, [slideContainerWidth, slideContainer]);
+
+    if (animateOnSlide) {
+      return (
+        <Box className={classes} ref={slideContainerRef}>
+          <Box className="oxygen-transition-stepper-container" sx={{left: `${slideLeftPosition}px`}}>
+            {steps.map((step: ReactElement) => (
+              <Box key={step.key} ref={ref} sx={{width: slideContainerWidth}}>
+                {step}
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      );
+    }
+
+    return steps[currentStep];
+  },
+) as OverridableComponent<BoxTypeMap<TransitionStepperProps>>;
+
+export default TransitionStepper;

--- a/packages/react/src/components/TransitionStepper/__tests__/TransitionStepper.test.tsx
+++ b/packages/react/src/components/TransitionStepper/__tests__/TransitionStepper.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import {ReactElement} from 'react';
+import Typography from '../../Typography';
+import TransitionStepper from '../TransitionStepper';
+
+const steps: ReactElement[] = [
+  <Typography>Step 1</Typography>,
+  <Typography>Step 2</Typography>,
+  <Typography>Step 3</Typography>,
+  <Typography>Step 4</Typography>,
+];
+
+describe('TransitionStepper', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(<TransitionStepper steps={steps} currentStep={0} />);
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(<TransitionStepper steps={steps} currentStep={0} />);
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/TransitionStepper/__tests__/__snapshots__/TransitionStepper.test.tsx.snap
+++ b/packages/react/src/components/TransitionStepper/__tests__/__snapshots__/TransitionStepper.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TransitionStepper should match the snapshot 1`] = `
+<body>
+  <div>
+    <p
+      class="MuiTypography-root MuiTypography-body1 oxygen-typography css-1qp7oek-MuiTypography-root"
+    >
+      Step 1
+    </p>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/TransitionStepper/index.ts
+++ b/packages/react/src/components/TransitionStepper/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './TransitionStepper';
+export * from './TransitionStepper';

--- a/packages/react/src/components/TransitionStepper/transition-stepper.scss
+++ b/packages/react/src/components/TransitionStepper/transition-stepper.scss
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.oxygen-transition-stepper {
+  overflow: hidden;
+
+  .oxygen-transition-stepper-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    width: max-content;
+    position: relative;
+    transition: left 0.5s ease-in-out;
+  }
+}

--- a/packages/react/src/components/Wizard/Wizard.tsx
+++ b/packages/react/src/components/Wizard/Wizard.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,7 +28,7 @@ import CardActions from '../CardActions';
 import CardContent from '../CardContent';
 import CardHeader from '../CardHeader';
 import LinearProgress from '../LinearProgress';
-import Stepper from '../Stepper';
+import TransitionStepper from '../TransitionStepper';
 import Typography from '../Typography';
 import './wizard.scss';
 
@@ -174,7 +174,7 @@ const Wizard: OverridableComponent<BoxTypeMap<WizardProps>> = forwardRef(
         <Card elevation={1} className="oxygen-wizard-card">
           <CardHeader title={title} subheader={subtitle} />
           <CardContent className="oxygen-wizard-card-content">
-            <Stepper animateOnSlide={animateOnSlide} currentStep={currentStep} steps={steps} />
+            <TransitionStepper animateOnSlide={animateOnSlide} currentStep={currentStep} steps={steps} />
           </CardContent>
           <CardActions className="oxygen-wizard-actions">
             <Box>


### PR DESCRIPTION
### Purpose

1. Adds components
	- StepLabel
	- StepContent
	- Step
	- Stepper

2. Rename the custom component `Stepper` to `TransitionStepper`. Refer the issue.

### Related Issues
- https://github.com/wso2/oxygen-ui/issues/2
- https://github.com/wso2/oxygen-ui/issues/302

### Related PRs
- N/A

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [x] Story provided. (Add screenshots)
- [x] Manual test round performed and verified.
- [x] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran ESLint & Prettier plugins and verified?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
