### PR TITLE
Exposed the `useSidebar` hook from `Sidebar`

### DIFF
--- a/.changeset/early-points-add.md
+++ b/.changeset/early-points-add.md
@@ -1,0 +1,7 @@
+---
+'@wso2/oxygen-ui': patch
+'@wso2/oxygen-ui-charts-react': patch
+'@wso2/oxygen-ui-icons-react': patch
+---
+
+Expose `useSidebar` hook

--- a/packages/oxygen-ui/src/components/index.ts
+++ b/packages/oxygen-ui/src/components/index.ts
@@ -52,7 +52,7 @@ export type {
   HeaderContextValue,
 } from './Header';
 
-export { Sidebar } from './Sidebar';
+export { Sidebar, useSidebar } from './Sidebar';
 export type {
   SidebarProps,
   SidebarNavProps,


### PR DESCRIPTION
This pull request makes a small but important update to the `Sidebar` component exports. The `useSidebar` hook is now exposed from the `Sidebar` module, making it available for use in other parts of the application.

- Exposed the `useSidebar` hook from `Sidebar` by updating the export statement in `packages/oxygen-ui/src/components/index.ts`
- Documented the change and published patch updates for `@wso2/oxygen-ui`, `@wso2/oxygen-ui-charts-react`, and `@wso2/oxygen-ui-icons-react` in `.changeset/early-points-add.md`