### PR TITLE
Improve ListingTable card variant header visibility in dark mode

### DIFF
--- a/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTable.tsx
+++ b/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTable.tsx
@@ -86,8 +86,13 @@ const StyledTable = styled(MuiTable, {
       backgroundColor: 'transparent',
       borderBottom: 'none',
       fontWeight: 600,
-      color: `${theme.palette.text.primary} !important`,
       padding: '0 16px 8px 16px',
+      ...theme.applyStyles('light', {
+        color: theme.palette.text.secondary,
+      }),
+      ...theme.applyStyles('dark', {
+        color: theme.palette.grey[400],
+      }),
     },
   }),
   // Standard table cell padding based on density

--- a/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableRow.tsx
+++ b/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableRow.tsx
@@ -55,7 +55,7 @@ const StyledTableRow = styled(MuiTableRow, {
     // Card variant specific styles
     ...(variant === 'card' && {
       // Use acrylic background for glassmorphism effect, consistent with MuiCard/MuiPaper
-      backgroundColor: theme.vars?.palette.background.acrylic ?? theme.palette.background.paper,
+      backgroundColor: theme.vars?.palette.background.acrylic ?? (theme.vars || theme).palette.background.paper,
       backdropFilter: theme.blur?.light,
       WebkitBackdropFilter: theme.blur?.light,
       borderRadius,
@@ -77,7 +77,7 @@ const StyledTableRow = styled(MuiTableRow, {
         isDarkMode ? 0.1 : 0.06
       )}`,
       '&:hover': {
-        backgroundColor: theme.palette.action.hover,
+        backgroundColor: (theme.vars || theme).palette.action.hover,
       },
     }),
     // Table variant - remove last child border

--- a/packages/oxygen-ui/src/styles/Themes/OxygenThemeBase.ts
+++ b/packages/oxygen-ui/src/styles/Themes/OxygenThemeBase.ts
@@ -133,6 +133,10 @@ const OxygenThemeBase = extendTheme({
           main: '#ff7300',
           contrastText: '#ffffff',
         },
+        background: {
+          default: '#fafafa',
+          paper: '#ffffff',
+        },
       },
     },
     dark: {
@@ -140,6 +144,10 @@ const OxygenThemeBase = extendTheme({
         primary: {
           main: '#ff7300',
           contrastText: '#ffffff',
+        },
+        background: {
+          default: '#121212',
+          paper: '#121212',
         },
       },
     },


### PR DESCRIPTION
## Summary
- Fix card variant column headers not visible in dark mode across all themes
- Apply proper theme-aware color styling using MUI v7's `applyStyles()` API
- Add defensive theme variable fallbacks in ListingTableRow

## Problem

The ListingTable card variant had poor header visibility in dark mode. Column headers (Name, Type, Status) were nearly invisible because:

1. The styling used `color: theme.palette.text.primary` which resolved at build time rather than runtime
2. MUI v7's CSS variables system requires `theme.applyStyles()` to properly switch colors based on color scheme
3. The `!important` flag prevented CSS cascade flexibility

**Before:**
| Theme | Light Mode | Dark Mode |
|-------|------------|-----------|
| Classic | Visible | Barely visible |
| Acrylic Orange | Visible | Barely visible |
| High Contrast | Visible | Invisible |

## Solution

Used `theme.applyStyles()` to apply mode-specific colors:
- **Light mode**: `text.secondary` - appropriate for secondary UI elements
- **Dark mode**: `grey[400]` (#BDBDBD) - provides good contrast against dark backgrounds

Also added:
- Theme variable fallbacks (`theme.vars || theme`) in ListingTableRow for CSS variables compatibility
- Explicit background color definitions in OxygenThemeBase for both color schemes
