### PR TITLE
Bump package versions to 0.0.1 across multiple packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "name": "@wso2/oxygen-ui-workspace",
-  "version": "0.0.0",
   "description": "WSO2 Oxygen UI | Workspace",
   "files": [
     "packages",

--- a/packages/esbuild-plugin-inline-css-fonts/package.json
+++ b/packages/esbuild-plugin-inline-css-fonts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wso2/esbuild-plugin-inline-css-fonts",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "ESBuild plugin to inline CSS and embed fonts as base64 data URIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-oxygen-ui/package.json
+++ b/packages/eslint-plugin-oxygen-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wso2/eslint-plugin-oxygen-ui",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "ESLint plugin to prevent @mui and lucide-react direct imports in Oxygen UI based projects.",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/oxygen-ui-docs/package.json
+++ b/packages/oxygen-ui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wso2/oxygen-ui-docs",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Documentation site for WSO2 Oxygen UI using Storybook",
   "private": true,
   "type": "module",

--- a/packages/oxygen-ui-icons-react/package.json
+++ b/packages/oxygen-ui-icons-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wso2/oxygen-ui-icons-react",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "WSO2 Oxygen UI Icons - Powered with Lucide icons library",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/oxygen-ui/package.json
+++ b/packages/oxygen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wso2/oxygen-ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "WSO2 Oxygen UI | Design System - Powered with Material-UI component library with TypeScript support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin-oxygen-ui/package.json
+++ b/packages/vite-plugin-oxygen-ui/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@wso2/vite-plugin-oxygen-ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Vite plugin to alias @wso2/oxygen-ui/* imports to @mui/material/* components.",
   "main": "./dist/index.js",
   "type": "module",

--- a/samples/oxygen-ui-test-app/package.json
+++ b/samples/oxygen-ui-test-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@wso2/oxygen-ui-test-app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Purpose

This pull request updates the version numbers for multiple packages in the repository from `0.0.0` to `0.0.1`. This is likely in preparation for an initial release or to indicate that the packages are now ready for publishing beyond the initial development stage.

Version updates across packages:

* Updated the `version` field from `0.0.0` to `0.0.1` in the following package manifests:
  - `packages/esbuild-plugin-inline-css-fonts/package.json`
  - `packages/eslint-plugin-oxygen-ui/package.json`
  - `packages/oxygen-ui-docs/package.json`
  - `packages/oxygen-ui-icons-react/package.json`
  - `packages/oxygen-ui/package.json`
  - `packages/vite-plugin-oxygen-ui/package.json`
  - `samples/oxygen-ui-test-app/package.json`

Other changes:

* Removed the `version` field from the workspace root `package.json` (`@wso2/oxygen-ui-workspace`), likely because workspaces typically do not need a version field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions across the project to reflect the initial release cycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->