### PR TITLE
fix(website): change `@oxygen-ui/logger` to get dependency from the workspace

### DIFF
--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -44,7 +44,7 @@
     "typescript": "4.9.3"
   },
   "devDependencies": {
-    "@oxygen-ui/logger": "2.1.0",
+    "@oxygen-ui/logger": "workspace:*",
     "@wso2/eslint-plugin": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730",
     "@wso2/prettier-config": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?b21bbbd7379ab3b7315d7d9478dbd88c0bf11241",
     "@wso2/stylelint-config": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/stylelint-config?b21bbbd7379ab3b7315d7d9478dbd88c0bf11241",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         version: 4.9.3
     devDependencies:
       '@oxygen-ui/logger':
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@wso2/eslint-plugin':
         specifier: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730
         version: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730(eslint@8.25.0)(typescript@4.9.3)
@@ -283,7 +283,7 @@ importers:
         version: 18.11.18
       '@wso2/eslint-plugin':
         specifier: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730
-        version: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730(eslint@8.25.0)(jest@29.0.3(@types/node@18.11.18))(typescript@4.9.4)
+        version: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730(eslint@8.25.0)(jest@29.0.3(@types/node@18.11.18)(ts-node@10.9.1(@types/node@18.11.18)(typescript@4.9.4)))(typescript@4.9.4)
       '@wso2/prettier-config':
         specifier: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?b21bbbd7379ab3b7315d7d9478dbd88c0bf11241
         version: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?b21bbbd7379ab3b7315d7d9478dbd88c0bf11241(prettier@2.8.1)(typescript@4.9.4)
@@ -298,7 +298,7 @@ importers:
         version: 11.1.0
       jest:
         specifier: 29.0.3
-        version: 29.0.3(@types/node@18.11.18)
+        version: 29.0.3(@types/node@18.11.18)(ts-node@10.9.1(@types/node@18.11.18)(typescript@4.9.4))
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
@@ -584,7 +584,7 @@ importers:
         version: 18.0.25
       '@wso2/eslint-plugin':
         specifier: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730
-        version: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730(eslint@8.25.0)(jest@29.0.3)(typescript@4.9.4)
+        version: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730(eslint@8.25.0)(jest@29.0.3(@types/node@18.11.18)(ts-node@10.9.1(@types/node@18.11.18)(typescript@4.9.4)))(typescript@4.9.4)
       '@wso2/prettier-config':
         specifier: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?d84dd6df97ba9812d30b17d482ecaec5d35d3e54
         version: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?d84dd6df97ba9812d30b17d482ecaec5d35d3e54(prettier@2.8.1)(typescript@4.9.4)
@@ -599,7 +599,7 @@ importers:
         version: 11.1.0
       jest:
         specifier: 29.0.3
-        version: 29.0.3
+        version: 29.0.3(@types/node@18.11.18)(ts-node@10.9.1(@types/node@18.11.18)(typescript@4.9.4))
       jest-environment-jsdom:
         specifier: 29.0.3
         version: 29.0.3
@@ -12910,40 +12910,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@29.3.1':
-    dependencies:
-      '@jest/console': 29.3.1
-      '@jest/reporters': 29.3.1
-      '@jest/test-result': 29.3.1
-      '@jest/transform': 29.3.1
-      '@jest/types': 29.4.1
-      '@types/node': 18.11.18
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.7.0
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-changed-files: 29.2.0
-      jest-config: 29.3.1(@types/node@18.11.18)(ts-node@10.9.1(@types/node@18.11.18)(typescript@4.9.4))
-      jest-haste-map: 29.3.1
-      jest-message-util: 29.3.1
-      jest-regex-util: 29.2.0
-      jest-resolve: 29.3.1
-      jest-resolve-dependencies: 29.3.1
-      jest-runner: 29.3.1
-      jest-runtime: 29.3.1
-      jest-snapshot: 29.3.1
-      jest-util: 29.4.1
-      jest-validate: 29.3.1
-      jest-watcher: 29.3.1
-      micromatch: 4.0.5
-      pretty-format: 29.3.1
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-
   '@jest/core@29.3.1(ts-node@10.9.1(@types/node@16.18.9)(typescript@4.9.4))':
     dependencies:
       '@jest/console': 29.3.1
@@ -16112,74 +16078,6 @@ snapshots:
       - jest
       - supports-color
 
-  '@wso2/eslint-plugin@https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730(eslint@8.25.0)(jest@29.0.3(@types/node@18.11.18))(typescript@4.9.4)':
-    dependencies:
-      '@babel/core': 7.20.5
-      '@babel/eslint-parser': 7.19.1(@babel/core@7.20.5)(eslint@8.25.0)
-      '@next/eslint-plugin-next': 13.0.7
-      '@typescript-eslint/eslint-plugin': 5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4)
-      '@typescript-eslint/parser': 5.46.1(eslint@8.25.0)(typescript@4.9.4)
-      eslint: 8.25.0
-      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0))(eslint-plugin-jsx-a11y@6.6.1(eslint@8.25.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.25.0))(eslint-plugin-react@7.31.11(eslint@8.25.0))(eslint@8.25.0)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0))(eslint@8.25.0)
-      eslint-config-airbnb-typescript: 17.0.0(@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4))(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0))(eslint@8.25.0)
-      eslint-config-prettier: 8.5.0(eslint@8.25.0)
-      eslint-plugin-eslint-plugin: 5.0.6(eslint@8.25.0)
-      eslint-plugin-header: 3.1.1(eslint@8.25.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)
-      eslint-plugin-jest: 27.1.7(@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(jest@29.0.3(@types/node@18.11.18))(typescript@4.9.4)
-      eslint-plugin-jsx-a11y: 6.6.1(eslint@8.25.0)
-      eslint-plugin-node: 11.1.0(eslint@8.25.0)
-      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.5.0(eslint@8.25.0))(eslint@8.25.0)(prettier@2.8.1)
-      eslint-plugin-react: 7.31.11(eslint@8.25.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.25.0)
-      eslint-plugin-testing-library: 5.9.1(eslint@8.25.0)(typescript@4.9.4)
-      eslint-plugin-tsdoc: 0.2.17
-      eslint-plugin-typescript-sort-keys: 2.1.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4)
-      prettier: 2.8.1
-      requireindex: 1.2.0
-    optionalDependencies:
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jest
-      - supports-color
-
-  '@wso2/eslint-plugin@https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730(eslint@8.25.0)(jest@29.0.3)(typescript@4.9.4)':
-    dependencies:
-      '@babel/core': 7.20.5
-      '@babel/eslint-parser': 7.19.1(@babel/core@7.20.5)(eslint@8.25.0)
-      '@next/eslint-plugin-next': 13.0.7
-      '@typescript-eslint/eslint-plugin': 5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4)
-      '@typescript-eslint/parser': 5.46.1(eslint@8.25.0)(typescript@4.9.4)
-      eslint: 8.25.0
-      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0))(eslint-plugin-jsx-a11y@6.6.1(eslint@8.25.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.25.0))(eslint-plugin-react@7.31.11(eslint@8.25.0))(eslint@8.25.0)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0))(eslint@8.25.0)
-      eslint-config-airbnb-typescript: 17.0.0(@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4))(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0))(eslint@8.25.0)
-      eslint-config-prettier: 8.5.0(eslint@8.25.0)
-      eslint-plugin-eslint-plugin: 5.0.6(eslint@8.25.0)
-      eslint-plugin-header: 3.1.1(eslint@8.25.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)
-      eslint-plugin-jest: 27.1.7(@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(jest@29.0.3)(typescript@4.9.4)
-      eslint-plugin-jsx-a11y: 6.6.1(eslint@8.25.0)
-      eslint-plugin-node: 11.1.0(eslint@8.25.0)
-      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.5.0(eslint@8.25.0))(eslint@8.25.0)(prettier@2.8.1)
-      eslint-plugin-react: 7.31.11(eslint@8.25.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.25.0)
-      eslint-plugin-testing-library: 5.9.1(eslint@8.25.0)(typescript@4.9.4)
-      eslint-plugin-tsdoc: 0.2.17
-      eslint-plugin-typescript-sort-keys: 2.1.0(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4)
-      prettier: 2.8.1
-      requireindex: 1.2.0
-    optionalDependencies:
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jest
-      - supports-color
-
   '@wso2/eslint-plugin@https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730(eslint@8.25.0)(typescript@4.9.3)':
     dependencies:
       '@babel/core': 7.20.5
