### PR TITLE
Bump package versions to 0.1.0-alpha.0

### DIFF
--- a/packages/oxygen-ui-icons-react/package.json
+++ b/packages/oxygen-ui-icons-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wso2/oxygen-ui-icons-react",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "description": "WSO2 Oxygen UI Icons - Powered with Lucide icons library",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/oxygen-ui/package.json
+++ b/packages/oxygen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wso2/oxygen-ui",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "description": "WSO2 Oxygen UI | Design System - Powered with Material-UI component library with TypeScript support",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
# Purpose

This pull request updates the version numbers for two packages to reflect a new pre-release version. There are no other functional or code changes.

- Version bump:
  * Updated `@wso2/oxygen-ui-icons-react` package to version `0.1.0-alpha.0` in `package.json`.
  * Updated `@wso2/oxygen-ui` package to version `0.1.0-alpha.0` in `package.json`.