### PR TITLE
fix(react): expose `DraggableNode` through the public API

### DIFF
--- a/packages/react/src/components/dnd/index.ts
+++ b/packages/react/src/components/dnd/index.ts
@@ -22,6 +22,9 @@ export * from './DnDContext';
 export {default as DnDProvider} from './DnDProvider';
 export * from './DnDProvider';
 
+export {default as DraggableNode} from './DraggableNode';
+export * from './DraggableNode';
+
 export {default as DroppableContainer} from './DroppableContainer';
 export * from './DroppableContainer';
 


### PR DESCRIPTION
### Purpose

This pull request includes changes to the `packages/react/src/components/dnd/index.ts` file to add new exports for the `DraggableNode` component.

Changes to exports:

* [`packages/react/src/components/dnd/index.ts`](diffhunk://#diff-21021a889dca8fb56f924839e13659358461f12cb400644cdfb2551012dc6a6cR25-R27): Added default and named exports for `DraggableNode`.

### Related Issues
- Fixes https://github.com/wso2/oxygen-ui/issues/334

### Related PRs
- https://github.com/wso2/oxygen-ui/pull/315

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran ESLint & Prettier plugins and verified?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
