### PR TITLE
Change deploy-gh-pages trigger to activate on release workflow

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -1,11 +1,14 @@
 # This workflow will deploy the docs as static content to GitHub Pages
 
-name: ☄️ Deploy Documentation
+name: 📖 Deploy Documentation
 
 on:
   pull_request:
     types: [closed]
     branches: [main]
+    branches-ignore: []
+    # Only trigger for PRs from changeset-release branches
+    paths-ignore: []
 
   workflow_dispatch:
     inputs:
@@ -35,7 +38,7 @@ jobs:
   deploy:
     if: |
       github.event.pull_request.merged == true && 
-      startsWith(github.event.pull_request.title, '[Release] [GitHub Action]') ||
+      contains(github.event.pull_request.head.ref, 'changeset-release') ||
       github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for deploying documentation to GitHub Pages. The main changes clarify the workflow's name and refine the deployment trigger conditions to better target release branches.

Workflow configuration improvements:

* Renamed the workflow to "📖 Deploy Documentation" for clearer identification in the Actions UI.

Trigger condition updates:

* Modified the deployment job condition to trigger on pull requests merged from branches containing "changeset-release" instead of relying on the pull request title, making the release process more robust.
* Added empty `branches-ignore` and `paths-ignore` fields to the `pull_request` trigger to ensure only relevant PRs (specifically from changeset-release branches) initiate the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated deployment trigger conditions for the documentation workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->