### PR TITLE
chore: pin node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   },
   "publishConfig": {
     "access": "restricted"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
### Purpose

This PR pins the node version making it easier for developers to setup the oxygen ui project.

### Related Issues
- https://github.com/wso2/oxygen-ui/issues/304

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran ESLint & Prettier plugins and verified?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