@@ -18825,28 +18723,6 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@27.1.7(@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(jest@29.0.3(@types/node@18.11.18))(typescript@4.9.4):
-    dependencies:
-      '@typescript-eslint/utils': 5.46.1(eslint@8.25.0)(typescript@4.9.4)
-      eslint: 8.25.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4)
-      jest: 29.0.3(@types/node@18.11.18)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-jest@27.1.7(@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(jest@29.0.3)(typescript@4.9.4):
-    dependencies:
-      '@typescript-eslint/utils': 5.46.1(eslint@8.25.0)(typescript@4.9.4)
-      eslint: 8.25.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.25.0)(typescript@4.9.4))(eslint@8.25.0)(typescript@4.9.4)
-      jest: 29.0.3
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   eslint-plugin-jsx-a11y@6.6.1(eslint@8.25.0):
     dependencies:
       '@babel/runtime': 7.22.6
@@ -20733,25 +20609,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.3.1:
-    dependencies:
-      '@jest/core': 29.3.1
-      '@jest/test-result': 29.3.1
-      '@jest/types': 29.4.1
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      jest-config: 29.3.1(@types/node@16.18.9)(ts-node@10.9.1(@types/node@16.18.9)(typescript@4.9.4))
-      jest-util: 29.4.1
-      jest-validate: 29.3.1
-      prompts: 2.4.2
-      yargs: 17.6.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-
   jest-cli@29.3.1(@types/node@16.18.9)(ts-node@10.9.1(@types/node@16.18.9)(typescript@4.9.4)):
     dependencies:
       '@jest/core': 29.3.1(ts-node@10.9.1(@types/node@16.18.9)(typescript@4.9.4))
