### PR TITLE
fix: make @oxygen-ui/logger dependency use the workspace build

### DIFF
--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/parser": "^7.20.5",
     "@divriots/style-dictionary-to-figma": "^0.4.0",
-    "@oxygen-ui/logger": "2.1.0",
+    "@oxygen-ui/logger": "workspace:*",
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.18",
     "@wso2/eslint-plugin": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?21281faa4f8354491747075f40f58b497d0c4730",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
     "@babel/types": "^7.20.2",
-    "@oxygen-ui/logger": "2.1.0",
+    "@oxygen-ui/logger": "workspace:*",
     "@oxygen-ui/primitives": "2.1.0",
     "@rollup/plugin-babel": "5.3.1",
     "@rollup/plugin-commonjs": "^23.0.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,7 @@
     "@mui/material": "^5.10.16",
     "@mui/system": "^5.10.16",
     "@mui/utils": "^5.10.16",
-    "@oxygen-ui/logger": "2.1.0",
+    "@oxygen-ui/logger": "workspace:*",
     "@rollup/plugin-commonjs": "^23.0.3",
     "@rollup/plugin-image": "^3.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,8 +273,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@oxygen-ui/logger':
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: workspace:*
+        version: link:../logger
       '@types/jest':
         specifier: ^29.2.3
         version: 29.2.5
@@ -364,8 +364,8 @@ importers:
         specifier: ^5.10.16
         version: 5.11.13(react@18.2.0)
       '@oxygen-ui/logger':
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: workspace:*
+        version: link:../logger
       '@rollup/plugin-commonjs':
         specifier: ^23.0.3
         version: 23.0.5(rollup@3.7.4)
@@ -556,8 +556,8 @@ importers:
         specifier: ^7.20.2
         version: 7.20.5
       '@oxygen-ui/logger':
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: workspace:*
+        version: link:../logger
       '@oxygen-ui/primitives':
         specifier: 2.1.0
         version: 2.1.0
@@ -2128,9 +2128,6 @@ packages:
 
   '@octokit/types@9.0.0':
     resolution: {integrity: sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==}
-
-  '@oxygen-ui/logger@2.1.0':
-    resolution: {integrity: sha512-eTTyTJQqvt8fbLTQwDm45be2ivPebtD2pN8bH0oDBzzK5K7cbETbNHr7S0vp+/pWN1BvwtR9C+4L0LWEal9sEw==}
 
   '@oxygen-ui/primitives@2.1.0':
     resolution: {integrity: sha512-rh7lUY19PQpN7uRHdzNLQ19nkDZWpTxGGK6gDPiUoLQPPFTiut1NT22e0IB1ZrMTCKWGILLn4wNPfbsy8FzgWw==}
@@ -13671,10 +13668,6 @@ snapshots:
   '@octokit/types@9.0.0':
     dependencies:
       '@octokit/openapi-types': 16.0.0
-
-  '@oxygen-ui/logger@2.1.0':
-    dependencies:
-      chalk: 5.2.0
 
   '@oxygen-ui/primitives@2.1.0': {}
 


### PR DESCRIPTION
### Purpose

$subject. Due to the failed release workflow.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran ESLint & Prettier plugins and verified?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
