### PR TITLE
feat(Icons): add search and tags to Icon Gallery

### DIFF
--- a/packages/oxygen-ui-docs/package.json
+++ b/packages/oxygen-ui-docs/package.json
@@ -43,6 +43,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "babel-loader": "10.0.0",
+    "lucide-react": "catalog:",
     "lucide-static": "1.16.0",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/packages/oxygen-ui-docs/package.json
+++ b/packages/oxygen-ui-docs/package.json
@@ -43,6 +43,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "babel-loader": "10.0.0",
+    "lucide-static": "1.16.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "storybook": "10.0.2"

--- a/packages/oxygen-ui-docs/stories/Utils/Icons.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Utils/Icons.stories.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   Box,
@@ -159,6 +159,8 @@ function buildIconCatalog(): IconEntry[] {
 
 const iconCatalog = buildIconCatalog();
 
+const PAGE_SIZE = 120;
+
 const gridSx = {
   display: 'grid',
   gridTemplateColumns: {
@@ -172,11 +174,15 @@ const gridSx = {
 
 function IconGalleryContent() {
   const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query);
   const [selected, setSelected] = useState<IconEntry | null>(null);
   const [copied, setCopied] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const filteredIcons = useMemo(() => {
-    const trimmed = query.trim();
+    const trimmed = deferredQuery.trim();
     if (!trimmed) return iconCatalog;
 
     const lower = trimmed.toLowerCase();
@@ -189,7 +195,39 @@ function IconGalleryContent() {
         (tag) => tag.toLowerCase().includes(lower) || normalizeForSearch(tag).includes(normalized),
       );
     });
-  }, [query]);
+  }, [deferredQuery]);
+
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0;
+    }
+  }, [deferredQuery]);
+
+  const visibleIcons = useMemo(
+    () => filteredIcons.slice(0, visibleCount),
+    [filteredIcons, visibleCount],
+  );
+
+  const hasMore = visibleCount < filteredIcons.length;
+
+  useEffect(() => {
+    const sentinel = loadMoreRef.current;
+    const root = scrollContainerRef.current;
+    if (!sentinel || !root || !hasMore) return undefined;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setVisibleCount((count) => Math.min(count + PAGE_SIZE, filteredIcons.length));
+        }
+      },
+      { root, rootMargin: '200px' },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, filteredIcons.length, visibleIcons.length]);
 
   const importSnippet = selected
     ? `import { ${selected.name} } from '@wso2/oxygen-ui-icons-react';`
@@ -243,7 +281,8 @@ function IconGalleryContent() {
           fullWidth
         />
         <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-          Showing {filteredIcons.length} of {iconCatalog.length} icons
+          Showing {visibleIcons.length} of {filteredIcons.length} matches ({iconCatalog.length}{' '}
+          total)
         </Typography>
       </Box>
 
@@ -254,57 +293,77 @@ function IconGalleryContent() {
           </Typography>
         </Box>
       ) : (
-        <Box sx={gridSx}>
-          {filteredIcons.map((entry) => {
-            const { Icon, name } = entry;
-            return (
-              <Tooltip key={name} title={name} arrow>
-                <Paper
-                  elevation={0}
-                  component="button"
-                  type="button"
-                  onClick={() => {
-                    setSelected(entry);
-                    setCopied(false);
-                  }}
-                  sx={{
-                    p: 2,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: 1,
-                    border: '1px solid',
-                    borderColor: 'divider',
-                    backgroundColor: 'background.paper',
-                    cursor: 'pointer',
-                    font: 'inherit',
-                    color: 'inherit',
-                    transition: 'all 0.2s',
-                    '&:hover': {
-                      borderColor: 'primary.main',
-                      backgroundColor: 'action.hover',
-                      transform: 'translateY(-2px)',
-                    },
-                  }}
-                >
-                  <Icon size={24} />
-                  <Typography
-                    variant="caption"
-                    align="center"
+        <Box
+          ref={scrollContainerRef}
+          sx={{
+            maxHeight: '60vh',
+            overflow: 'auto',
+            pr: 0.5,
+          }}
+        >
+          <Box sx={gridSx}>
+            {visibleIcons.map((entry) => {
+              const { Icon, name } = entry;
+              return (
+                <Tooltip key={name} title={name} arrow>
+                  <Paper
+                    elevation={0}
+                    component="button"
+                    type="button"
+                    onClick={() => {
+                      setSelected(entry);
+                      setCopied(false);
+                    }}
                     sx={{
-                      fontSize: '0.7rem',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      width: '100%',
+                      p: 2,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 1,
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      backgroundColor: 'background.paper',
+                      cursor: 'pointer',
+                      font: 'inherit',
+                      color: 'inherit',
+                      transition: 'all 0.2s',
+                      '&:hover': {
+                        borderColor: 'primary.main',
+                        backgroundColor: 'action.hover',
+                        transform: 'translateY(-2px)',
+                      },
                     }}
                   >
-                    {name}
-                  </Typography>
-                </Paper>
-              </Tooltip>
-            );
-          })}
+                    <Icon size={24} />
+                    <Typography
+                      variant="caption"
+                      align="center"
+                      sx={{
+                        fontSize: '0.7rem',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        width: '100%',
+                      }}
+                    >
+                      {name}
+                    </Typography>
+                  </Paper>
+                </Tooltip>
+              );
+            })}
+          </Box>
+          {hasMore && (
+            <Box
+              ref={loadMoreRef}
+              sx={{ py: 2, textAlign: 'center' }}
+              aria-hidden
+            >
+              <Typography variant="caption" color="text.secondary">
+                Loading more icons…
+              </Typography>
+            </Box>
+          )}
         </Box>
       )}
 

