### PR TITLE
ci: stick node version to `18.x` in ci

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ lts/* ]
+        node-version: [ 18.x ]
     steps:
       - name: ⬇️ Checkout
         id: checkout

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [ 18.x ]
     steps:
       - name: ⬇️ Checkout
         id: checkout

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ lts/* ]
+        node-version: [ 18.x ]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ lts/* ]
+        node-version: [ 18.x ]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ lts/* ]
+        node-version: [ 18.x ]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ lts/* ]
+        node-version: [ 18.x ]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -240,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ lts/* ]
+        node-version: [ 18.x ]
     steps:
       - name: ⬇️ Checkout
         id: checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [18.x]
         pnpm-version: [8.15.7]
     steps:
       - name: ⬇️ Checkout

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ lts/* ]
+        node-version: [ 18.x ]
     steps:
       - name: ⬇️ Checkout
         id: checkout


### PR DESCRIPTION
### Purpose

$subject to avoid confilcts with `node-sass` version.

### Related Issues
- https://github.com/wso2/oxygen-ui/issues/304

### Related PRs
- N/A

