### PR TITLE
Update changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,19 +7,19 @@
     }
   ],
   "commit": false,
-  "fixed": [
-    [
-      "@wso2/oxygen-ui",
-      "@wso2/oxygen-ui-icons-react",
-      "@wso2/oxygen-ui-charts-react"
-    ]
-  ],
+  "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
-  "ignore": [],
+  "ignore": [
+    "@wso2/oxygen-ui-docs",
+    "@wso2/oxygen-ui-test-app",
+    "@wso2/vite-plugin-oxygen-ui",
+    "@wso2/esbuild-plugin-inline-css-fonts",
+    "@wso2/eslint-plugin-oxygen-ui"
+  ],
   "privatePackages": {
     "version": false,
     "tag": false


### PR DESCRIPTION
This pull request updates the `.changeset/config.json` configuration to adjust how packages are managed during release workflows. The most important change is that it now ignores several internal or tooling-related packages, and it removes the previous "fixed" group of packages.

Configuration changes:

* Removed the "fixed" group for `@wso2/oxygen-ui`, `@wso2/oxygen-ui-icons-react`, and `@wso2/oxygen-ui-charts-react`, so these packages are no longer versioned together.
* Added multiple packages to the "ignore" list (`@wso2/oxygen-ui-docs`, `@wso2/oxygen-ui-test-app`, `@wso2/vite-plugin-oxygen-ui`, `@wso2/esbuild-plugin-inline-css-fonts`, `@wso2/eslint-plugin-oxygen-ui`), preventing them from being included in release versioning and changelogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->