### PR TITLE
fix(react): fix `TextField` component to preserve `InputProps`

### DIFF
--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -56,7 +56,7 @@ export type TextFieldProps<C extends ElementType = ElementType> = {
 
 const PasswordField: ForwardRefExoticComponent<TextFieldProps> = forwardRef(
   <C extends ElementType = ElementType>(
-    {type, variant, InputProps = {}, ...rest}: TextFieldProps<C>,
+    {type, variant, InputProps, ...rest}: TextFieldProps<C>,
     ref: Ref<HTMLDivElement>,
   ): ReactElement => {
     const [showPassword, setShowPassword] = useState(false);
@@ -72,8 +72,8 @@ const PasswordField: ForwardRefExoticComponent<TextFieldProps> = forwardRef(
         ref={ref}
         type={showPassword ? 'text' : 'password'}
         InputProps={{
-          ...InputProps,
-          endAdornment: InputProps.endAdornment || (
+          ...(InputProps ?? {}),
+          endAdornment: InputProps?.endAdornment || (
             <InputAdornment position="end">
               <IconButton
                 aria-label="toggle password visibility"

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -56,7 +56,7 @@ export type TextFieldProps<C extends ElementType = ElementType> = {
 
 const PasswordField: ForwardRefExoticComponent<TextFieldProps> = forwardRef(
   <C extends ElementType = ElementType>(
-    {type, variant, ...rest}: TextFieldProps<C>,
+    {type, variant, InputProps = {}, ...rest}: TextFieldProps<C>,
     ref: Ref<HTMLDivElement>,
   ): ReactElement => {
     const [showPassword, setShowPassword] = useState(false);
@@ -72,7 +72,8 @@ const PasswordField: ForwardRefExoticComponent<TextFieldProps> = forwardRef(
         ref={ref}
         type={showPassword ? 'text' : 'password'}
         InputProps={{
-          endAdornment: (
+          ...InputProps,
+          endAdornment: InputProps.endAdornment || (
             <InputAdornment position="end">
               <IconButton
                 aria-label="toggle password visibility"


### PR DESCRIPTION
### Purpose
Currently in the textfield component the `InputProps` are not being preserved, thereby some of the properties such as `readOnly` is lost due to `InputProps` being overridden.  This PR fixes that by spreading input props and conditionally setting `endAdornment`.
 
### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/336

### Related PRs
- None

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [X] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [X] Ran ESLint & Prettier plugins and verified?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
