### PR TITLE
style: use outlined variant for Cancel buttons in dialogs

### DIFF
--- a/packages/oxygen-ui-docs/stories/AppElements/AppShell.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/AppElements/AppShell.stories.tsx
@@ -774,7 +774,7 @@ export const Playground: Story = {
               </DialogContentText>
             </DialogContent>
             <DialogActions>
-              <Button onClick={() => setConfirmDialogOpen(false)}>Cancel</Button>
+              <Button variant="outlined" onClick={() => setConfirmDialogOpen(false)}>Cancel</Button>
               <Button
                 variant="contained"
                 onClick={() => {
@@ -983,7 +983,11 @@ export const WithConfirmDialog: Story = {
               </DialogContentText>
             </DialogContent>
             <DialogActions>
-              <Button onClick={() => setDialogOpen(false)} disabled={loading}>
+              <Button
+                variant="outlined"
+                onClick={() => setDialogOpen(false)}
+                disabled={loading}
+              >
                 Cancel
               </Button>
               <Button

--- a/packages/oxygen-ui-docs/stories/Feedback/Dialog.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Feedback/Dialog.stories.tsx
@@ -56,8 +56,8 @@ export const Default: Story = {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setOpen(false)}>Cancel</Button>
-            <Button onClick={() => setOpen(false)} variant="contained">
+            <Button variant="outlined" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button variant="contained" onClick={() => setOpen(false)}>
               Confirm
             </Button>
           </DialogActions>
@@ -83,7 +83,7 @@ export const Alert: Story = {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={() => setOpen(false)} variant="outlined">Cancel</Button>
             <Button onClick={() => setOpen(false)} variant="contained" color="error">
               Delete
             </Button>

--- a/packages/oxygen-ui-docs/stories/Utils/Modal.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Utils/Modal.stories.tsx
@@ -106,7 +106,7 @@ export const WithActions: Story = {
               Are you sure you want to proceed with this action?
             </Typography>
             <Box sx={{ mt: 3, display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
-              <Button onClick={() => setOpen(false)}>Cancel</Button>
+              <Button variant="outlined" onClick={() => setOpen(false)}>Cancel</Button>
               <Button variant="contained" onClick={() => setOpen(false)}>
                 Confirm
               </Button>

--- a/samples/oxygen-ui-test-app/src/layouts/AppLayout.tsx
+++ b/samples/oxygen-ui-test-app/src/layouts/AppLayout.tsx
@@ -482,7 +482,12 @@ export default function AppLayout(): JSX.Element {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setConfirmDialogOpen(false)}>Cancel</Button>
+            <Button
+              variant="outlined"
+              onClick={() => setConfirmDialogOpen(false)}
+            >
+              Cancel
+            </Button>
             <Button
               variant="contained"
               onClick={() => {


### PR DESCRIPTION
### Purpose

Cancel actions in dialogs should read as secondary next to primary Confirm/Delete actions. Update Storybook examples (Dialog, Modal, AppShell) and the sample AppLayout confirm dialog so Cancel buttons use `variant="outlined"`.

### Related Issues

- Fixes #536

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?