### PR TITLE
fix(UserMenu): prevent showName prop from leaking to the DOM

### DIFF
--- a/.changeset/tidy-donuts-repeat.md
+++ b/.changeset/tidy-donuts-repeat.md
@@ -1,0 +1,4 @@
+---
+'@wso2/oxygen-ui': patch
+---
+Fix `showName` prop leaking to the DOM in `UserMenu.Trigger` by filtering it with `shouldForwardProp`

--- a/packages/oxygen-ui/src/components/UserMenu/UserMenuTrigger.tsx
+++ b/packages/oxygen-ui/src/components/UserMenu/UserMenuTrigger.tsx
@@ -38,8 +38,10 @@ export interface UserMenuTriggerProps {
 /**
  * Styled avatar button for the user menu trigger.
  */
-const StyledTrigger = styled(IconButton, {  name: 'MuiUserMenu',
+const StyledTrigger = styled(IconButton, {
+  name: 'MuiUserMenu',
   slot: 'Trigger',
+  shouldForwardProp: (prop) => prop !== 'showName',
 })<{ showName?: boolean }>(({ theme, showName }) => ({
   padding: theme.spacing(0.5),
   gap: theme.spacing(1),


### PR DESCRIPTION
### Purpose

`UserMenu.Trigger` forwards its custom `showName` prop to the underlying DOM element because the `StyledTrigger` styled component (a styled MUI `IconButton`) does not define `shouldForwardProp`. This causes React to log an unknown-prop warning in the console:

```
Warning: React does not recognize the `showName` prop on a DOM element.
```

This PR filters the prop out in the styled call:

```tsx
const StyledTrigger = styled(IconButton, {
  name: 'MuiUserMenu',
  slot: 'Trigger',
  shouldForwardProp: (prop) => prop !== 'showName',
})<{ showName?: boolean }>(...);
```

A patch changeset for `@wso2/oxygen-ui` is included.

### Related Issues

- Fixes #537

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?