### PR TITLE
Add onlyUpdatePeerDependentsWhenOutOfRange:true for changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -23,5 +23,8 @@
   "privatePackages": {
     "version": false,
     "tag": false
+  },
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
   }
 }


### PR DESCRIPTION
This pull request introduces a configuration update to `.changeset/config.json` that enables an experimental option to control how peer dependencies are updated. The change is minor but may affect how dependency updates are handled in future releases.

Configuration update:

* Enabled the `onlyUpdatePeerDependentsWhenOutOfRange` experimental option under `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH`, which restricts peer dependency updates to only when they are out of range. (.changeset/config.json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->