### PR TITLE
Fix versioning issues

### DIFF
--- a/packages/oxygen-ui-icons-react/package.json
+++ b/packages/oxygen-ui-icons-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wso2/oxygen-ui-icons-react",
-  "version": "0.1.0-alpha.0",
+  "version": "0.0.0",
   "description": "WSO2 Oxygen UI Icons - Powered with Lucide icons library",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/oxygen-ui/package.json
+++ b/packages/oxygen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wso2/oxygen-ui",
-  "version": "0.1.0-alpha.0",
+  "version": "0.0.0",
   "description": "WSO2 Oxygen UI | Design System - Powered with Material-UI component library with TypeScript support",
   "type": "module",
   "main": "./dist/index.js",
@@ -67,6 +67,7 @@
   "homepage": "https://github.com/wso2/oxygen-ui#readme",
   "dependencies": {
     "@fontsource-variable/inter": "5.2.8",
+    "@wso2/oxygen-ui-icons-react": "workspace:*",
     "prismjs": "^1.30.0"
   },
   "peerDependencies": {
@@ -77,7 +78,6 @@
     "@mui/x-data-grid": "catalog:",
     "@mui/x-date-pickers": "catalog:",
     "@mui/x-tree-view": "catalog:",
-    "@wso2/oxygen-ui-icons-react": "workspace:*",
     "date-fns": "4.1.0",
     "react": "catalog:",
     "react-dom": "catalog:"


### PR DESCRIPTION
# Purpose

This pull request updates package versions and adjusts dependencies for the `@wso2/oxygen-ui` and `@wso2/oxygen-ui-icons-react` packages. The most significant changes include resetting package versions to `0.0.0` and moving `@wso2/oxygen-ui-icons-react` from a peer dependency to a regular dependency in `@wso2/oxygen-ui`.

**Version updates:**
* Reset the version of `@wso2/oxygen-ui` to `0.0.0` in `package.json`.
* Reset the version of `@wso2/oxygen-ui-icons-react` to `0.0.0` in `package.json`.

**Dependency management:**
* Added `@wso2/oxygen-ui-icons-react` as a regular dependency in `@wso2/oxygen-ui`'s `package.json` and removed it from `peerDependencies`. [[1]](diffhunk://#diff-4a76caa92680c75f2cedb901f0c08e1bf20adceccdeee0bdaab1ca9ae3ab7078R70) [[2]](diffhunk://#diff-4a76caa92680c75f2cedb901f0c08e1bf20adceccdeee0bdaab1ca9ae3ab7078L80)

# Related Issues
- https://github.com/wso2/oxygen-ui/issues/454
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions from 0.1.0-alpha.0 to 0.0.0
  * Adjusted package dependency structure for improved integration between components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->