### PR TITLE
feat(react): Add Table, TableRow, TableHead, TableBody and associated components

### DIFF
--- a/packages/react/.storybook/story-config.ts
+++ b/packages/react/.storybook/story-config.ts
@@ -114,6 +114,13 @@ export type Stories =
   | 'Stepper'
   | 'Switch'
   | 'Tab'
+  | 'Table'
+  | 'TableBody'
+  | 'TableCell'
+  | 'TableContainer'
+  | 'TableFooter'
+  | 'TableHead'
+  | 'TableRow'
   | 'TabPanel'
   | 'Tabs'
   | 'TransitionStepper'
@@ -391,6 +398,27 @@ const StoryConfig: StorybookConfig = {
   },
   Tab: {
     hierarchy: `${StorybookCategories.Navigation}/Tab`,
+  },
+  Table: {
+    hierarchy: `${StorybookCategories.DataDisplay}/Table`,
+  },
+  TableBody: {
+    hierarchy: `${StorybookCategories.DataDisplay}/Table Body`,
+  },
+  TableCell: {
+    hierarchy: `${StorybookCategories.DataDisplay}/Table Cell`,
+  },
+  TableContainer: {
+    hierarchy: `${StorybookCategories.DataDisplay}/Table Container`,
+  },
+  TableFooter: {
+    hierarchy: `${StorybookCategories.DataDisplay}/Table Footer`,
+  },
+  TableHead: {
+    hierarchy: `${StorybookCategories.DataDisplay}/Table Head`,
+  },
+  TableRow: {
+    hierarchy: `${StorybookCategories.DataDisplay}/Table Row`,
   },
   TabPanel: {
     hierarchy: `${StorybookCategories.Navigation}/Tab Panel`,

--- a/packages/react/src/components/Table/Table.stories.mdx
+++ b/packages/react/src/components/Table/Table.stories.mdx
@@ -1,0 +1,90 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import Table from './Table.tsx';
+import TableRow from '../TableRow/TableRow.tsx';
+import TableHead from '../TableHead/TableHead.tsx';
+import TableBody from '../TableBody/TableBody.tsx';
+import TableCell from '../TableCell/TableCell.tsx';
+
+export const meta = {
+  component: Table,
+  title: StoryConfig.Table.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => {
+  return (
+    <Table {...args}>
+      <TableHead>
+        <TableRow>
+          <TableCell>
+            Table Head Cell 1
+          </TableCell>
+          <TableCell>
+            Table Head Cell 2
+          </TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell>
+            Table Body Cell 1
+          </TableCell>
+          <TableCell>
+            Table Body Cell 2
+          </TableCell>
+        </TableRow>
+        <TableRow hideBorder={true}>
+          <TableCell>
+            Table Body Cell 3
+          </TableCell>
+          <TableCell>
+            Table Body Cell 4
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+};
+
+# Table
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+The `Table` component is used to display a set of data in a tabular format.
+
+<Canvas>
+  <Story name="Overview">
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `Table` component in your components as follows:
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import Table from '@oxygen-ui/react/Table';\n
+function Demo {
+  return (
+    <Table>
+      {/** Table content */}
+    </Table>
+  );
+}
+`}
+/>

--- a/packages/react/src/components/Table/Table.tsx
+++ b/packages/react/src/components/Table/Table.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiTable, {TableProps as MuiTableProps, TableTypeMap} from '@mui/material/Table';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ElementType, ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+
+export type TableProps<
+  C extends ElementType = ElementType,
+  D extends ElementType = TableTypeMap['defaultComponent'],
+  P = {},
+> = {
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   */
+  component?: C;
+} & Omit<MuiTableProps<D, P>, 'component'>;
+
+/**
+ * The Table component lets display sets of data
+ *
+ * Demos:
+ *
+ * - [Table (Oxygen UI)](https://wso2.github.io/oxygen-ui/react/?path=/docs/data-display-table)
+ * - [Table (MUI)](https://mui.com/material-ui/react-table/)
+ *
+ * API:
+ *
+ * - [Table API](https://mui.com/material-ui/api/table/)
+ *
+ * @remarks
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the Table component.
+ * @param ref - The ref to be forwarded to the MuiTable component.
+ * @returns The rendered Table component.
+ */
+const Table: ForwardRefExoticComponent<TableProps> = forwardRef(
+  <C extends ElementType = ElementType>(
+    {className, ...rest}: TableProps<C>,
+    ref: Ref<HTMLTableElement>,
+  ): ReactElement => {
+    const classes: string = clsx('oxygen-table', className);
+
+    return <MuiTable ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<TableProps>;
+
+export default Table;

--- a/packages/react/src/components/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/components/Table/__tests__/Table.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import Table from '../Table';
+
+describe('Table', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <Table>
+        <p>test Table</p>
+      </Table>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <Table>
+        <p>test Table</p>
+      </Table>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table should match the snapshot 1`] = `
+<body>
+  <div>
+    <table
+      class="MuiTable-root oxygen-table css-1du9rtx-MuiTable-root"
+    >
+      <p>
+        test Table
+      </p>
+    </table>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/Table/index.ts
+++ b/packages/react/src/components/Table/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './Table';
+export * from './Table';
+
+export {TablePropsSizeOverrides} from '@mui/material/Table';
+export {TableTypeMap} from '@mui/material/Table';

--- a/packages/react/src/components/TableBody/TableBody.stories.mdx
+++ b/packages/react/src/components/TableBody/TableBody.stories.mdx
@@ -1,0 +1,65 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import TableBody from './TableBody.tsx';
+import TableRow from '../TableRow/TableRow.tsx';
+import TableCell from '../TableCell/TableCell.tsx';
+
+export const meta = {
+  component: TableBody,
+  title: StoryConfig.TableBody.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => {
+  return (
+    <TableBody {...args}>
+      <TableCell>
+        Table Body Cell 1
+      </TableCell>
+      <TableCell>
+        Table Body Cell 2
+      </TableCell>
+    </TableBody>
+  );
+};
+
+# TableBody
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+The `TableBody` component is used to define the body section within the `Table` component.
+
+<Canvas>
+  <Story name="Overview">
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `TableBody` component in your components as follows:
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import TableBody from '@oxygen-ui/react/TableBody';\n
+function Demo {
+  return (
+    <TableBody>
+      {/** Table Body content */}
+    </TableBody>
+  );
+}`}
+/>

--- a/packages/react/src/components/TableBody/TableBody.tsx
+++ b/packages/react/src/components/TableBody/TableBody.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiTableBody, {TableBodyProps as MuiTableBodyProps, TableBodyTypeMap} from '@mui/material/TableBody';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ElementType, ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+
+export type TableBodyProps<
+  C extends ElementType = ElementType,
+  D extends ElementType = TableBodyTypeMap['defaultComponent'],
+  P = {},
+> = {
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   */
+  component?: C;
+} & Omit<MuiTableBodyProps<D, P>, 'component'>;
+
+/**
+ * The TableBody component lets display a body of the Table
+ *
+ * API:
+ * - [TableBody API](https://mui.com/material-ui/api/table-head/)
+ *
+ * @remarks
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the TableBody component.
+ * @param ref - The ref to be forwarded to the MuiTable component.
+ * @returns The rendered TableBody component.
+ */
+const TableBody: ForwardRefExoticComponent<TableBodyProps> = forwardRef(
+  <C extends ElementType = ElementType>(
+    {className, ...rest}: TableBodyProps<C>,
+    ref: Ref<HTMLTableSectionElement>,
+  ): ReactElement => {
+    const classes: string = clsx('oxygen-table-body', className);
+
+    return <MuiTableBody ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<TableBodyProps>;
+
+export default TableBody;

--- a/packages/react/src/components/TableBody/__tests__/TableBody.test.tsx
+++ b/packages/react/src/components/TableBody/__tests__/TableBody.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import TableBody from '../TableBody';
+
+describe('TableBody', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <TableBody>
+        <p>test TableBody</p>
+      </TableBody>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <TableBody>
+        <p>test TableBody</p>
+      </TableBody>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/TableBody/__tests__/__snapshots__/TableBody.test.tsx.snap
+++ b/packages/react/src/components/TableBody/__tests__/__snapshots__/TableBody.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableBody should match the snapshot 1`] = `
+<body>
+  <div>
+    <tbody
+      class="MuiTableBody-root oxygen-table-body css-apqrd9-MuiTableBody-root"
+    >
+      <p>
+        test TableBody
+      </p>
+    </tbody>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/TableBody/index.ts
+++ b/packages/react/src/components/TableBody/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './TableBody';
+export * from './TableBody';
+
+export {TableBodyTypeMap} from '@mui/material/TableBody';

--- a/packages/react/src/components/TableCell/TableCell.stories.mdx
+++ b/packages/react/src/components/TableCell/TableCell.stories.mdx
@@ -1,0 +1,60 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import TableCell from './TableCell.tsx';
+
+export const meta = {
+  component: TableCell,
+  title: StoryConfig.TableCell.hierarchy
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => {
+  return (
+    <TableCell {...args}>
+      Table Cell
+    </TableCell>
+  );
+};
+
+# TableCell
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+The `TableCell` component is used to display individual cells within a `Table` component.
+
+<Canvas>
+  <Story name="Overview">
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `TableCell` component in your components as follows:
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import TableCell from '@oxygen-ui/react/TableCell';
+import TableRow from '@oxygen-ui/react/TableRow';
+import Table from '@oxygen-ui/react/Table';\n
+function Demo {
+  return (
+    <TableCell>
+      {/** Cell content */}
+    </TableCell>
+  );
+}`}
+/>

--- a/packages/react/src/components/TableCell/TableCell.tsx
+++ b/packages/react/src/components/TableCell/TableCell.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiTableCell, {TableCellProps as MuiTableCellProps} from '@mui/material/TableCell';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ElementType, ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+
+export type TableCellProps<C extends ElementType = ElementType> = {
+  /**
+   * Additional class names for the TableCell.
+   */
+  className?: string;
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   */
+  component?: C;
+} & Omit<MuiTableCellProps, 'td'>;
+
+/**
+ * The TableCell component lets display a cell of the Table
+ *
+ *
+ * API:
+ * - [TableCell API](https://mui.com/material-ui/api/table-cell/)
+ *
+ * @remarks
+ * - ✔️ Props of the native component are also available.
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the TableCell component.
+ * @param ref - The ref to be forwarded to the MuiTableCell component.
+ * @returns The rendered TableCell component.
+ */
+const TableCell: ForwardRefExoticComponent<TableCellProps> = forwardRef(
+  <C extends ElementType = ElementType>(
+    {className, ...rest}: TableCellProps<C>,
+    ref: Ref<HTMLTableCellElement>,
+  ): ReactElement => {
+    const classes: string = clsx('oxygen-table-cell', className);
+
+    return <MuiTableCell ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<TableCellProps>;
+
+export default TableCell;

--- a/packages/react/src/components/TableCell/__tests__/TableCell.test.tsx
+++ b/packages/react/src/components/TableCell/__tests__/TableCell.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import TableCell from '../TableCell';
+
+describe('TableCell', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <TableCell>
+        <p>test TableCell</p>
+      </TableCell>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <TableCell>
+        <p>test TableCell</p>
+      </TableCell>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/TableCell/__tests__/__snapshots__/TableCell.test.tsx.snap
+++ b/packages/react/src/components/TableCell/__tests__/__snapshots__/TableCell.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableCell should match the snapshot 1`] = `
+<body>
+  <div>
+    <td
+      class="MuiTableCell-root MuiTableCell-sizeMedium oxygen-table-cell css-1wbjwh4-MuiTableCell-root"
+    >
+      <p>
+        test TableCell
+      </p>
+    </td>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/TableCell/index.ts
+++ b/packages/react/src/components/TableCell/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './TableCell';
+export * from './TableCell';
+
+export {TableCellPropsSizeOverrides} from '@mui/material/TableCell';
+export {TableCellPropsVariantOverrides} from '@mui/material/TableCell';
+export {SortDirection} from '@mui/material/TableCell';

--- a/packages/react/src/components/TableContainer/TableContainer.stories.mdx
+++ b/packages/react/src/components/TableContainer/TableContainer.stories.mdx
@@ -1,0 +1,73 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import TableContainer from './TableContainer.tsx';
+import TableCell from '../TableCell/TableCell.tsx';
+import TableRow from '../TableRow/TableRow.tsx';
+import Table from '../Table/Table.tsx';
+import Paper from '../Paper/Paper.tsx';
+
+export const meta = {
+  component: TableContainer,
+  title: StoryConfig.TableContainer.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => {
+  return (
+    <TableContainer {...args} component={Paper}>
+      <Table>
+        <TableRow {...args}>
+          <TableCell>
+            Table Cell 1
+          </TableCell>
+          <TableCell>
+            Table Cell 2
+          </TableCell>
+        </TableRow>
+      </Table>
+    </TableContainer>
+  );
+};
+
+# TableContainer
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## TableContainer
+
+The `TableContainer` component is used to define a container for the `Table` component.
+
+<Canvas>
+  <Story name="Overview">
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `TableContainer` component in your components as follows:
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import Paper from '@oxygen-ui/react/Paper';
+import TableContainer from '@oxygen-ui/react/TableContainer';\n
+function Demo {
+  return (
+    <TableContainer component={Paper}>
+      {/** TableContainer content */}
+    </TableContainer>
+  );
+}
+`}
+/>

--- a/packages/react/src/components/TableContainer/TableContainer.tsx
+++ b/packages/react/src/components/TableContainer/TableContainer.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiTableContainer, {
+  TableContainerProps as MuiTableContainerProps,
+  TableContainerTypeMap,
+} from '@mui/material/TableContainer';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ElementType, ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+
+export type TableContainerProps<
+  C extends ElementType = ElementType,
+  D extends ElementType = TableContainerTypeMap['defaultComponent'],
+  P = {},
+> = {
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   */
+  component?: C;
+} & Omit<MuiTableContainerProps<D, P>, 'component'>;
+
+/**
+ * The TableContainer component lets display a container of the table
+ *
+ * Demos:
+ *
+ * - [Table](https://mui.com/material-ui/react-table/)
+ *
+ * API:
+ *
+ * - [TableContainer API](https://mui.com/material-ui/api/table-container/)
+ * @remarks
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the Table component.
+ * @param ref - The ref to be forwarded to the MuiTable component.
+ * @returns The rendered Tablee component.
+ */
+const TableContainer: ForwardRefExoticComponent<TableContainerProps> = forwardRef(
+  <C extends ElementType = ElementType>(
+    {className, ...rest}: TableContainerProps<C>,
+    ref: Ref<HTMLDivElement>,
+  ): ReactElement => {
+    const classes: string = clsx('oxygen-table-container', className);
+
+    return <MuiTableContainer ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<TableContainerProps>;
+
+export default TableContainer;

--- a/packages/react/src/components/TableContainer/__tests__/TableContainer.test.tsx
+++ b/packages/react/src/components/TableContainer/__tests__/TableContainer.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import TableContainer from '../TableContainer';
+
+describe('TableContainer', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <TableContainer>
+        <p>test TableContainer</p>
+      </TableContainer>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <TableContainer>
+        <p>test TableContainer</p>
+      </TableContainer>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/TableContainer/__tests__/__snapshots__/TableContainer.test.tsx.snap
+++ b/packages/react/src/components/TableContainer/__tests__/__snapshots__/TableContainer.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableContainer should match the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiTableContainer-root oxygen-table-container css-rorn0c-MuiTableContainer-root"
+    >
+      <p>
+        test TableContainer
+      </p>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/TableContainer/index.ts
+++ b/packages/react/src/components/TableContainer/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './TableContainer';
+export * from './TableContainer';
+
+export {TableContainerTypeMap} from '@mui/material/TableContainer';

--- a/packages/react/src/components/TableFooter/TableFooter.stories.mdx
+++ b/packages/react/src/components/TableFooter/TableFooter.stories.mdx
@@ -1,0 +1,68 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import TableFooter from './TableFooter.tsx';
+import TableCell from '../TableCell/TableCell.tsx';
+import Table from '../Table/Table.tsx';
+
+export const meta = {
+  component: TableFooter,
+  title: StoryConfig.TableFooter.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => {
+  return (
+    <Table>
+      <TableFooter {...args}>
+        <TableCell>
+          Table Cell 1
+        </TableCell>
+        <TableCell>
+          Table Cell 2
+        </TableCell>
+      </TableFooter>
+    </Table>
+  );
+};
+
+# TableFooter
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## TableFooter
+
+The `TableFooter` component is used to define a footer for the `Table` component.
+
+<Canvas>
+  <Story name="Overview">
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `TableFooter` component in your components as follows:
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import TableFooter from '@oxygen-ui/react/TableFooter';\n
+function Demo {
+  return (
+    <TableFooter>
+      {/** TableFooter content */}
+    </TableFooter>
+  );
+}
+`}
+/>

--- a/packages/react/src/components/TableFooter/TableFooter.tsx
+++ b/packages/react/src/components/TableFooter/TableFooter.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiTableFooter, {TableFooterProps as MuiTableFooterProps, TableFooterTypeMap} from '@mui/material/TableFooter';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ElementType, ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+
+export type TableFooterProps<
+  C extends ElementType = ElementType,
+  D extends ElementType = TableFooterTypeMap['defaultComponent'],
+  P = {},
+> = {
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   */
+  component?: C;
+} & Omit<MuiTableFooterProps<D, P>, 'component'>;
+
+/**
+ * The TableFooter component lets display a footer of the table
+ *
+ *
+ * API:
+ * - [TableFooter API](https://mui.com/material-ui/api/table-footer/)
+ *
+ * @remarks
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the TableFooter component.
+ * @param ref - The ref to be forwarded to the MuiTableFooter component.
+ * @returns The rendered TableFooter component.
+ */
+const TableFooter: ForwardRefExoticComponent<TableFooterProps> = forwardRef(
+  <C extends ElementType = ElementType>(
+    {className, ...rest}: TableFooterProps<C>,
+    ref: Ref<HTMLTableSectionElement>,
+  ): ReactElement => {
+    const classes: string = clsx('oxygen-table-footer', className);
+
+    return <MuiTableFooter ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<TableFooterProps>;
+
+export default TableFooter;

--- a/packages/react/src/components/TableFooter/__tests__/TableFooter.test.tsx
+++ b/packages/react/src/components/TableFooter/__tests__/TableFooter.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import TableFooter from '../TableFooter';
+
+describe('TableFooter', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <TableFooter>
+        <p>test TableFooter</p>
+      </TableFooter>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <TableFooter>
+        <p>test TableFooter</p>
+      </TableFooter>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/TableFooter/__tests__/__snapshots__/TableFooter.test.tsx.snap
+++ b/packages/react/src/components/TableFooter/__tests__/__snapshots__/TableFooter.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableFooter should match the snapshot 1`] = `
+<body>
+  <div>
+    <tfoot
+      class="MuiTableFooter-root oxygen-table-footer css-9cgc89-MuiTableFooter-root"
+    >
+      <p>
+        test TableFooter
+      </p>
+    </tfoot>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/TableFooter/index.ts
+++ b/packages/react/src/components/TableFooter/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './TableFooter';
+export * from './TableFooter';
+
+export {TableFooterTypeMap} from '@mui/material/TableFooter';

--- a/packages/react/src/components/TableHead/TableHead.stories.mdx
+++ b/packages/react/src/components/TableHead/TableHead.stories.mdx
@@ -1,0 +1,67 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import TableHead from './TableHead.tsx';
+import TableRow from '../TableRow/TableRow.tsx';
+import TableCell from '../TableCell/TableCell.tsx';
+
+export const meta = {
+  component: TableHead,
+  title: StoryConfig.TableHead.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => {
+  return (
+    <TableHead {...args}>
+      <TableRow>
+        <TableCell>
+          Table Head Cell 1
+        </TableCell>
+        <TableCell>
+          Table Head Cell 2
+        </TableCell>
+      </TableRow>
+    </TableHead>
+  );
+};
+
+# TableHead
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+The `TableHead` component is used to define the header section within the `Table` component.
+
+<Canvas>
+  <Story name="Overview">
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `TableHead` component in your components as follows:
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import TableHead from '@oxygen-ui/react/TableHead';\n
+function Demo {
+  return (
+    <TableHead>
+      {/** Table Head content */}
+    </TableHead>
+  );
+}`}
+/>

--- a/packages/react/src/components/TableHead/TableHead.tsx
+++ b/packages/react/src/components/TableHead/TableHead.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MuiTableHead, {TableHeadProps as MuiTableHeadProps, TableHeadTypeMap} from '@mui/material/TableHead';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ElementType, ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+import './table-head.scss';
+
+export type TableHeadProps<
+  C extends ElementType = ElementType,
+  D extends ElementType = TableHeadTypeMap['defaultComponent'],
+  P = {},
+> = {
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   */
+  component?: C;
+} & Omit<MuiTableHeadProps<D, P>, 'component'>;
+
+/**
+ * The TableHead component lets display a header of the Table
+ *
+ *
+ * API:
+ * - [TableHead API](https://mui.com/material-ui/api/table-head/)
+ *
+ * @remarks
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the Table component.
+ * @param ref - The ref to be forwarded to the MuiTable component.
+ * @returns The rendered Tablee component.
+ */
+const TableHead: ForwardRefExoticComponent<TableHeadProps> = forwardRef(
+  <C extends ElementType = ElementType>(
+    {className, ...rest}: TableHeadProps<C>,
+    ref: Ref<HTMLTableSectionElement>,
+  ): ReactElement => {
+    const classes: string = clsx('oxygen-table-head', className);
+
+    return <MuiTableHead ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<TableHeadProps>;
+
+export default TableHead;

--- a/packages/react/src/components/TableHead/__tests__/TableHead.test.tsx
+++ b/packages/react/src/components/TableHead/__tests__/TableHead.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import TableHead from '../TableHead';
+
+describe('TableHead', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <TableHead>
+        <p>test TableHead</p>
+      </TableHead>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <TableHead>
+        <p>test TableHead</p>
+      </TableHead>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/TableHead/__tests__/__snapshots__/TableHead.test.tsx.snap
+++ b/packages/react/src/components/TableHead/__tests__/__snapshots__/TableHead.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableHead should match the snapshot 1`] = `
+<body>
+  <div>
+    <thead
+      class="MuiTableHead-root oxygen-table-head css-15wwp11-MuiTableHead-root"
+    >
+      <p>
+        test TableHead
+      </p>
+    </thead>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/TableHead/index.ts
+++ b/packages/react/src/components/TableHead/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './TableHead';
+export * from './TableHead';
+
+export {TableHeadTypeMap} from '@mui/material/TableHead';

--- a/packages/react/src/components/TableHead/table-head.scss
+++ b/packages/react/src/components/TableHead/table-head.scss
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.oxygen-table-head {
+  /** Add Styles */
+  background-color: var(--oxygen-palette-customComponents-Code-background);
+}

--- a/packages/react/src/components/TableRow/TableRow.stories.mdx
+++ b/packages/react/src/components/TableRow/TableRow.stories.mdx
@@ -1,0 +1,68 @@
+import {ArgsTable, Source, Story, Canvas, Meta} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import StoryConfig from '../../../.storybook/story-config.ts';
+import TableRow from './TableRow.tsx';
+import TableCell from '../TableCell/TableCell.tsx';
+import Table from '../Table/Table.tsx';
+
+export const meta = {
+  component: TableRow,
+  title: StoryConfig.TableRow.hierarchy,
+};
+
+<Meta title={meta.title} component={meta.component} />
+
+export const Template = args => {
+  return (
+    <Table>
+      <TableRow {...args}>
+        <TableCell>
+          Table Cell 1
+        </TableCell>
+        <TableCell>
+          Table Cell 2
+        </TableCell>
+      </TableRow>
+    </Table>
+  );
+};
+
+# TableRow
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## TableRow
+
+The `TableRow` component is used to define a row within the `Table` component.
+
+<Canvas>
+  <Story name="Overview">
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable story="Overview" />
+
+## Usage
+
+Import and use the `TableRow` component in your components as follows:
+
+<Source
+  language="jsx"
+  dark
+  format
+  code={dedent`
+import TableRow from '@oxygen-ui/react/TableRow';\n
+function Demo {
+  return (
+    <TableRow>
+      {/** Row content */}
+    </TableRow>
+  );
+}
+`}
+/>

--- a/packages/react/src/components/TableRow/TableRow.tsx
+++ b/packages/react/src/components/TableRow/TableRow.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {styled} from '@mui/material/styles';
+import MuiTableRow, {TableRowProps as MuiTableRowProps, TableRowTypeMap} from '@mui/material/TableRow';
+import clsx from 'clsx';
+import {forwardRef} from 'react';
+import type {ElementType, ForwardRefExoticComponent, ReactElement, Ref} from 'react';
+
+const TableRowWithoutBorder: typeof MuiTableRow = styled(MuiTableRow)(() => ({
+  'td, th': {
+    border: 0,
+  },
+}));
+
+export type TableRowProps<
+  C extends ElementType = ElementType,
+  D extends ElementType = TableRowTypeMap['defaultComponent'],
+  P = {},
+> = {
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   */
+  component?: C;
+  /**
+   * If `true`, the table row will not have a bottom border.
+   * @default false
+   * @optional
+   * @type boolean
+   */
+  hideBorder?: boolean;
+} & Omit<MuiTableRowProps<D, P>, 'component'>;
+
+/**
+ * The TableRow component lets display a row of data
+ *
+ *
+ * API:
+ * - [TableRow API](https://mui.com/material-ui/api/table-row/)
+ *
+ * @remarks
+ * - ✅ `component` prop is supported.
+ * - ✅ The `ref` is forwarded to the root element.
+ *
+ * @template C - The type of the component.
+ * @param props - The props for the Table component.
+ * @param ref - The ref to be forwarded to the MuiTable component.
+ * @returns The rendered Tablee component.
+ */
+const TableRow: ForwardRefExoticComponent<TableRowProps> = forwardRef(
+  <C extends ElementType = ElementType>(
+    {className, hideBorder, ...rest}: TableRowProps<C>,
+    ref: Ref<HTMLTableRowElement>,
+  ): ReactElement => {
+    const classes: string = clsx('oxygen-table-row', className);
+
+    if (hideBorder) {
+      return <TableRowWithoutBorder ref={ref} className={classes} {...rest} />;
+    }
+
+    return <MuiTableRow ref={ref} className={classes} {...rest} />;
+  },
+) as ForwardRefExoticComponent<TableRowProps>;
+
+export default TableRow;

--- a/packages/react/src/components/TableRow/__tests__/TableRow.test.tsx
+++ b/packages/react/src/components/TableRow/__tests__/TableRow.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@unit-testing';
+import TableRow from '../TableRow';
+
+describe('TableRow', () => {
+  it('should render successfully', () => {
+    const {baseElement} = render(
+      <TableRow>
+        <p>test TableRow</p>
+      </TableRow>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('should match the snapshot', () => {
+    const {baseElement} = render(
+      <TableRow>
+        <p>test TableRow</p>
+      </TableRow>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/TableRow/__tests__/__snapshots__/TableRow.test.tsx.snap
+++ b/packages/react/src/components/TableRow/__tests__/__snapshots__/TableRow.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableRow should match the snapshot 1`] = `
+<body>
+  <div>
+    <tr
+      class="MuiTableRow-root oxygen-table-row css-tm3l9i-MuiTableRow-root"
+    >
+      <p>
+        test TableRow
+      </p>
+    </tr>
+  </div>
+</body>
+`;

--- a/packages/react/src/components/TableRow/index.ts
+++ b/packages/react/src/components/TableRow/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {default} from './TableRow';
+export * from './TableRow';
+
+export {TableRowTypeMap} from '@mui/material/TableRow';

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -250,6 +250,27 @@ export * from './Switch';
 export {default as Tab} from './Tab';
 export * from './Tab';
 
+export {default as Table} from './Table';
+export * from './Table';
+
+export {default as TableBody} from './TableBody';
+export * from './TableBody';
+
+export {default as TableCell} from './TableCell';
+export * from './TableCell';
+
+export {default as TableContainer} from './TableContainer';
+export * from './TableContainer';
+
+export {default as TableFooter} from './TableFooter';
+export * from './TableFooter';
+
+export {default as TableHead} from './TableHead';
+export * from './TableHead';
+
+export {default as TableRow} from './TableRow';
+export * from './TableRow';
+
 export {default as TabPanel} from './TabPanel';
 export * from './TabPanel';
 


### PR DESCRIPTION
### Purpose
This PR will add the following components to oxygen-ui

1. Table
2. TableRow
3. TableHead
4. TableBody
5. TableCell
6. TableContainer
7. TableFooter

### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/226
- https://github.com/wso2/oxygen-ui/issues/2

### Related PRs
- N/A

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [x] Story provided. (Add screenshots)
- [x] Manual test round performed and verified.
- [x] Unit tests provided. (Add links if there are any)
- [x] Documentation provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran ESLint & Prettier plugins and verified?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
