### PR TITLE
ci: stick pnpm version to latest version available

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        pnpm-version: [8.15.7]
+        pnpm-version: [9.15.3]
     steps:
       - name: ⬇️ Checkout
         id: checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        pnpm-version: [9.15.3]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -54,7 +53,7 @@ jobs:
         id: setup-pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: ${{ matrix.pnpm-version }}
+          version: latest
           run_install: false
 
       - name: 🎈 Get pnpm store directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
+        pnpm-version: [latest]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -53,7 +54,7 @@ jobs:
         id: setup-pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: latest
+          version: ${{ matrix.pnpm-version }}
           run_install: false
 
       - name: 🎈 Get pnpm store directory


### PR DESCRIPTION
### Purpose
$subject. At the time of creating the PR, the latest pnpm version is [`9.15.3`](https://github.com/pnpm/pnpm/releases/tag/v9.15.3)

This was introduced since the release job was failing for the pnpm 8 version. The failed release job can be found here - https://github.com/wso2/oxygen-ui/actions/runs/12688751069/job/35366358079

Failed logs can be found here - 
[logs_32856295407.zip](https://github.com/user-attachments/files/18371092/logs_32856295407.zip)

### Related Issues
- N/A

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran ESLint & Prettier plugins and verified?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
