### PR TITLE
Remove workspace:* usage

### DIFF
--- a/packages/oxygen-ui-docs/package.json
+++ b/packages/oxygen-ui-docs/package.json
@@ -22,8 +22,8 @@
     "url": "https://github.com/wso2/oxygen-ui.git"
   },
   "dependencies": {
-    "@wso2/oxygen-ui": "workspace:*",
-    "@wso2/oxygen-ui-icons-react": "workspace:*",
+    "@wso2/oxygen-ui": "workspace:^",
+    "@wso2/oxygen-ui-icons-react": "workspace:^",
     "react-hook-form": "7.62.0",
     "@hookform/resolvers": "5.2.1",
     "zod": "4.0.10"

--- a/packages/oxygen-ui/package.json
+++ b/packages/oxygen-ui/package.json
@@ -90,7 +90,7 @@
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "@vitest/ui": "catalog:",
-    "@wso2/esbuild-plugin-inline-css-fonts": "workspace:*",
+    "@wso2/esbuild-plugin-inline-css-fonts": "workspace:^",
     "esbuild": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,7 @@ importers:
         specifier: 'catalog:'
         version: 4.0.6(vitest@4.0.6)
       '@wso2/esbuild-plugin-inline-css-fonts':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../esbuild-plugin-inline-css-fonts
       esbuild:
         specifier: 'catalog:'
@@ -306,10 +306,10 @@ importers:
         specifier: 5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.2.3))
       '@wso2/oxygen-ui':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../oxygen-ui
       '@wso2/oxygen-ui-icons-react':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../oxygen-ui-icons-react
       react-hook-form:
         specifier: 7.62.0
@@ -443,10 +443,10 @@ importers:
   samples/oxygen-ui-test-app:
     dependencies:
       '@wso2/oxygen-ui':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/oxygen-ui
       '@wso2/oxygen-ui-icons-react':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/oxygen-ui-icons-react
       react:
         specifier: 'catalog:'

--- a/samples/oxygen-ui-test-app/package.json
+++ b/samples/oxygen-ui-test-app/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@wso2/oxygen-ui": "workspace:*",
-    "@wso2/oxygen-ui-icons-react": "workspace:*",
+    "@wso2/oxygen-ui": "workspace:^",
+    "@wso2/oxygen-ui-icons-react": "workspace:^",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-router": "7.9.4"


### PR DESCRIPTION
This pull request updates the workspace dependency specifiers for several internal packages from `workspace:*` to `workspace:^` across multiple `package.json` files and the `pnpm-lock.yaml`. This change ensures that the dependencies resolve to the latest compatible versions within the workspace, improving consistency and maintainability.

**Dependency specifier updates:**

* Changed `@wso2/oxygen-ui` and `@wso2/oxygen-ui-icons-react` dependency specifiers from `workspace:*` to `workspace:^` in `packages/oxygen-ui-docs/package.json` [[1]](diffhunk://#diff-fc1fbf82ae304c3f43d28b4e1126c9b8cdb061ddaa2af639e30e253998e1a933L25-R26) `samples/oxygen-ui-test-app/package.json` [[2]](diffhunk://#diff-3a68e6969a5e46d2289c113db1daae0b6ca986391dd7b298d2ecfb4c7dd29013L13-R14) and in the corresponding sections of `pnpm-lock.yaml` [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL309-R312) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL446-R449).
* Updated `@wso2/esbuild-plugin-inline-css-fonts` dependency specifier from `workspace:*` to `workspace:^` in `packages/oxygen-ui/package.json` [[1]](diffhunk://#diff-4a76caa92680c75f2cedb901f0c08e1bf20adceccdeee0bdaab1ca9ae3ab7078L93-R93) and `pnpm-lock.yaml` [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL221-R221).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workspace dependency version specifiers across multiple packages to refine version resolution and compatibility management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->