### PR TITLE
ci: update NPM_TOKEN environment variable in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,5 +86,5 @@ jobs:
           version: pnpm run version:packages
           commit: '[Oxygen UI Release] [GitHub Action] [Release] [skip ci] update package versions'
         env:
-          NPM_TOKEN: ${{ env.NPM_TOKEN_WSO2 }}
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ env.GH_TOKEN }}


### PR DESCRIPTION
### Purpose

This pull request includes a minor update to the release workflow configuration. The change updates the environment variable used for the npm authentication token to a more generic value.

* Workflow configuration: Changed the `NPM_TOKEN` environment variable in `.github/workflows/release.yml` from `NPM_TOKEN_WSO2` to `NPM_TOKEN` to standardize the npm authentication process.
### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Figma Board Updated. (Mandatory for Icon and Component PRs. If you don't have access, please ask the core team to update it.)
- [ ] UX/UI review done on the final implementation.
- [ ] Story provided. (Add screenshots)
- [ ] Manual test round performed and verified.
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Documentation provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran ESLint & Prettier plugins and verified?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