@@ -20762,25 +20619,6 @@ snapshots:
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.3.1(@types/node@16.18.9)(ts-node@10.9.1(@types/node@16.18.9)(typescript@4.9.4))
-      jest-util: 29.4.1
-      jest-validate: 29.3.1
-      prompts: 2.4.2
-      yargs: 17.6.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-
-  jest-cli@29.3.1(@types/node@18.11.18):
-    dependencies:
-      '@jest/core': 29.3.1
-      '@jest/test-result': 29.3.1
-      '@jest/types': 29.4.1
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      jest-config: 29.3.1(@types/node@18.11.18)(ts-node@10.9.1(@types/node@18.11.18)(typescript@4.9.4))
       jest-util: 29.4.1
       jest-validate: 29.3.1
       prompts: 2.4.2
@@ -21577,34 +21415,12 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@29.0.3:
-    dependencies:
-      '@jest/core': 29.3.1
-      '@jest/types': 29.3.1
-      import-local: 3.1.0
-      jest-cli: 29.3.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-
   jest@29.0.3(@types/node@16.18.9)(ts-node@10.9.1(@types/node@16.18.9)(typescript@4.9.4)):
     dependencies:
       '@jest/core': 29.3.1(ts-node@10.9.1(@types/node@16.18.9)(typescript@4.9.4))
       '@jest/types': 29.3.1
       import-local: 3.1.0
       jest-cli: 29.3.1(@types/node@16.18.9)(ts-node@10.9.1(@types/node@16.18.9)(typescript@4.9.4))
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-
-  jest@29.0.3(@types/node@18.11.18):
-    dependencies:
-      '@jest/core': 29.3.1
-      '@jest/types': 29.3.1
-      import-local: 3.1.0
-      jest-cli: 29.3.1(@types/node@18.11.18)
     transitivePeerDependencies:
       - '@types/node'
       - supports-color


### PR DESCRIPTION
### Purpose
$subject. Applied this fix to avoid the failure during the release workflow.

```
ERROR Scope: all 7 workspace projects
 WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
Progress: resolved 1, reused 0, downloaded 0, added 0
docs/website                             |  WARN  deprecated eslint@8.25.0
/home/runner/work/oxygen-ui/oxygen-ui/docs/website:
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @oxygen-ui/logger@2.2.0
This error happened while installing a direct dependency of /home/runner/work/oxygen-ui/oxygen-ui/docs/website
The latest release of @oxygen-ui/logger is "2.1.0".
If you need the full list of all [69](https://github.com/wso2/oxygen-ui/actions/runs/12704212914/job/35414806099#step:8:70) published versions run "$ pnpm view @oxygen-ui/logger versions".
```

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran ESLint & Prettier plugins and verified?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