--- a/packages/oxygen-ui-docs/stories/Utils/Icons.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Utils/Icons.stories.tsx
@@ -104,6 +104,8 @@ type IconEntry = {
   tags: string[];
 };
 
+type CopyStatus = 'idle' | 'copied' | 'error';
+
 const NON_ICON_EXPORTS = new Set([
   'Icon',
   'createLucideIcon',
@@ -174,7 +176,7 @@ function IconGalleryContent() {
   const [query, setQuery] = useState('');
   const deferredQuery = useDeferredValue(query);
   const [selected, setSelected] = useState<IconEntry | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
   const [containerWidth, setContainerWidth] = useState(0);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
@@ -250,16 +252,17 @@ function IconGalleryContent() {
     if (!importSnippet) return;
     try {
       await navigator.clipboard.writeText(importSnippet);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
+      setCopyStatus('copied');
+      window.setTimeout(() => setCopyStatus('idle'), 2000);
     } catch {
-      setCopied(false);
+      setCopyStatus('error');
+      window.setTimeout(() => setCopyStatus('idle'), 2000);
     }
   };
 
   const handleClose = () => {
     setSelected(null);
-    setCopied(false);
+    setCopyStatus('idle');
   };
 
   const SelectedIcon = selected?.Icon;
@@ -332,7 +335,7 @@ function IconGalleryContent() {
                   title={name}
                   onClick={() => {
                     setSelected(entry);
-                    setCopied(false);
+                    setCopyStatus('idle');
                   }}
                   sx={{
                     position: 'absolute',
@@ -420,10 +423,23 @@ function IconGalleryContent() {
                 <Button
                   size="small"
                   variant="outlined"
-                  startIcon={copied ? <Check size={16} /> : <Copy size={16} />}
+                  color={copyStatus === 'error' ? 'error' : 'primary'}
+                  startIcon={
+                    copyStatus === 'copied' ? (
+                      <Check size={16} />
+                    ) : copyStatus === 'error' ? (
+                      <X size={16} />
+                    ) : (
+                      <Copy size={16} />
+                    )
+                  }
                   onClick={handleCopy}
                 >
-                  {copied ? 'Copied' : 'Copy'}
+                  {copyStatus === 'copied'
+                    ? 'Copied'
+                    : copyStatus === 'error'
+                      ? 'Copy failed'
+                      : 'Copy'}
                 </Button>
               </Box>
 

--- a/packages/oxygen-ui-docs/stories/Utils/Icons.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Utils/Icons.stories.tsx
@@ -22,7 +22,6 @@ import {
   Box,
   Typography,
   Paper,
-  Tooltip,
   Button,
   SearchBar,
   Dialog,
@@ -159,27 +158,27 @@ function buildIconCatalog(): IconEntry[] {
 
 const iconCatalog = buildIconCatalog();
 
-const PAGE_SIZE = 120;
+/** Matches MUI default breakpoints used by the previous CSS grid. */
+const GAP_PX = 16;
+const ROW_HEIGHT_PX = 96;
+const OVERSCAN_ROWS = 2;
 
-const gridSx = {
-  display: 'grid',
-  gridTemplateColumns: {
-    xs: 'repeat(2, 1fr)',
-    sm: 'repeat(3, 1fr)',
-    md: 'repeat(4, 1fr)',
-    lg: 'repeat(6, 1fr)',
-  },
-  gap: 2,
-} as const;
+function getColumnCount(width: number): number {
+  if (width >= 1200) return 6;
+  if (width >= 900) return 4;
+  if (width >= 600) return 3;
+  return 2;
+}
 
 function IconGalleryContent() {
   const [query, setQuery] = useState('');
   const deferredQuery = useDeferredValue(query);
   const [selected, setSelected] = useState<IconEntry | null>(null);
   const [copied, setCopied] = useState(false);
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-  const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const filteredIcons = useMemo(() => {
     const trimmed = deferredQuery.trim();
@@ -198,36 +197,50 @@ function IconGalleryContent() {
   }, [deferredQuery]);
 
   useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
+    setScrollTop(0);
     if (scrollContainerRef.current) {
       scrollContainerRef.current.scrollTop = 0;
     }
   }, [deferredQuery]);
 
-  const visibleIcons = useMemo(
-    () => filteredIcons.slice(0, visibleCount),
-    [filteredIcons, visibleCount],
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return undefined;
+
+    const updateSize = () => {
+      setContainerWidth(el.clientWidth);
+      setViewportHeight(el.clientHeight);
+    };
+
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [filteredIcons.length]);
+
+  const columnCount = containerWidth > 0 ? getColumnCount(containerWidth) : 6;
+  const rowCount = Math.ceil(filteredIcons.length / columnCount);
+  const totalHeight = rowCount * ROW_HEIGHT_PX;
+
+  const startRow = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT_PX) - OVERSCAN_ROWS);
+  const endRow = Math.min(
+    rowCount,
+    Math.ceil((scrollTop + viewportHeight) / ROW_HEIGHT_PX) + OVERSCAN_ROWS,
   );
 
-  const hasMore = visibleCount < filteredIcons.length;
+  const visibleCells = useMemo(() => {
+    const cells: { entry: IconEntry; row: number; col: number }[] = [];
+    for (let row = startRow; row < endRow; row += 1) {
+      for (let col = 0; col < columnCount; col += 1) {
+        const index = row * columnCount + col;
+        if (index >= filteredIcons.length) break;
+        cells.push({ entry: filteredIcons[index], row, col });
+      }
+    }
+    return cells;
+  }, [startRow, endRow, columnCount, filteredIcons]);
 
-  useEffect(() => {
-    const sentinel = loadMoreRef.current;
-    const root = scrollContainerRef.current;
-    if (!sentinel || !root || !hasMore) return undefined;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          setVisibleCount((count) => Math.min(count + PAGE_SIZE, filteredIcons.length));
-        }
-      },
-      { root, rootMargin: '200px' },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [hasMore, filteredIcons.length, visibleIcons.length]);
+  const cellWidthPercent = 100 / columnCount;
 
   const importSnippet = selected
     ? `import { ${selected.name} } from '@wso2/oxygen-ui-icons-react';`
@@ -281,8 +294,7 @@ function IconGalleryContent() {
           fullWidth
         />
         <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-          Showing {visibleIcons.length} of {filteredIcons.length} matches ({iconCatalog.length}{' '}
-          total)
+          Showing {filteredIcons.length} of {iconCatalog.length} icons
         </Typography>
       </Box>
 
@@ -295,75 +307,76 @@ function IconGalleryContent() {
       ) : (
         <Box
           ref={scrollContainerRef}
+          onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
           sx={{
             maxHeight: '60vh',
             overflow: 'auto',
             pr: 0.5,
           }}
         >
-          <Box sx={gridSx}>
-            {visibleIcons.map((entry) => {
+          <Box
+            sx={{
+              position: 'relative',
+              height: totalHeight,
+              width: '100%',
+            }}
+          >
+            {visibleCells.map(({ entry, row, col }) => {
               const { Icon, name } = entry;
               return (
-                <Tooltip key={name} title={name} arrow>
-                  <Paper
-                    elevation={0}
-                    component="button"
-                    type="button"
-                    onClick={() => {
-                      setSelected(entry);
-                      setCopied(false);
-                    }}
+                <Paper
+                  key={name}
+                  elevation={0}
+                  component="button"
+                  type="button"
+                  title={name}
+                  onClick={() => {
+                    setSelected(entry);
+                    setCopied(false);
+                  }}
+                  sx={{
+                    position: 'absolute',
+                    top: row * ROW_HEIGHT_PX,
+                    left: `calc(${col * cellWidthPercent}% + ${GAP_PX / 2}px)`,
+                    width: `calc(${cellWidthPercent}% - ${GAP_PX}px)`,
+                    height: ROW_HEIGHT_PX - GAP_PX,
+                    p: 2,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 1,
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    backgroundColor: 'background.paper',
+                    cursor: 'pointer',
+                    font: 'inherit',
+                    color: 'inherit',
+                    transition: 'border-color 0.15s, background-color 0.15s',
+                    '&:hover': {
+                      borderColor: 'primary.main',
+                      backgroundColor: 'action.hover',
+                    },
+                  }}
+                >
+                  <Icon size={24} />
+                  <Typography
+                    variant="caption"
+                    align="center"
                     sx={{
-                      p: 2,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: 1,
-                      border: '1px solid',
-                      borderColor: 'divider',
-                      backgroundColor: 'background.paper',
-                      cursor: 'pointer',
-                      font: 'inherit',
-                      color: 'inherit',
-                      transition: 'all 0.2s',
-                      '&:hover': {
-                        borderColor: 'primary.main',
-                        backgroundColor: 'action.hover',
-                        transform: 'translateY(-2px)',
-                      },
+                      fontSize: '0.7rem',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      width: '100%',
                     }}
                   >
-                    <Icon size={24} />
-                    <Typography
-                      variant="caption"
-                      align="center"
-                      sx={{
-                        fontSize: '0.7rem',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        width: '100%',
-                      }}
-                    >
-                      {name}
-                    </Typography>
-                  </Paper>
-                </Tooltip>
+                    {name}
+                  </Typography>
+                </Paper>
               );
             })}
           </Box>
-          {hasMore && (
-            <Box
-              ref={loadMoreRef}
-              sx={{ py: 2, textAlign: 'center' }}
-              aria-hidden
-            >
-              <Typography variant="caption" color="text.secondary">
-                Loading more icons…
-              </Typography>
-            </Box>
-          )}
         </Box>
       )}
 

--- a/packages/oxygen-ui-docs/stories/Utils/Icons.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Utils/Icons.stories.tsx
@@ -16,14 +16,27 @@
  * under the License.
  */
 
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Box, Typography, Paper, Tooltip, Button } from '@wso2/oxygen-ui';
-// lucide-react is a direct dependency of @wso2/oxygen-ui-icons-react; version is read from its installed package.json
+import {
+  Box,
+  Typography,
+  Paper,
+  Tooltip,
+  Button,
+  SearchBar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Chip,
+  Stack,
+} from '@wso2/oxygen-ui';
 import lucideReactPkg from 'lucide-react/package.json';
+import lucideTags from 'lucide-static/tags.json';
+import * as OxygenIcons from '@wso2/oxygen-ui-icons-react';
 import {
   Home,
-  User,
   Settings,
   Search,
   Mail,
@@ -56,10 +69,8 @@ import {
   Info,
   CheckCircle,
   XCircle,
-  GitLab,
-  Bitbucket,
-  MCP,
 } from '@wso2/oxygen-ui-icons-react';
+import customKeywords from './icon-keywords.json';
 
 const meta: Meta = {
   title: 'Utils/Icons',
@@ -73,7 +84,10 @@ const meta: Meta = {
           '**Installation:**\n```bash\nnpm install @wso2/oxygen-ui-icons-react\n```\n\n' +
           '**Usage:**\n```tsx\nimport { Home, User, Settings } from "@wso2/oxygen-ui-icons-react";\n\n' +
           '<Home size={24} color="primary" />\n```\n\n' +
-          'For the complete list of available icons, visit [Lucide Icons](https://lucide.dev/icons/).',
+          'Use the **Icon Gallery** story below to search all icons by name or tags ' +
+          '(for example, searching `logout` finds `LogOut`). ' +
+          'Click an icon to see its import snippet and associated tags. ' +
+          'You can also browse the full Lucide set at [lucide.dev/icons](https://lucide.dev/icons/).',
       },
     },
   },
@@ -83,185 +97,291 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
-declare const require: {
-  context(path: string, deep: boolean, filter: RegExp): { keys(): string[]; (id: string): any }
+type IconComponent = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>;
+
+type IconEntry = {
+  Icon: IconComponent;
+  name: string;
+  tags: string[];
 };
 
-// NOTE: This only works with Storybook -> Webpack.
-// If we switch to Vite, we will need to change this to use dynamic imports instead.
-const iconModules = require.context(
-  '../../node_modules/@wso2/oxygen-ui-icons-react/dist/icons',
-  false,
-  /^\.\/[A-Z]\w+\.js$/
-);
+const NON_ICON_EXPORTS = new Set([
+  'Icon',
+  'createLucideIcon',
+  'icons',
+  'default',
+  'LucideProvider',
+  'DynamicIcon',
+]);
 
-const customIconsList: { Icon: React.ComponentType<any>; name: string }[] = iconModules
-  .keys()
-  .sort()
-  .map((key: string) => {
-    const name = key.replace(/^\.\//, '').replace(/\.js$/, '')
-    return { Icon: iconModules(key)[name], name }
-  });
+function kebabToPascal(kebab: string): string {
+  return kebab
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
 
-const featuredBrandIcons = [
-  { Icon: GitLab, name: 'GitLab' },
-  { Icon: Bitbucket, name: 'Bitbucket' },
-  { Icon: MCP, name: 'MCP' },
-];
+function normalizeForSearch(value: string): string {
+  return value.toLowerCase().replace(/[-_\s]/g, '');
+}
 
-const iconsList = [
-  { Icon: Home, name: 'Home' },
-  { Icon: User, name: 'User' },
-  { Icon: Settings, name: 'Settings' },
-  { Icon: Search, name: 'Search' },
-  { Icon: Mail, name: 'Mail' },
-  { Icon: Bell, name: 'Bell' },
-]
+function buildTagMap(): Record<string, string[]> {
+  const map: Record<string, string[]> = {};
 
-export const IconGallery: Story = {
-  render: () => (
+  for (const [kebabName, tags] of Object.entries(lucideTags as Record<string, string[]>)) {
+    map[kebabToPascal(kebabName)] = tags;
+  }
+
+  for (const [name, tags] of Object.entries(customKeywords as Record<string, string[]>)) {
+    map[name] = [...new Set([...(map[name] ?? []), ...tags])];
+  }
+
+  return map;
+}
+
+const tagMap = buildTagMap();
+
+function buildIconCatalog(): IconEntry[] {
+  return Object.entries(OxygenIcons)
+    .filter(([name, value]) => {
+      if (!/^[A-Z]/.test(name)) return false;
+      if (name.endsWith('Icon')) return false;
+      if (NON_ICON_EXPORTS.has(name)) return false;
+      return typeof value === 'function' || (typeof value === 'object' && value !== null);
+    })
+    .map(([name, Icon]) => ({
+      Icon: Icon as IconComponent,
+      name,
+      tags: tagMap[name] ?? [],
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const iconCatalog = buildIconCatalog();
+
+const gridSx = {
+  display: 'grid',
+  gridTemplateColumns: {
+    xs: 'repeat(2, 1fr)',
+    sm: 'repeat(3, 1fr)',
+    md: 'repeat(4, 1fr)',
+    lg: 'repeat(6, 1fr)',
+  },
+  gap: 2,
+} as const;
+
+function IconGalleryContent() {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<IconEntry | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const filteredIcons = useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return iconCatalog;
+
+    const lower = trimmed.toLowerCase();
+    const normalized = normalizeForSearch(trimmed);
+
+    return iconCatalog.filter(({ name, tags }) => {
+      if (name.toLowerCase().includes(lower)) return true;
+      if (normalizeForSearch(name).includes(normalized)) return true;
+      return tags.some(
+        (tag) => tag.toLowerCase().includes(lower) || normalizeForSearch(tag).includes(normalized),
+      );
+    });
+  }, [query]);
+
+  const importSnippet = selected
+    ? `import { ${selected.name} } from '@wso2/oxygen-ui-icons-react';`
+    : '';
+
+  const handleCopy = async () => {
+    if (!importSnippet) return;
+    try {
+      await navigator.clipboard.writeText(importSnippet);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const handleClose = () => {
+    setSelected(null);
+    setCopied(false);
+  };
+
+  const SelectedIcon = selected?.Icon;
+
+  return (
     <Box>
       <Typography variant="h5" gutterBottom>
-        Icons from Lucide Library
+        Icon Gallery
       </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Browse <strong>{iconCatalog.length}</strong> icons from{' '}
+        <strong>lucide-react v{lucideReactPkg.version}</strong> plus Oxygen UI custom icons. Search by
+        name or tags (e.g. <code>logout</code> finds <code>LogOut</code>).
+      </Typography>
+
       <Box
         sx={{
-          mb: 3,
-          px: 2,
+          position: 'sticky',
+          top: 0,
+          zIndex: 1,
+          bgcolor: 'background.paper',
           py: 1.5,
-          borderRadius: 1,
-          bgcolor: 'info.50',
-          border: '1px solid',
-          borderColor: 'info.light',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
+          mb: 2,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
         }}
       >
-        <Typography variant="body2" color="info.dark">
-          Showing <strong>{iconsList.length}</strong> popular icons from{' '}
-          <strong>lucide-react v{lucideReactPkg.version}</strong>. Visit{' '}
-          <a
-            href="https://lucide.dev/icons/"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'inherit', fontWeight: 600, textDecoration: 'underline' }}
-          >
-            lucide.dev/icons
-          </a>{' '}
-          for the complete list of <strong>1000+ icons</strong>.
+        <SearchBar
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search icons by name or tag…"
+          fullWidth
+        />
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+          Showing {filteredIcons.length} of {iconCatalog.length} icons
         </Typography>
-      </Box>
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: {
-            xs: 'repeat(2, 1fr)',
-            sm: 'repeat(3, 1fr)',
-            md: 'repeat(4, 1fr)',
-            lg: 'repeat(6, 1fr)',
-          },
-          gap: 2,
-        }}
-      >
-        {iconsList.map(({ Icon, name }) => (
-          <Tooltip key={name} title={name} arrow>
-            <Paper
-              elevation={0}
-              sx={{
-                p: 2,
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                gap: 1,
-                border: '1px solid',
-                borderColor: 'divider',
-                transition: 'all 0.2s',
-                '&:hover': {
-                  borderColor: 'primary.main',
-                  backgroundColor: 'action.hover',
-                  transform: 'translateY(-2px)',
-                },
-              }}
-            >
-              <Icon size={24} />
-              <Typography
-                variant="caption"
-                align="center"
-                sx={{
-                  fontSize: '0.7rem',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  width: '100%',
-                }}
-              >
-                {name}
-              </Typography>
-            </Paper>
-          </Tooltip>
-        ))}
       </Box>
 
-      <Box sx={{ mt: 6 }}>
-        <Typography variant="h5" gutterBottom>
-          Custom Icons
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          Custom SVG icons bundled with Oxygen UI Icons React, not part of the Lucide library.
-        </Typography>
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: {
-              xs: 'repeat(2, 1fr)',
-              sm: 'repeat(3, 1fr)',
-              md: 'repeat(5, 1fr)',
-            },
-            gap: 2,
-          }}
-        >
-          {customIconsList.map(({ Icon, name }) => (
-            <Tooltip key={name} title={name} arrow>
-              <Paper
-                elevation={0}
-                sx={{
-                  p: 2,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  gap: 1,
-                  border: '1px solid',
-                  borderColor: 'divider',
-                  transition: 'all 0.2s',
-                  '&:hover': {
-                    borderColor: 'primary.main',
-                    backgroundColor: 'action.hover',
-                    transform: 'translateY(-2px)',
-                  },
-                }}
-              >
-                <Icon size={24} />
-                <Typography
-                  variant="caption"
-                  align="center"
+      {filteredIcons.length === 0 ? (
+        <Box sx={{ py: 8, textAlign: 'center' }}>
+          <Typography variant="body1" color="text.secondary">
+            No icons match &ldquo;{query.trim()}&rdquo;. Try a different name or tag.
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={gridSx}>
+          {filteredIcons.map((entry) => {
+            const { Icon, name } = entry;
+            return (
+              <Tooltip key={name} title={name} arrow>
+                <Paper
+                  elevation={0}
+                  component="button"
+                  type="button"
+                  onClick={() => {
+                    setSelected(entry);
+                    setCopied(false);
+                  }}
                   sx={{
-                    fontSize: '0.7rem',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    width: '100%',
+                    p: 2,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 1,
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    backgroundColor: 'background.paper',
+                    cursor: 'pointer',
+                    font: 'inherit',
+                    color: 'inherit',
+                    transition: 'all 0.2s',
+                    '&:hover': {
+                      borderColor: 'primary.main',
+                      backgroundColor: 'action.hover',
+                      transform: 'translateY(-2px)',
+                    },
                   }}
                 >
-                  {name}
-                </Typography>
-              </Paper>
-            </Tooltip>
-          ))}
+                  <Icon size={24} />
+                  <Typography
+                    variant="caption"
+                    align="center"
+                    sx={{
+                      fontSize: '0.7rem',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      width: '100%',
+                    }}
+                  >
+                    {name}
+                  </Typography>
+                </Paper>
+              </Tooltip>
+            );
+          })}
         </Box>
-      </Box>
+      )}
+
+      <Dialog open={selected !== null} onClose={handleClose} maxWidth="sm" fullWidth>
+        {selected && SelectedIcon && (
+          <>
+            <DialogTitle>{selected.name}</DialogTitle>
+            <DialogContent dividers>
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+                <SelectedIcon size={64} />
+              </Box>
+
+              <Typography variant="subtitle2" gutterBottom>
+                Import
+              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  mb: 3,
+                  p: 1.5,
+                  borderRadius: 1,
+                  bgcolor: 'action.hover',
+                  border: '1px solid',
+                  borderColor: 'divider',
+                }}
+              >
+                <Typography
+                  component="code"
+                  variant="body2"
+                  sx={{
+                    flex: 1,
+                    fontFamily: 'monospace',
+                    fontSize: '0.8rem',
+                    wordBreak: 'break-all',
+                  }}
+                >
+                  {importSnippet}
+                </Typography>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={copied ? <Check size={16} /> : <Copy size={16} />}
+                  onClick={handleCopy}
+                >
+                  {copied ? 'Copied' : 'Copy'}
+                </Button>
+              </Box>
+
+              <Typography variant="subtitle2" gutterBottom>
+                Tags
+              </Typography>
+              {selected.tags.length > 0 ? (
+                <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
+                  {selected.tags.map((tag) => (
+                    <Chip key={tag} label={tag} size="small" variant="outlined" />
+                  ))}
+                </Stack>
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  No tags available for this icon.
+                </Typography>
+              )}
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleClose}>Close</Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
     </Box>
-  ),
+  );
+}
+
+export const IconGallery: Story = {
+  render: () => <IconGalleryContent />,
 };
 
 export const IconSizes: Story = {

--- a/packages/oxygen-ui-docs/stories/Utils/icon-keywords.json
+++ b/packages/oxygen-ui-docs/stories/Utils/icon-keywords.json
@@ -1,0 +1,10 @@
+{
+  "Bitbucket": ["git", "vcs", "source control", "atlassian", "repository"],
+  "Facebook": ["social", "meta", "network", "login", "oauth"],
+  "GitHub": ["git", "vcs", "source control", "octocat", "repository", "microsoft"],
+  "GitLab": ["git", "vcs", "source control", "repository", "ci", "cd"],
+  "Google": ["search", "oauth", "login", "g suite", "workspace"],
+  "Lambda": ["aws", "serverless", "function", "cloud", "faas"],
+  "MCP": ["model context protocol", "ai", "agent", "tool", "llm"],
+  "WSO2": ["identity", "api", "enterprise", "open source", "asgardeo"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       babel-loader:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.28.5)(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
+      lucide-react:
+        specifier: 'catalog:'
+        version: 1.16.0(react@19.2.3)
       lucide-static:
         specifier: 1.16.0
         version: 1.16.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       babel-loader:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.28.5)(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
+      lucide-static:
+        specifier: 1.16.0
+        version: 1.16.0
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -4042,6 +4045,9 @@ packages:
     resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lucide-static@1.16.0:
+    resolution: {integrity: sha512-/EH96rDLRLNKaxuhqHHbmUPx3+qHS/kQRzI1ZGZqnxmh6ljX9yX0xC2UZlQSfBE/n84eNIaxKsv9P8sMiOdCww==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -9218,6 +9224,8 @@ snapshots:
   lucide-react@1.16.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  lucide-static@1.16.0: {}
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
### Purpose

Adds search and tag-based discovery to the Storybook Icon Gallery so consumers can find icons by name or related keywords (for example, searching `logout` finds `LogOut`), and open a dialog with the import snippet and associated tags.

Also builds the catalog from `@wso2/oxygen-ui-icons-react` exports (instead of `require.context`), uses Lucide tags via `lucide-static` plus custom keywords, and virtualizes the grid for smoother scrolling with the full icon set.

### Related Issues

- Fixes #137

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
