### PR TITLE
fix(HeaderToggle): show distinct icons for sidebar expand/collapse

### DIFF
--- a/.changeset/kind-spies-argue.md
+++ b/.changeset/kind-spies-argue.md
@@ -1,0 +1,5 @@
+---
+'@wso2/oxygen-ui': patch
+---
+
+Use distinct default icons in `HeaderToggle` for sidebar expand/collapse (`Menu` when collapsed, `PanelLeftClose` when expanded)

--- a/packages/oxygen-ui-docs/stories/AppElements/Header.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/AppElements/Header.stories.tsx
@@ -126,6 +126,7 @@ export const Default: Story = {
 
 /**
  * Header with sidebar toggle button.
+ * The icon switches between Menu (collapsed) and PanelLeftClose (expanded).
  */
 export const WithToggle: Story = {
   render: () => {

--- a/packages/oxygen-ui/src/components/Header/HeaderToggle.tsx
+++ b/packages/oxygen-ui/src/components/Header/HeaderToggle.tsx
@@ -21,7 +21,7 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { styled } from '@mui/material/styles';
 import type { SxProps, Theme } from '@mui/material/styles';
-import { Menu } from '@wso2/oxygen-ui-icons-react';
+import { Menu, PanelLeftClose } from '@wso2/oxygen-ui-icons-react';
 import { AppShellContext } from '../AppShell/context';
 
 /**
@@ -57,11 +57,11 @@ export interface HeaderToggleProps {
 /**
  * HeaderToggle - Sidebar toggle button for the header.
  *
- * Displays an animated icon that indicates the current sidebar state
+ * Displays an icon that indicates the current sidebar state
  * and toggles between expanded/collapsed states.
  *
  * Custom icons can be provided via `expandIcon` and `collapseIcon` props.
- * If not provided, defaults to Menu icon.
+ * Defaults: `Menu` when collapsed (expand), `PanelLeftClose` when expanded (collapse).
  *
  * Theme tokens used:
  * - `text.secondary` - Icon color
@@ -88,7 +88,7 @@ export const HeaderToggle: React.FC<HeaderToggleProps> = ({
         {collapsed ? (
           expandIcon || <Menu size={20} />
         ) : (
-          collapseIcon || <Menu size={20} />
+          collapseIcon || <PanelLeftClose size={20} />
         )}
       </HeaderToggleRoot>
     </Tooltip>


### PR DESCRIPTION
### Purpose

`HeaderToggle` previously used the same `Menu` icon for both sidebar states, so the control did not communicate that the panel can be collapsed or expanded. It now defaults to `Menu` when the sidebar is collapsed and `PanelLeftClose` when expanded. Custom `expandIcon` / `collapseIcon` overrides are unchanged, and the Storybook `WithToggle` story notes the icon switch.

### Related Issues

- Fixes #149

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

Made with [Cursor](https://cursor.com)