### PR TITLE
feat: add CSP compatibility for OxygenUIThemeProvider and font styles

### DIFF
--- a/.changeset/tidy-shirts-guess.md
+++ b/.changeset/tidy-shirts-guess.md
@@ -6,4 +6,4 @@ Add CSP (Content Security Policy) compatibility (#523)
 
 - `OxygenUIThemeProvider` now accepts a `nonce` prop that applies a CSP nonce to all style tags injected by the styling engine (Emotion), and an `emotionCache` prop as a full escape hatch for supplying a custom Emotion cache (cache key, insertion point, stylis plugins, containers, SSR caches).
 - Re-export `createEmotionCache` and the `EmotionCache` type from `@emotion/cache` so consumers can build custom caches without an extra dependency.
-- The bundled Inter font styles (injected at import time) now resolve a nonce from the `__webpack_nonce__` global (webpack), a `<meta property="csp-nonce">` tag (Vite), or a `<meta name="csp-nonce" content="...">` tag (MUI/Next).
+- The bundled CSS injected at import time (Inter font styles and theme CSS) now resolves a nonce from the `__webpack_nonce__` global (webpack), a `<meta property="csp-nonce">` tag (Vite), or a `<meta name="csp-nonce" content="...">` tag (MUI/Next). The nonce source must be present before the app bundle executes. Since fonts are embedded as base64 data URIs, CSPs must also allow `font-src 'self' data:`.

--- a/.changeset/tidy-shirts-guess.md
+++ b/.changeset/tidy-shirts-guess.md
@@ -6,4 +6,4 @@ Add CSP (Content Security Policy) compatibility (#523)
 
 - `OxygenUIThemeProvider` now accepts a `nonce` prop that applies a CSP nonce to all style tags injected by the styling engine (Emotion), and an `emotionCache` prop as a full escape hatch for supplying a custom Emotion cache (cache key, insertion point, stylis plugins, containers, SSR caches).
 - Re-export `createEmotionCache` and the `EmotionCache` type from `@emotion/cache` so consumers can build custom caches without an extra dependency.
-- The bundled Inter font styles (injected at import time) now resolve a nonce from the `__webpack_nonce__` global (webpack convention) or a `<meta property="csp-nonce" nonce="...">` tag (Vite convention).
+- The bundled Inter font styles (injected at import time) now resolve a nonce from the `__webpack_nonce__` global (webpack), a `<meta property="csp-nonce">` tag (Vite), or a `<meta name="csp-nonce" content="...">` tag (MUI/Next).

--- a/.changeset/tidy-shirts-guess.md
+++ b/.changeset/tidy-shirts-guess.md
@@ -1,0 +1,9 @@
+---
+'@wso2/oxygen-ui': minor
+---
+
+Add CSP (Content Security Policy) compatibility (#523)
+
+- `OxygenUIThemeProvider` now accepts a `nonce` prop that applies a CSP nonce to all style tags injected by the styling engine (Emotion), and an `emotionCache` prop as a full escape hatch for supplying a custom Emotion cache (cache key, insertion point, stylis plugins, containers, SSR caches).
+- Re-export `createEmotionCache` and the `EmotionCache` type from `@emotion/cache` so consumers can build custom caches without an extra dependency.
+- The bundled Inter font styles (injected at import time) now resolve a nonce from the `__webpack_nonce__` global (webpack convention) or a `<meta property="csp-nonce" nonce="...">` tag (Vite convention).

--- a/packages/esbuild-plugin-inline-css-fonts/README.md
+++ b/packages/esbuild-plugin-inline-css-fonts/README.md
@@ -67,16 +67,20 @@ esbuild.build({
 
 ## Content Security Policy (CSP)
 
-If the consuming application enforces a strict `style-src` CSP directive, the injected `<style>` tag needs a nonce. Because injection happens at module load time (before any framework renders), the nonce is resolved from well-known conventions, in order:
+If the consuming application enforces a strict `style-src` / `style-src-elem` CSP directive, the injected `<style>` tag needs a nonce. Because injection happens at module load time (before any framework renders), the nonce is resolved from well-known conventions, in order:
 
 1. The `__webpack_nonce__` global ([webpack convention](https://webpack.js.org/guides/csp/))
-2. A `<meta property="csp-nonce" nonce="...">` tag in the document ([Vite convention](https://vite.dev/guide/features.html#content-security-policy-csp))
+2. A `<meta property="csp-nonce" nonce="...">` tag in the document ([Vite convention](https://vite.dev/guide/features.html#content-security-policy-csp)); `content` is also accepted as a fallback
+3. A `<meta name="csp-nonce" content="...">` tag ([MUI / Next.js convention](https://mui.com/material-ui/guides/content-security-policy/))
 
-If neither is present, the style tag is injected without a nonce (unchanged behavior).
+If none are present, the style tag is injected without a nonce (unchanged behavior).
 
 ```html
-<!-- Server-rendered HTML -->
+<!-- Vite convention -->
 <meta property="csp-nonce" nonce="YOUR_SERVER_GENERATED_NONCE" />
+
+<!-- MUI / Next.js convention -->
+<meta name="csp-nonce" content="YOUR_SERVER_GENERATED_NONCE" />
 ```
 
 ## Example

--- a/packages/esbuild-plugin-inline-css-fonts/README.md
+++ b/packages/esbuild-plugin-inline-css-fonts/README.md
@@ -75,6 +75,8 @@ If the consuming application enforces a strict `style-src` / `style-src-elem` CS
 
 If none are present, the style tag is injected without a nonce (unchanged behavior).
 
+Because the nonce is read at module evaluation time, the meta tag (or the `__webpack_nonce__` assignment) must already be present in the document before the bundle executes — a meta tag added later from JavaScript results in a style tag without a nonce.
+
 ```html
 <!-- Vite convention -->
 <meta property="csp-nonce" nonce="YOUR_SERVER_GENERATED_NONCE" />
@@ -82,6 +84,8 @@ If none are present, the style tag is injected without a nonce (unchanged behavi
 <!-- MUI / Next.js convention -->
 <meta name="csp-nonce" content="YOUR_SERVER_GENERATED_NONCE" />
 ```
+
+Since fonts are embedded as base64 `data:` URIs, the CSP must also allow them via `font-src`, e.g. `font-src 'self' data:;` — otherwise `font-src` falls back to `default-src 'self'` and the browser blocks the embedded fonts even when the style tag itself is allowed.
 
 ## Example
 

--- a/packages/esbuild-plugin-inline-css-fonts/README.md
+++ b/packages/esbuild-plugin-inline-css-fonts/README.md
@@ -7,6 +7,7 @@ ESBuild plugin to inline CSS and embed fonts as base64 data URIs.
 - ✅ Resolves CSS `@import` statements (including from node_modules)
 - ✅ Converts font file references to base64 data URIs
 - ✅ Injects CSS as a `<style>` tag at runtime
+- ✅ CSP-compatible: applies a nonce to the injected style tag when available
 - ✅ Supports `.woff`, `.woff2`, `.ttf`, `.otf`, and `.eot` font formats
 - ✅ Zero configuration required
 - ✅ TypeScript support
@@ -63,6 +64,20 @@ esbuild.build({
 1. **CSS Resolution**: The plugin intercepts CSS imports and resolves `@import` statements recursively, including imports from `node_modules`
 2. **Font Embedding**: All font file references (`url(...)`) are converted to base64 data URIs
 3. **Runtime Injection**: The processed CSS is converted to JavaScript that creates and injects a `<style>` tag when the module loads
+
+## Content Security Policy (CSP)
+
+If the consuming application enforces a strict `style-src` CSP directive, the injected `<style>` tag needs a nonce. Because injection happens at module load time (before any framework renders), the nonce is resolved from well-known conventions, in order:
+
+1. The `__webpack_nonce__` global ([webpack convention](https://webpack.js.org/guides/csp/))
+2. A `<meta property="csp-nonce" nonce="...">` tag in the document ([Vite convention](https://vite.dev/guide/features.html#content-security-policy-csp))
+
+If neither is present, the style tag is injected without a nonce (unchanged behavior).
+
+```html
+<!-- Server-rendered HTML -->
+<meta property="csp-nonce" nonce="YOUR_SERVER_GENERATED_NONCE" />
+```
 
 ## Example
 

--- a/packages/esbuild-plugin-inline-css-fonts/package.json
+++ b/packages/esbuild-plugin-inline-css-fonts/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "esbuild",
@@ -35,6 +37,8 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "esbuild": "catalog:",
-    "typescript": "catalog:"
+    "jsdom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/esbuild-plugin-inline-css-fonts/src/index.test.ts
+++ b/packages/esbuild-plugin-inline-css-fonts/src/index.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import * as esbuild from 'esbuild';
+import { inlineCSSFontsPlugin } from './index';
+
+async function buildCssInjectionScript(css: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), 'inline-css-fonts-'));
+  const entry = join(dir, 'entry.css');
+  writeFileSync(entry, css, 'utf8');
+
+  try {
+    const result = await esbuild.build({
+      entryPoints: [entry],
+      bundle: true,
+      write: false,
+      plugins: [inlineCSSFontsPlugin({ verbose: false })],
+    });
+
+    const js = result.outputFiles?.[0]?.text;
+    if (!js) {
+      throw new Error('esbuild produced no output');
+    }
+    return js;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function runInjection(
+  js: string,
+  options: {
+    webpackNonce?: string;
+    headHtml?: string;
+  } = {}
+): HTMLStyleElement | null {
+  const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>', {
+    runScripts: 'outside-only',
+  });
+  const { window } = dom;
+
+  if (options.headHtml) {
+    window.document.head.innerHTML = options.headHtml;
+  }
+
+  if (options.webpackNonce !== undefined) {
+    (window as unknown as { __webpack_nonce__: string }).__webpack_nonce__ = options.webpackNonce;
+  }
+
+  // Evaluate the generated IIFE against this document.
+  window.eval(js);
+
+  return window.document.querySelector<HTMLStyleElement>('style[data-inline-css="true"]');
+}
+
+describe('inlineCSSFontsPlugin CSP nonce resolution', () => {
+  it('injects styles without a nonce when no source is present', async () => {
+    const js = await buildCssInjectionScript('.root { color: red; }');
+    const style = runInjection(js);
+
+    expect(style).not.toBeNull();
+    expect(style?.textContent).toContain('color: red');
+    expect(style?.getAttribute('nonce')).toBeNull();
+  });
+
+  it('applies nonce from __webpack_nonce__', async () => {
+    const js = await buildCssInjectionScript('.root { color: blue; }');
+    const style = runInjection(js, { webpackNonce: 'webpack-nonce-123' });
+
+    expect(style).not.toBeNull();
+    expect(style?.getAttribute('nonce')).toBe('webpack-nonce-123');
+  });
+
+  it('applies nonce from Vite meta[property="csp-nonce"]', async () => {
+    const js = await buildCssInjectionScript('.root { color: green; }');
+    const style = runInjection(js, {
+      headHtml: '<meta property="csp-nonce" nonce="vite-nonce-456" />',
+    });
+
+    expect(style).not.toBeNull();
+    expect(style?.getAttribute('nonce')).toBe('vite-nonce-456');
+  });
+
+  it('applies nonce from MUI/Next meta[name="csp-nonce"] content', async () => {
+    const js = await buildCssInjectionScript('.root { color: purple; }');
+    const style = runInjection(js, {
+      headHtml: '<meta name="csp-nonce" content="mui-nonce-789" />',
+    });
+
+    expect(style).not.toBeNull();
+    expect(style?.getAttribute('nonce')).toBe('mui-nonce-789');
+  });
+
+  it('prefers __webpack_nonce__ over meta tags', async () => {
+    const js = await buildCssInjectionScript('.root { color: orange; }');
+    const style = runInjection(js, {
+      webpackNonce: 'webpack-wins',
+      headHtml: '<meta name="csp-nonce" content="mui-ignored" />',
+    });
+
+    expect(style?.getAttribute('nonce')).toBe('webpack-wins');
+  });
+});

--- a/packages/esbuild-plugin-inline-css-fonts/src/index.ts
+++ b/packages/esbuild-plugin-inline-css-fonts/src/index.ts
@@ -43,6 +43,8 @@ export interface InlineCSSFontsOptions {
  * - Resolves CSS imports (including @import statements)
  * - Converts font file references to base64 data URIs
  * - Injects CSS as a style tag at runtime
+ * - Applies a CSP nonce to the injected style tag when available, resolved
+ *   from `__webpack_nonce__` or `<meta property="csp-nonce" nonce="...">`
  * 
  * @example
  * ```ts
@@ -128,12 +130,32 @@ export function inlineCSSFontsPlugin(options: InlineCSSFontsOptions = {}): Plugi
           }
         });
 
-        // Convert CSS to JS that injects a style tag
+        // Convert CSS to JS that injects a style tag.
+        // For CSP (Content Security Policy) support, a nonce is resolved at
+        // injection time from the `__webpack_nonce__` global (webpack
+        // convention) or a `<meta property="csp-nonce" nonce="...">` tag
+        // (Vite convention) and applied to the style element.
         const jsCode = `
 (function() {
   if (typeof document !== 'undefined') {
     const style = document.createElement('style');
     style.setAttribute('${styleAttribute}', 'true');
+    let nonce;
+    try {
+      if (typeof __webpack_nonce__ !== 'undefined' && __webpack_nonce__) {
+        nonce = __webpack_nonce__;
+      } else {
+        const meta = document.querySelector('meta[property="csp-nonce"]');
+        if (meta) {
+          nonce = meta.nonce || meta.getAttribute('nonce');
+        }
+      }
+    } catch (e) {
+      // Nonce resolution must never break style injection
+    }
+    if (nonce) {
+      style.setAttribute('nonce', nonce);
+    }
     style.textContent = ${JSON.stringify(css)};
     document.head.appendChild(style);
   }

--- a/packages/esbuild-plugin-inline-css-fonts/src/index.ts
+++ b/packages/esbuild-plugin-inline-css-fonts/src/index.ts
@@ -44,7 +44,8 @@ export interface InlineCSSFontsOptions {
  * - Converts font file references to base64 data URIs
  * - Injects CSS as a style tag at runtime
  * - Applies a CSP nonce to the injected style tag when available, resolved
- *   from `__webpack_nonce__` or `<meta property="csp-nonce" nonce="...">`
+ *   from `__webpack_nonce__`, `<meta property="csp-nonce">` (Vite), or
+ *   `<meta name="csp-nonce">` (MUI/Next)
  * 
  * @example
  * ```ts
@@ -132,9 +133,10 @@ export function inlineCSSFontsPlugin(options: InlineCSSFontsOptions = {}): Plugi
 
         // Convert CSS to JS that injects a style tag.
         // For CSP (Content Security Policy) support, a nonce is resolved at
-        // injection time from the `__webpack_nonce__` global (webpack
-        // convention) or a `<meta property="csp-nonce" nonce="...">` tag
-        // (Vite convention) and applied to the style element.
+        // injection time from well-known conventions (in order):
+        // 1. `__webpack_nonce__` (webpack)
+        // 2. `<meta property="csp-nonce">` (Vite)
+        // 3. `<meta name="csp-nonce">` (MUI/Next)
         const jsCode = `
 (function() {
   if (typeof document !== 'undefined') {
@@ -145,9 +147,15 @@ export function inlineCSSFontsPlugin(options: InlineCSSFontsOptions = {}): Plugi
       if (typeof __webpack_nonce__ !== 'undefined' && __webpack_nonce__) {
         nonce = __webpack_nonce__;
       } else {
-        const meta = document.querySelector('meta[property="csp-nonce"]');
-        if (meta) {
-          nonce = meta.nonce || meta.getAttribute('nonce');
+        const viteMeta = document.querySelector('meta[property="csp-nonce"]');
+        if (viteMeta) {
+          nonce = viteMeta.nonce || viteMeta.getAttribute('nonce') || viteMeta.getAttribute('content');
+        }
+        if (!nonce) {
+          const muiMeta = document.querySelector('meta[name="csp-nonce"]');
+          if (muiMeta) {
+            nonce = muiMeta.getAttribute('content');
+          }
         }
       }
     } catch (e) {

--- a/packages/esbuild-plugin-inline-css-fonts/tsconfig.json
+++ b/packages/esbuild-plugin-inline-css-fonts/tsconfig.json
@@ -12,5 +12,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/packages/esbuild-plugin-inline-css-fonts/vitest.config.ts
+++ b/packages/esbuild-plugin-inline-css-fonts/vitest.config.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Node environment is required so esbuild's TextEncoder invariant holds.
+    // Tests create a JSDOM document explicitly when evaluating injection code.
+    environment: 'node',
+  },
+});

--- a/packages/oxygen-ui-docs/stories/Theming/OxygenUIThemeProvider.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Theming/OxygenUIThemeProvider.stories.tsx
@@ -78,11 +78,13 @@ const customTheme = extendTheme({
 \`\`\`
 
 ### Content Security Policy (CSP)
-For applications enforcing a strict \`style-src\` CSP directive, pass a nonce
-(or a custom Emotion cache) so runtime-injected style tags are allowed:
+For applications enforcing a strict CSP, pass a nonce (or a custom Emotion
+cache) so runtime-injected style tags are allowed. Pair with
+\`style-src-elem 'nonce-...'\` and \`style-src-attr 'unsafe-inline'\` as
+recommended by MUI:
 
 \`\`\`tsx
-<OxygenUIThemeProvider nonce={window.__MY_APP_NONCE__}>
+<OxygenUIThemeProvider nonce={serverNonce}>
   <YourApp />
 </OxygenUIThemeProvider>
 \`\`\`
@@ -112,11 +114,11 @@ For applications enforcing a strict \`style-src\` CSP directive, pass a nonce
     },
     nonce: {
       control: 'text',
-      description: 'CSP (Content Security Policy) nonce applied to all style tags injected by the styling engine (Emotion). Use when your application enforces a strict `style-src` CSP directive. Ignored if `emotionCache` is provided.',
+      description: 'CSP (Content Security Policy) nonce applied to all style tags injected by the styling engine (Emotion). Use with style-src-elem nonce and style-src-attr unsafe-inline as recommended by MUI. Ignored if `emotionCache` is provided.',
     },
     emotionCache: {
       control: false,
-      description: 'A custom Emotion cache instance for full control over style injection (cache key, nonce, insertion point, stylis plugins, container). Create one with `createEmotionCache`. Takes precedence over the `nonce` prop.',
+      description: 'A custom Emotion cache instance for full control over style injection (cache key, nonce, insertion point, stylis plugins, container). Create one with `createEmotionCache` and set `prepend: true` to preserve injectFirst cascade. Takes precedence over the `nonce` prop.',
       table: {
         type: { summary: 'EmotionCache' },
       },
@@ -281,24 +283,27 @@ export const ContentSecurityPolicy: Story = {
   render: () => (
     <Stack spacing={2} sx={{ maxWidth: 600 }}>
       <Typography variant="body2" color="text.secondary">
-        Pass your server-generated nonce so runtime-injected style tags satisfy a
-        strict style-src CSP directive. For full control over style injection,
-        pass a custom Emotion cache instead.
+        Pass your server-generated nonce so runtime-injected style tags satisfy
+        style-src-elem. Also allow style-src-attr &apos;unsafe-inline&apos; for MUI
+        inline style attributes. For full control over style injection, pass a
+        custom Emotion cache with prepend: true.
       </Typography>
       <CodeBlock 
         language="tsx"
         code={`import { OxygenUIThemeProvider, createEmotionCache } from "@wso2/oxygen-ui";
 
+// serverNonce is generated per request and must match the CSP header.
 // Option 1: simple - pass the nonce directly
-<OxygenUIThemeProvider nonce={window.__MY_APP_NONCE__}>
+<OxygenUIThemeProvider nonce={serverNonce}>
   <YourApp />
 </OxygenUIThemeProvider>
 
 // Option 2: advanced - pass a custom Emotion cache
 // (full control: key, nonce, insertion point, stylis plugins, ...)
+// prepend: true preserves the previous injectFirst cascade.
 const cache = createEmotionCache({
   key: "css",
-  nonce: window.__MY_APP_NONCE__,
+  nonce: serverNonce,
   prepend: true,
 });
 
@@ -308,8 +313,9 @@ const cache = createEmotionCache({
       />
       <Typography variant="body2" color="text.secondary">
         The bundled Inter font styles are injected at import time, so their nonce
-        is resolved from the __webpack_nonce__ global (webpack) or a
-        {' '}meta[property=&quot;csp-nonce&quot;] tag (Vite convention) instead of a prop.
+        is resolved from the __webpack_nonce__ global (webpack), a
+        {' '}meta[property=&quot;csp-nonce&quot;] tag (Vite), or a
+        {' '}meta[name=&quot;csp-nonce&quot;] tag (MUI/Next) instead of a prop.
       </Typography>
     </Stack>
   ),

--- a/packages/oxygen-ui-docs/stories/Theming/OxygenUIThemeProvider.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Theming/OxygenUIThemeProvider.stories.tsx
@@ -76,6 +76,16 @@ const customTheme = extendTheme({
   <YourApp />
 </OxygenUIThemeProvider>
 \`\`\`
+
+### Content Security Policy (CSP)
+For applications enforcing a strict \`style-src\` CSP directive, pass a nonce
+(or a custom Emotion cache) so runtime-injected style tags are allowed:
+
+\`\`\`tsx
+<OxygenUIThemeProvider nonce={window.__MY_APP_NONCE__}>
+  <YourApp />
+</OxygenUIThemeProvider>
+\`\`\`
         `,
       },
     },
@@ -98,6 +108,17 @@ const customTheme = extendTheme({
       description: 'Callback function triggered after all themes are loaded. Receives an array of loaded themes with their key, label, and theme object. Useful for tracking when dynamically loaded theme files are ready.',
       table: {
         type: { summary: '(themes: LoadedTheme[]) => void' },
+      },
+    },
+    nonce: {
+      control: 'text',
+      description: 'CSP (Content Security Policy) nonce applied to all style tags injected by the styling engine (Emotion). Use when your application enforces a strict `style-src` CSP directive. Ignored if `emotionCache` is provided.',
+    },
+    emotionCache: {
+      control: false,
+      description: 'A custom Emotion cache instance for full control over style injection (cache key, nonce, insertion point, stylis plugins, container). Create one with `createEmotionCache`. Takes precedence over the `nonce` prop.',
+      table: {
+        type: { summary: 'EmotionCache' },
       },
     },
     children: {
@@ -248,6 +269,48 @@ function ThemeInfo() {
   );
 }`}
       />
+    </Stack>
+  ),
+};
+
+/**
+ * Make Oxygen UI compatible with a strict Content Security Policy (CSP)
+ * by passing a nonce or a custom Emotion cache.
+ */
+export const ContentSecurityPolicy: Story = {
+  render: () => (
+    <Stack spacing={2} sx={{ maxWidth: 600 }}>
+      <Typography variant="body2" color="text.secondary">
+        Pass your server-generated nonce so runtime-injected style tags satisfy a
+        strict style-src CSP directive. For full control over style injection,
+        pass a custom Emotion cache instead.
+      </Typography>
+      <CodeBlock 
+        language="tsx"
+        code={`import { OxygenUIThemeProvider, createEmotionCache } from "@wso2/oxygen-ui";
+
+// Option 1: simple - pass the nonce directly
+<OxygenUIThemeProvider nonce={window.__MY_APP_NONCE__}>
+  <YourApp />
+</OxygenUIThemeProvider>
+
+// Option 2: advanced - pass a custom Emotion cache
+// (full control: key, nonce, insertion point, stylis plugins, ...)
+const cache = createEmotionCache({
+  key: "css",
+  nonce: window.__MY_APP_NONCE__,
+  prepend: true,
+});
+
+<OxygenUIThemeProvider emotionCache={cache}>
+  <YourApp />
+</OxygenUIThemeProvider>`}
+      />
+      <Typography variant="body2" color="text.secondary">
+        The bundled Inter font styles are injected at import time, so their nonce
+        is resolved from the __webpack_nonce__ global (webpack) or a
+        {' '}meta[property=&quot;csp-nonce&quot;] tag (Vite convention) instead of a prop.
+      </Typography>
     </Stack>
   ),
 };

--- a/packages/oxygen-ui-docs/stories/Theming/OxygenUIThemeProvider.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Theming/OxygenUIThemeProvider.stories.tsx
@@ -81,7 +81,8 @@ const customTheme = extendTheme({
 For applications enforcing a strict CSP, pass a nonce (or a custom Emotion
 cache) so runtime-injected style tags are allowed. Pair with
 \`style-src-elem 'nonce-...'\` and \`style-src-attr 'unsafe-inline'\` as
-recommended by MUI:
+recommended by MUI, plus \`font-src 'self' data:\` because the bundled Inter
+font is embedded as base64 data URIs:
 
 \`\`\`tsx
 <OxygenUIThemeProvider nonce={serverNonce}>
@@ -285,8 +286,9 @@ export const ContentSecurityPolicy: Story = {
       <Typography variant="body2" color="text.secondary">
         Pass your server-generated nonce so runtime-injected style tags satisfy
         style-src-elem. Also allow style-src-attr &apos;unsafe-inline&apos; for MUI
-        inline style attributes. For full control over style injection, pass a
-        custom Emotion cache with prepend: true.
+        inline style attributes, and font-src &apos;self&apos; data: because the
+        bundled Inter font is embedded as base64 data URIs. For full control over
+        style injection, pass a custom Emotion cache with prepend: true.
       </Typography>
       <CodeBlock 
         language="tsx"
@@ -312,10 +314,11 @@ const cache = createEmotionCache({
 </OxygenUIThemeProvider>`}
       />
       <Typography variant="body2" color="text.secondary">
-        The bundled Inter font styles are injected at import time, so their nonce
-        is resolved from the __webpack_nonce__ global (webpack), a
-        {' '}meta[property=&quot;csp-nonce&quot;] tag (Vite), or a
+        The bundled CSS (Inter font styles and theme CSS) is injected at import
+        time, so its nonce is resolved from the __webpack_nonce__ global
+        (webpack), a {' '}meta[property=&quot;csp-nonce&quot;] tag (Vite), or a
         {' '}meta[name=&quot;csp-nonce&quot;] tag (MUI/Next) instead of a prop.
+        The meta tag (or global) must be present before the app bundle executes.
       </Typography>
     </Stack>
   ),

--- a/packages/oxygen-ui/README.md
+++ b/packages/oxygen-ui/README.md
@@ -311,36 +311,48 @@ function MyComponent() {
 
 ## Content Security Policy (CSP)
 
-Oxygen UI (via MUI and Emotion) injects styles at runtime using `<style>` tags. If your application enforces a strict `style-src` CSP directive, pass a nonce so those tags are allowed.
+Oxygen UI (via MUI and Emotion) injects styles at runtime using `<style>` tags. If your application enforces a strict CSP, pass a nonce so those tags are allowed. Follow the same directives recommended in the [MUI Content Security Policy guide](https://mui.com/material-ui/guides/content-security-policy/):
+
+```text
+Content-Security-Policy:
+  default-src 'self';
+  style-src-elem 'self' 'nonce-<value>';
+  style-src-attr 'unsafe-inline';
+```
+
+- **`style-src-elem`** — Emotion injects `<style>` elements; each needs a matching nonce.
+- **`style-src-attr 'unsafe-inline'`** — MUI components apply dynamic inline `style` attributes (dimensions, CSS custom properties, positioning). Nonces cannot cover style attributes.
+- **`script-src 'nonce-...'`** — Only required if your app uses MUI's `InitColorSchemeScript`. Oxygen UI does not ship that script.
 
 ### Using the `nonce` prop
 
-Pass your server-generated nonce to `OxygenUIThemeProvider`. It is applied to every style tag injected by the styling engine (components, `CssBaseline`, theme styles):
+Pass your server-generated nonce to `OxygenUIThemeProvider`. It is applied to every style tag injected by the styling engine (components, `CssBaseline`, theme styles). The value must match the nonce in your CSP header:
 
 ```typescript
 import { OxygenUIThemeProvider } from '@wso2/oxygen-ui';
 
-function App() {
+// `serverNonce` is generated per request on the server and must match the CSP header.
+function App({ serverNonce }: { serverNonce: string }) {
   return (
-    <OxygenUIThemeProvider nonce={window.__MY_APP_NONCE__}>
+    <OxygenUIThemeProvider nonce={serverNonce}>
       <YourApp />
     </OxygenUIThemeProvider>
   );
 }
 ```
 
-The nonce must match the one in your CSP header, e.g. `Content-Security-Policy: style-src 'self' 'nonce-<value>'`.
-
 ### Using a custom Emotion cache
 
-For full control over style injection (cache key, insertion point, stylis plugins, shadow DOM containers, SSR caches), pass a custom Emotion cache. `createEmotionCache` is re-exported from `@emotion/cache` for convenience:
+For full control over style injection (cache key, insertion point, stylis plugins, shadow DOM containers, SSR caches), pass a custom Emotion cache. `createEmotionCache` is re-exported from `@emotion/cache` for convenience.
+
+Set `prepend: true` to preserve the previous `injectFirst` cascade (application styles can override Oxygen UI styles). Omitting it changes style order.
 
 ```typescript
 import { OxygenUIThemeProvider, createEmotionCache } from '@wso2/oxygen-ui';
 
 const cache = createEmotionCache({
   key: 'css',
-  nonce: window.__MY_APP_NONCE__,
+  nonce: serverNonce,
   prepend: true,
 });
 
@@ -355,16 +367,24 @@ function App() {
 
 `emotionCache` takes precedence over `nonce` if both are provided.
 
+### Server-side rendering (SSR)
+
+Generate a unique nonce per request on the server, include it in the CSP header, and pass the same value to `OxygenUIThemeProvider` via `nonce` or a shared `emotionCache` on both server and client. Keep server and client Emotion caches aligned (same key, nonce, and insertion options). See the [MUI CSP guide](https://mui.com/material-ui/guides/content-security-policy/) for framework-specific examples (Next.js, Vite, and Emotion SSR).
+
 ### Bundled fonts
 
 The Inter Variable font styles are injected as a separate `<style>` tag when the package is imported (before React renders), so the nonce for that tag is resolved from well-known conventions instead of a prop:
 
 1. The `__webpack_nonce__` global ([webpack convention](https://webpack.js.org/guides/csp/))
-2. A `<meta property="csp-nonce" nonce="...">` tag in the document ([Vite convention](https://vite.dev/guide/features.html#content-security-policy-csp))
+2. A `<meta property="csp-nonce" nonce="...">` tag ([Vite convention](https://vite.dev/guide/features.html#content-security-policy-csp)); `content` is also accepted as a fallback
+3. A `<meta name="csp-nonce" content="...">` tag ([MUI / Next.js convention](https://mui.com/material-ui/guides/content-security-policy/))
 
 ```html
-<!-- Server-rendered HTML -->
+<!-- Vite convention -->
 <meta property="csp-nonce" nonce="YOUR_SERVER_GENERATED_NONCE" />
+
+<!-- MUI / Next.js convention -->
+<meta name="csp-nonce" content="YOUR_SERVER_GENERATED_NONCE" />
 ```
 
 ### Known limitation: runtime theme loading

--- a/packages/oxygen-ui/README.md
+++ b/packages/oxygen-ui/README.md
@@ -318,10 +318,12 @@ Content-Security-Policy:
   default-src 'self';
   style-src-elem 'self' 'nonce-<value>';
   style-src-attr 'unsafe-inline';
+  font-src 'self' data:;
 ```
 
 - **`style-src-elem`** — Emotion injects `<style>` elements; each needs a matching nonce.
 - **`style-src-attr 'unsafe-inline'`** — MUI components apply dynamic inline `style` attributes (dimensions, CSS custom properties, positioning). Nonces cannot cover style attributes.
+- **`font-src 'self' data:`** — The bundled Inter font is embedded as base64 `data:` URIs. Without `data:` in `font-src` (which otherwise falls back to `default-src 'self'`), the browser blocks the fonts even when the style tag itself is allowed.
 - **`script-src 'nonce-...'`** — Only required if your app uses MUI's `InitColorSchemeScript`. Oxygen UI does not ship that script.
 
 ### Using the `nonce` prop
@@ -367,17 +369,21 @@ function App() {
 
 `emotionCache` takes precedence over `nonce` if both are provided.
 
+Note that the `nonce` prop creates an Emotion cache per provider instance. If your app mounts multiple providers or remounts the provider (for example, on route-level key changes), each mount injects a fresh set of style tags. In that case, prefer a module-level cache passed via `emotionCache` (as in the example above) so styles are injected only once.
+
 ### Server-side rendering (SSR)
 
 Generate a unique nonce per request on the server, include it in the CSP header, and pass the same value to `OxygenUIThemeProvider` via `nonce` or a shared `emotionCache` on both server and client. Keep server and client Emotion caches aligned (same key, nonce, and insertion options). See the [MUI CSP guide](https://mui.com/material-ui/guides/content-security-policy/) for framework-specific examples (Next.js, Vite, and Emotion SSR).
 
-### Bundled fonts
+### Bundled fonts and theme CSS
 
-The Inter Variable font styles are injected as a separate `<style>` tag when the package is imported (before React renders), so the nonce for that tag is resolved from well-known conventions instead of a prop:
+The bundled CSS — the Inter Variable font styles and the theme CSS — is injected as separate `<style>` tags when the package is imported (before React renders), so the nonce for those tags is resolved from well-known conventions instead of a prop:
 
 1. The `__webpack_nonce__` global ([webpack convention](https://webpack.js.org/guides/csp/))
 2. A `<meta property="csp-nonce" nonce="...">` tag ([Vite convention](https://vite.dev/guide/features.html#content-security-policy-csp)); `content` is also accepted as a fallback
 3. A `<meta name="csp-nonce" content="...">` tag ([MUI / Next.js convention](https://mui.com/material-ui/guides/content-security-policy/))
+
+Because the nonce is read at module evaluation time, the meta tag (or the `__webpack_nonce__` assignment) must already be present in the document before the app bundle executes. A meta tag added later from JavaScript silently results in style tags without a nonce.
 
 ```html
 <!-- Vite convention -->

--- a/packages/oxygen-ui/README.md
+++ b/packages/oxygen-ui/README.md
@@ -309,6 +309,68 @@ function MyComponent() {
 }
 ```
 
+## Content Security Policy (CSP)
+
+Oxygen UI (via MUI and Emotion) injects styles at runtime using `<style>` tags. If your application enforces a strict `style-src` CSP directive, pass a nonce so those tags are allowed.
+
+### Using the `nonce` prop
+
+Pass your server-generated nonce to `OxygenUIThemeProvider`. It is applied to every style tag injected by the styling engine (components, `CssBaseline`, theme styles):
+
+```typescript
+import { OxygenUIThemeProvider } from '@wso2/oxygen-ui';
+
+function App() {
+  return (
+    <OxygenUIThemeProvider nonce={window.__MY_APP_NONCE__}>
+      <YourApp />
+    </OxygenUIThemeProvider>
+  );
+}
+```
+
+The nonce must match the one in your CSP header, e.g. `Content-Security-Policy: style-src 'self' 'nonce-<value>'`.
+
+### Using a custom Emotion cache
+
+For full control over style injection (cache key, insertion point, stylis plugins, shadow DOM containers, SSR caches), pass a custom Emotion cache. `createEmotionCache` is re-exported from `@emotion/cache` for convenience:
+
+```typescript
+import { OxygenUIThemeProvider, createEmotionCache } from '@wso2/oxygen-ui';
+
+const cache = createEmotionCache({
+  key: 'css',
+  nonce: window.__MY_APP_NONCE__,
+  prepend: true,
+});
+
+function App() {
+  return (
+    <OxygenUIThemeProvider emotionCache={cache}>
+      <YourApp />
+    </OxygenUIThemeProvider>
+  );
+}
+```
+
+`emotionCache` takes precedence over `nonce` if both are provided.
+
+### Bundled fonts
+
+The Inter Variable font styles are injected as a separate `<style>` tag when the package is imported (before React renders), so the nonce for that tag is resolved from well-known conventions instead of a prop:
+
+1. The `__webpack_nonce__` global ([webpack convention](https://webpack.js.org/guides/csp/))
+2. A `<meta property="csp-nonce" nonce="...">` tag in the document ([Vite convention](https://vite.dev/guide/features.html#content-security-policy-csp))
+
+```html
+<!-- Server-rendered HTML -->
+<meta property="csp-nonce" nonce="YOUR_SERVER_GENERATED_NONCE" />
+```
+
+### Known limitation: runtime theme loading
+
+Loading themes from URLs (`themes: [{ key: 'x', label: 'X', theme: '/themes/x.js' }]`) evaluates the fetched theme file with `new Function(...)`, which additionally requires `script-src 'unsafe-eval'`. Under a strict CSP, prefer passing theme objects directly instead of URL-based themes.
+
 ## Available Exports
 
 ### Custom Oxygen UI Components
@@ -322,6 +384,8 @@ function MyComponent() {
 - `ColorSchemeToggle` - Toggle for light/dark mode
 - `Layout` - Layout components
 - `useThemeSwitcher` - Hook to access theme switcher context
+- `createEmotionCache` - Create a custom Emotion cache (re-export of `@emotion/cache`, for CSP and advanced style injection)
+- `EmotionCache` - Type for Emotion cache instances
 
 ### Material-UI Components
 

--- a/packages/oxygen-ui/package.json
+++ b/packages/oxygen-ui/package.json
@@ -66,6 +66,7 @@
   },
   "homepage": "https://github.com/wso2/oxygen-ui#readme",
   "dependencies": {
+    "@emotion/cache": "catalog:",
     "@emotion/react": "catalog:",
     "@emotion/styled": "catalog:",
     "@fontsource-variable/inter": "5.2.8",
@@ -84,6 +85,8 @@
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/prismjs": "^1.26.5",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
@@ -96,6 +99,7 @@
     "eslint": "catalog:",
     "eslint-plugin-react": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",
+    "jsdom": "catalog:",
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/packages/oxygen-ui/package.json
+++ b/packages/oxygen-ui/package.json
@@ -41,7 +41,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rimraf dist",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "test:watch": "vitest"
   },
   "keywords": [

--- a/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.test.tsx
+++ b/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.test.tsx
@@ -101,13 +101,37 @@ describe('OxygenUIThemeProvider CSP support', () => {
     expect(document.querySelector('style[nonce="ignored-nonce"]')).toBeNull();
   });
 
-  it('renders without a nonce or custom cache (default behavior)', () => {
-    const { getByRole } = render(
-      <OxygenUIThemeProvider>
-        <Button variant="contained">Default render</Button>
-      </OxygenUIThemeProvider>
-    );
+  it('defaults to StyledEngineProvider injectFirst without a nonce or custom cache', () => {
+    // Simulates a pre-existing application style tag at the end of <head>.
+    // injectFirst must insert Oxygen UI styles before it so application
+    // styles can override Oxygen UI styles.
+    const marker = document.createElement('style');
+    marker.setAttribute('data-test-marker', 'true');
+    document.head.appendChild(marker);
 
-    expect(getByRole('button')).toHaveProperty('textContent', 'Default render');
+    try {
+      const { getByRole } = render(
+        <OxygenUIThemeProvider>
+          <Button variant="contained">Default render</Button>
+        </OxygenUIThemeProvider>
+      );
+
+      expect(getByRole('button')).toHaveProperty('textContent', 'Default render');
+
+      // MUI's StyledEngineProvider injectFirst inserts styles at an
+      // emotion-insertion-point meta tag prepended to <head>.
+      expect(document.head.querySelector('meta[name="emotion-insertion-point"]')).not.toBeNull();
+
+      const styleTags = getEmotionStyleTags('css');
+      expect(styleTags.length).toBeGreaterThan(0);
+      styleTags.forEach((tag) => {
+        expect(tag.getAttribute('nonce')).toBeNull();
+        // Emotion style tags must precede the pre-existing marker style.
+        const position = tag.compareDocumentPosition(marker);
+        expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      });
+    } finally {
+      marker.remove();
+    }
   });
 });

--- a/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.test.tsx
+++ b/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Button } from '@mui/material';
+import createCache from '@emotion/cache';
+import OxygenUIThemeProvider from './OxygenUIThemeProvider';
+
+/**
+ * Collects all Emotion-generated style tags for a given cache key.
+ * In test/development mode Emotion runs in non-speedy mode, so every
+ * inserted rule produces an inspectable `<style data-emotion="<key>">` tag.
+ */
+function getEmotionStyleTags(key: string): HTMLStyleElement[] {
+  return Array.from(document.querySelectorAll<HTMLStyleElement>(`style[data-emotion="${key}"]`));
+}
+
+describe('OxygenUIThemeProvider CSP support', () => {
+  beforeEach(() => {
+    // Remove style tags injected by previous tests so assertions only see
+    // styles produced by the current render.
+    document.head.querySelectorAll('style').forEach((el) => el.remove());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('applies the nonce to all Emotion style tags when the `nonce` prop is set', () => {
+    const nonce = 'test-nonce-abc123';
+
+    render(
+      <OxygenUIThemeProvider nonce={nonce}>
+        <Button variant="contained">Click me</Button>
+      </OxygenUIThemeProvider>
+    );
+
+    const styleTags = getEmotionStyleTags('css');
+    expect(styleTags.length).toBeGreaterThan(0);
+    styleTags.forEach((tag) => {
+      expect(tag.getAttribute('nonce')).toBe(nonce);
+    });
+  });
+
+  it('uses a custom Emotion cache passed via the `emotionCache` prop', () => {
+    const nonce = 'custom-cache-nonce';
+    const cache = createCache({ key: 'oxygen-csp', nonce, prepend: true });
+
+    const { getByRole } = render(
+      <OxygenUIThemeProvider emotionCache={cache}>
+        <Button variant="contained">Click me</Button>
+      </OxygenUIThemeProvider>
+    );
+
+    // Styles are injected through the custom cache (custom key)...
+    const styleTags = getEmotionStyleTags('oxygen-csp');
+    expect(styleTags.length).toBeGreaterThan(0);
+    styleTags.forEach((tag) => {
+      expect(tag.getAttribute('nonce')).toBe(nonce);
+    });
+
+    // ...and generated class names carry the custom cache key.
+    const button = getByRole('button');
+    const hasCustomKeyClass = Array.from(button.classList).some((cls) =>
+      cls.startsWith('oxygen-csp-')
+    );
+    expect(hasCustomKeyClass).toBe(true);
+  });
+
+  it('prefers `emotionCache` over `nonce` when both are provided', () => {
+    const cache = createCache({ key: 'wins', nonce: 'cache-nonce' });
+
+    render(
+      <OxygenUIThemeProvider emotionCache={cache} nonce="ignored-nonce">
+        <Button variant="contained">Click me</Button>
+      </OxygenUIThemeProvider>
+    );
+
+    expect(getEmotionStyleTags('wins').length).toBeGreaterThan(0);
+    expect(document.querySelector('style[nonce="ignored-nonce"]')).toBeNull();
+  });
+
+  it('renders without a nonce or custom cache (default behavior)', () => {
+    const { getByRole } = render(
+      <OxygenUIThemeProvider>
+        <Button variant="contained">Default render</Button>
+      </OxygenUIThemeProvider>
+    );
+
+    expect(getByRole('button')).toHaveProperty('textContent', 'Default render');
+  });
+});

--- a/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.test.tsx
+++ b/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.test.tsx
@@ -25,10 +25,15 @@ import OxygenUIThemeProvider from './OxygenUIThemeProvider';
 /**
  * Collects all Emotion-generated style tags for a given cache key.
  * In test/development mode Emotion runs in non-speedy mode, so every
- * inserted rule produces an inspectable `<style data-emotion="<key>">` tag.
+ * inserted rule produces an inspectable `<style data-emotion="<key> <ids...>">`
+ * tag. Match by prefix so both exact (`css`) and spaced (`css abc`) forms work.
  */
 function getEmotionStyleTags(key: string): HTMLStyleElement[] {
-  return Array.from(document.querySelectorAll<HTMLStyleElement>(`style[data-emotion="${key}"]`));
+  return Array.from(
+    document.querySelectorAll<HTMLStyleElement>(
+      `style[data-emotion="${key}"], style[data-emotion^="${key} "]`
+    )
+  );
 }
 
 describe('OxygenUIThemeProvider CSP support', () => {

--- a/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.tsx
+++ b/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.tsx
@@ -225,7 +225,10 @@ interface OxygenUIThemeProviderProps {
    *
    * When provided, an Emotion cache is created internally with
    * `createCache({ key: 'css', nonce, prepend: true })` and supplied via
-   * Emotion's `CacheProvider`.
+   * Emotion's `CacheProvider`. The cache is created per provider instance, so
+   * apps that mount multiple providers or remount the provider should prefer
+   * passing a module-level cache via `emotionCache` to avoid re-injecting
+   * styles on every mount.
    *
    * Ignored if `emotionCache` is provided.
    */

--- a/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.tsx
+++ b/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.tsx
@@ -235,6 +235,10 @@ interface OxygenUIThemeProviderProps {
    * (cache key, nonce, insertion point, stylis plugins, container, etc.).
    * Create one with `createEmotionCache` (re-exported from `@emotion/cache`).
    *
+   * Set `prepend: true` when creating the cache to preserve the previous
+   * `StyledEngineProvider injectFirst` cascade (application styles can override
+   * Oxygen UI styles). Omitting `prepend: true` changes style insertion order.
+   *
    * Takes precedence over the `nonce` prop.
    */
   emotionCache?: EmotionCache;

--- a/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.tsx
+++ b/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.tsx
@@ -240,6 +240,25 @@ interface OxygenUIThemeProviderProps {
   emotionCache?: EmotionCache;
 }
 
+/**
+ * Root theme provider for Oxygen UI applications.
+ *
+ * Wraps children with MUI's ThemeProvider and CssBaseline. When `themes` is
+ * provided, enables theme switching via context (`useThemeSwitcher`).
+ *
+ * For CSP-restricted environments, pass `nonce` to apply a Content Security
+ * Policy nonce to Emotion-injected style tags, or supply a fully custom
+ * Emotion cache via `emotionCache` (takes precedence over `nonce`).
+ *
+ * @param props - Provider configuration
+ * @param props.children - Application content to theme
+ * @param props.theme - Optional single theme (disables switching)
+ * @param props.themes - Optional theme options enabling switching
+ * @param props.initialTheme - Initial theme key when switching is enabled
+ * @param props.onThemesLoaded - Callback when themes finish resolving
+ * @param props.nonce - CSP nonce for Emotion style tags
+ * @param props.emotionCache - Custom Emotion cache (overrides `nonce`)
+ */
 export default function OxygenUIThemeProvider({
   children,
   theme,

--- a/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.tsx
+++ b/packages/oxygen-ui/src/contexts/OxygenUIThemeProvider/OxygenUIThemeProvider.tsx
@@ -18,7 +18,10 @@
 
 import { ThemeProvider, StyledEngineProvider, Theme } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
-import { ReactNode, createContext, useContext, useState, useEffect } from 'react';
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
+import type { EmotionCache } from '@emotion/cache';
+import { ReactNode, createContext, useContext, useState, useEffect, useMemo } from 'react';
 import OxygenTheme from '../../styles/Themes/AcrylicBaseTheme';
 
 const THEME_STORAGE_KEY = 'oxygen-theme';
@@ -215,6 +218,26 @@ interface OxygenUIThemeProviderProps {
    * Receives the array of resolved theme configurations.
    */
   onThemesLoaded?: (themes: ThemeOption[]) => void;
+  /**
+   * CSP (Content Security Policy) nonce applied to all style tags injected by
+   * the styling engine (Emotion). Use this when your application enforces a
+   * strict `style-src` CSP directive.
+   *
+   * When provided, an Emotion cache is created internally with
+   * `createCache({ key: 'css', nonce, prepend: true })` and supplied via
+   * Emotion's `CacheProvider`.
+   *
+   * Ignored if `emotionCache` is provided.
+   */
+  nonce?: string;
+  /**
+   * A custom Emotion cache instance, for full control over style injection
+   * (cache key, nonce, insertion point, stylis plugins, container, etc.).
+   * Create one with `createEmotionCache` (re-exported from `@emotion/cache`).
+   *
+   * Takes precedence over the `nonce` prop.
+   */
+  emotionCache?: EmotionCache;
 }
 
 export default function OxygenUIThemeProvider({
@@ -223,10 +246,27 @@ export default function OxygenUIThemeProvider({
   themes,
   initialTheme,
   onThemesLoaded,
+  nonce,
+  emotionCache,
 }: OxygenUIThemeProviderProps) {
   // State for managing dynamically loaded themes
   const [resolvedThemes, setResolvedThemes] = useState<ThemeOption[]>([]);
   const [themesLoaded, setThemesLoaded] = useState(false);
+
+  // Resolve the Emotion cache used for style injection. When a custom cache or
+  // a CSP nonce is provided, styles are delivered through Emotion's
+  // CacheProvider instead of MUI's StyledEngineProvider (which does not expose
+  // cache options such as `nonce`). `prepend: true` mirrors the `injectFirst`
+  // behavior so application styles can still override Oxygen UI styles.
+  const styleCache = useMemo<EmotionCache | null>(() => {
+    if (emotionCache) {
+      return emotionCache;
+    }
+    if (nonce) {
+      return createCache({ key: 'css', nonce, prepend: true });
+    }
+    return null;
+  }, [emotionCache, nonce]);
 
   // Resolve any string path themes to actual Theme objects
   useEffect(() => {
@@ -340,13 +380,17 @@ export default function OxygenUIThemeProvider({
     return null;
   }
 
-  const content = (
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={resolvedTheme}>
-        <CssBaseline enableColorScheme />
-        {children}
-      </ThemeProvider>
-    </StyledEngineProvider>
+  const themedContent = (
+    <ThemeProvider theme={resolvedTheme}>
+      <CssBaseline enableColorScheme />
+      {children}
+    </ThemeProvider>
+  );
+
+  const content = styleCache ? (
+    <CacheProvider value={styleCache}>{themedContent}</CacheProvider>
+  ) : (
+    <StyledEngineProvider injectFirst>{themedContent}</StyledEngineProvider>
   );
 
   // Only provide context if theme switching is enabled

--- a/packages/oxygen-ui/src/contexts/index.ts
+++ b/packages/oxygen-ui/src/contexts/index.ts
@@ -18,3 +18,9 @@
 
 export { default as OxygenUIThemeProvider, useThemeSwitcher } from './OxygenUIThemeProvider/OxygenUIThemeProvider';
 export type { ThemeOption, ThemeSwitcherContextValue } from './OxygenUIThemeProvider/OxygenUIThemeProvider';
+
+// Re-export Emotion cache utilities so consumers can create a custom cache
+// (e.g. for CSP nonces, custom insertion points, or shadow DOM containers)
+// without installing @emotion/cache themselves.
+export { default as createEmotionCache } from '@emotion/cache';
+export type { EmotionCache } from '@emotion/cache';

--- a/packages/oxygen-ui/vitest.config.ts
+++ b/packages/oxygen-ui/vitest.config.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@emotion/cache':
+      specifier: 11.14.0
+      version: 11.14.0
     '@emotion/react':
       specifier: 11.14.0
       version: 11.14.0
@@ -30,6 +33,12 @@ catalogs:
     '@mui/x-tree-view':
       specifier: 8.14.0
       version: 8.14.0
+    '@testing-library/dom':
+      specifier: 10.4.1
+      version: 10.4.1
+    '@testing-library/react':
+      specifier: 16.3.2
+      version: 16.3.2
     '@types/eslint':
       specifier: 9.6.1
       version: 9.6.1
@@ -75,6 +84,9 @@ catalogs:
     globals:
       specifier: 16.4.0
       version: 16.4.0
+    jsdom:
+      specifier: 29.1.1
+      version: 29.1.1
     lucide-react:
       specifier: 1.16.0
       version: 1.16.0
@@ -156,6 +168,9 @@ importers:
 
   packages/oxygen-ui:
     dependencies:
+      '@emotion/cache':
+        specifier: 'catalog:'
+        version: 11.14.0
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@19.2.2)(react@19.2.3)
@@ -196,6 +211,12 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.0
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/prismjs':
         specifier: ^1.26.5
         version: 1.26.5
@@ -232,6 +253,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: 'catalog:'
         version: 5.2.0(eslint@9.12.0)
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1
       rimraf:
         specifier: 'catalog:'
         version: 6.1.0
@@ -243,7 +267,7 @@ importers:
         version: 7.1.12(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(terser@5.44.0)(yaml@2.8.1)
+        version: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1)
 
   packages/oxygen-ui-charts-react:
     dependencies:
@@ -298,7 +322,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(terser@5.44.0)(yaml@2.8.1)
+        version: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1)
 
   packages/oxygen-ui-docs:
     dependencies:
@@ -338,16 +362,16 @@ importers:
         version: 3.1.1(@types/react@19.2.2)(react@19.2.3)
       '@storybook/addon-docs':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(esbuild@0.25.12)(rollup@4.52.5)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
+        version: 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(esbuild@0.25.12)(rollup@4.52.5)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
       '@storybook/addon-links':
         specifier: 10.4.6
-        version: 10.4.6(@types/react@19.2.2)(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
+        version: 10.4.6(@types/react@19.2.2)(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
+        version: 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: 10.4.6
-        version: 10.4.6(@swc/core@1.13.5)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(esbuild@0.25.12)(postcss@8.5.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
+        version: 10.4.6(@swc/core@1.13.5)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(esbuild@0.25.12)(postcss@8.5.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
       '@svgr/webpack':
         specifier: 8.1.0
         version: 8.1.0(typescript@5.9.3)
@@ -374,7 +398,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
 
   packages/oxygen-ui-icons-react:
     dependencies:
@@ -429,7 +453,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(terser@5.44.0)(yaml@2.8.1)
+        version: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1)
 
   packages/vite-plugin-oxygen-ui:
     dependencies:
@@ -517,6 +541,21 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1088,6 +1127,10 @@ packages:
       '@types/react':
         optional: true
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@changesets/apply-release-plan@7.0.13':
     resolution: {integrity: sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==}
 
@@ -1148,6 +1191,42 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1603,6 +1682,15 @@ packages:
   '@eslint/plugin-kit@0.4.0':
     resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
@@ -2620,13 +2708,28 @@ packages:
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
-  '@testing-library/dom@10.4.0':
-    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
@@ -3114,6 +3217,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -3320,6 +3426,10 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
@@ -3383,6 +3493,10 @@ packages:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -3412,6 +3526,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
@@ -3568,6 +3685,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -3987,6 +4108,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
@@ -4158,6 +4283,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -4246,6 +4374,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -4341,6 +4478,10 @@ packages:
     resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -4372,6 +4513,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
@@ -4600,6 +4744,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
@@ -4984,6 +5131,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -5203,6 +5354,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
@@ -5307,6 +5461,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.8:
+    resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
+
+  tldts@7.4.8:
+    resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
+    hasBin: true
+
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
@@ -5319,8 +5480,16 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -5384,6 +5553,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -5550,6 +5723,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -5559,6 +5736,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-dev-middleware@6.1.3:
     resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}
@@ -5588,6 +5769,14 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -5649,6 +5838,13 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -5683,6 +5879,26 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6420,7 +6636,7 @@ snapshots:
 
   '@base-ui-components/utils@0.1.2(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.10
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -6428,6 +6644,10 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@changesets/apply-release-plan@7.0.13':
     dependencies:
@@ -6588,6 +6808,30 @@ snapshots:
       human-id: 4.1.2
       prettier: 2.8.8
 
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -6636,7 +6880,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.27.1
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -6946,6 +7190,8 @@ snapshots:
       '@eslint/core': 0.16.0
       levn: 0.4.1
 
+  '@exodus/bytes@1.15.1': {}
+
   '@floating-ui/utils@0.2.10': {}
 
   '@fontsource-variable/inter@5.2.8': {}
@@ -7024,7 +7270,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -7091,7 +7337,7 @@ snapshots:
 
   '@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.3))(@types/react@19.2.2)(react@19.2.3))(@types/react@19.2.2)(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/private-theming': 7.3.3(@types/react@19.2.2)(react@19.2.3)
       '@mui/styled-engine': 7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.3))(@types/react@19.2.2)(react@19.2.3))(react@19.2.3)
       '@mui/types': 7.4.7(@types/react@19.2.2)
@@ -7107,7 +7353,7 @@ snapshots:
 
   '@mui/types@7.4.7(@types/react@19.2.2)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -7119,7 +7365,7 @@ snapshots:
 
   '@mui/utils@7.3.3(@types/react@19.2.2)(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/types': 7.4.7(@types/react@19.2.2)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
@@ -7182,7 +7428,7 @@ snapshots:
 
   '@mui/x-internals@8.14.0(@types/react@19.2.2)(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/utils': 7.3.3(@types/react@19.2.2)(react@19.2.3)
       react: 19.2.3
       reselect: 5.1.1
@@ -7192,7 +7438,7 @@ snapshots:
 
   '@mui/x-internals@8.16.0(@types/react@19.2.2)(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/utils': 7.3.3(@types/react@19.2.2)(react@19.2.3)
       react: 19.2.3
       reselect: 5.1.1
@@ -7222,7 +7468,7 @@ snapshots:
 
   '@mui/x-virtualizer@0.2.6(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/utils': 7.3.3(@types/react@19.2.2)(react@19.2.3)
       '@mui/x-internals': 8.16.0(@types/react@19.2.2)(react@19.2.3)
       react: 19.2.3
@@ -7509,15 +7755,15 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(esbuild@0.25.12)(rollup@4.52.5)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(esbuild@0.25.12)(rollup@4.52.5)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.2)(react@19.2.3)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.25.12)(rollup@4.52.5)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.25.12)(rollup@4.52.5)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
       '@storybook/icons': 2.1.0(react@19.2.3)
-      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 19.2.2
@@ -7528,17 +7774,17 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-links@10.4.6(@types/react@19.2.2)(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))':
+  '@storybook/addon-links@10.4.6(@types/react@19.2.2)(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.2
       react: 19.2.3
 
-  '@storybook/builder-webpack5@10.4.6(@swc/core@1.13.5)(esbuild@0.25.12)(postcss@8.5.6)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@10.4.6(@swc/core@1.13.5)(esbuild@0.25.12)(postcss@8.5.6)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
+      '@storybook/core-webpack': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       css-loader: 7.1.2(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
@@ -7546,7 +7792,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
       html-webpack-plugin: 5.6.4(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
       magic-string: 0.30.21
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
       style-loader: 4.0.0(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
       terser-webpack-plugin: 5.6.1(@swc/core@1.13.5)(esbuild@0.25.12)(postcss@8.5.6)(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
       ts-dedent: 2.2.0
@@ -7572,14 +7818,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/core-webpack@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))':
+  '@storybook/core-webpack@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))':
     dependencies:
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.25.12)(rollup@4.52.5)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.25.12)(rollup@4.52.5)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))':
     dependencies:
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.25.12
@@ -7593,9 +7839,9 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@storybook/preset-react-webpack@10.4.6(@swc/core@1.13.5)(esbuild@0.25.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@10.4.6(@swc/core@1.13.5)(esbuild@0.25.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
+      '@storybook/core-webpack': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12))
       '@types/semver': 7.7.1
       magic-string: 0.30.21
@@ -7604,7 +7850,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       resolve: 1.22.11
       semver: 7.7.3
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
       tsconfig-paths: 4.2.0
       webpack: 5.102.1(@swc/core@1.13.5)(esbuild@0.25.12)
     optionalDependencies:
@@ -7630,23 +7876,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))':
+  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  '@storybook/react-webpack5@10.4.6(@swc/core@1.13.5)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(esbuild@0.25.12)(postcss@8.5.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)':
+  '@storybook/react-webpack5@10.4.6(@swc/core@1.13.5)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(esbuild@0.25.12)(postcss@8.5.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)':
     dependencies:
-      '@storybook/builder-webpack5': 10.4.6(@swc/core@1.13.5)(esbuild@0.25.12)(postcss@8.5.6)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 10.4.6(@swc/core@1.13.5)(esbuild@0.25.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 10.4.6(@swc/core@1.13.5)(esbuild@0.25.12)(postcss@8.5.6)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 10.4.6(@swc/core@1.13.5)(esbuild@0.25.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7668,15 +7914,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)':
+  '@storybook/react@10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3))
       react: 19.2.3
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
@@ -7829,15 +8075,15 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@testing-library/dom@10.4.0':
+  '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
-      chalk: 4.1.2
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
+      picocolors: 1.1.1
       pretty-format: 27.5.1
 
   '@testing-library/jest-dom@6.9.1':
@@ -7849,9 +8095,19 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@testing-library/dom': 10.4.0
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -8138,7 +8394,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -8398,7 +8654,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
@@ -8435,6 +8691,10 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bl@4.1.0:
     dependencies:
@@ -8649,6 +8909,11 @@ snapshots:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
@@ -8699,6 +8964,13 @@ snapshots:
 
   d3-timer@3.0.1: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -8726,6 +8998,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   dedent@0.7.0: {}
 
@@ -8790,7 +9064,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       csstype: 3.1.3
 
   dom-serializer@1.4.1:
@@ -8881,6 +9155,8 @@ snapshots:
   entities@2.2.0: {}
 
   entities@4.5.0: {}
+
+  entities@8.0.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -9485,6 +9761,12 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-entities@2.6.0: {}
 
   html-minifier-terser@6.1.0:
@@ -9641,6 +9923,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -9737,6 +10021,32 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -9818,6 +10128,8 @@ snapshots:
 
   lru-cache@11.2.2: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -9843,6 +10155,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.0.30: {}
+
+  mdn-data@2.27.1: {}
 
   memfs@3.5.3:
     dependencies:
@@ -10154,6 +10468,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
@@ -10345,7 +10663,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -10567,6 +10885,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   schema-utils@3.3.0:
@@ -10696,12 +11018,12 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3):
+  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.2)(prettier@3.6.2)(react@19.2.3):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.1.0(react@19.2.3)
       '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
@@ -10830,6 +11152,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  symbol-tree@3.2.4: {}
+
   tapable@2.3.0: {}
 
   tar-stream@2.2.0:
@@ -10892,6 +11216,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.4.8: {}
+
+  tldts@7.4.8:
+    dependencies:
+      tldts-core: 7.4.8
+
   tmp@0.2.5: {}
 
   to-regex-range@5.0.1:
@@ -10900,7 +11230,15 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.8
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -10978,6 +11316,8 @@ snapshots:
   undici-types@7.13.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -11078,7 +11418,7 @@ snapshots:
       terser: 5.44.0
       yaml: 2.8.1
 
-  vitest@4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(terser@5.44.0)(yaml@2.8.1):
+  vitest@4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.6
       '@vitest/mocker': 4.0.6(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))
@@ -11103,6 +11443,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.9.1
       '@vitest/ui': 4.0.6(vitest@4.0.6)
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -11117,6 +11458,10 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -11127,6 +11472,8 @@ snapshots:
       defaults: 1.0.4
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-dev-middleware@6.1.3(webpack@5.102.1(@swc/core@1.13.5)(esbuild@0.25.12)):
     dependencies:
@@ -11179,6 +11526,16 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -11256,6 +11613,10 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,15 @@ importers:
       esbuild:
         specifier: 'catalog:'
         version: 0.25.11
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.6(@types/node@24.6.0)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1)
 
   packages/eslint-plugin-oxygen-ui:
     dependencies:
@@ -4474,10 +4480,6 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
-  lru-cache@11.2.2:
-    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
-    engines: {node: 20 || >=22}
-
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -8352,6 +8354,14 @@ snapshots:
       chai: 6.2.0
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@4.0.6(vite@7.2.1(@types/node@24.6.0)(terser@5.44.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.1(@types/node@24.6.0)(terser@5.44.0)(yaml@2.8.1)
+
   '@vitest/mocker@4.0.6(vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.6
@@ -8394,7 +8404,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 4.0.6(@types/node@24.6.0)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -10126,8 +10136,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  lru-cache@11.2.2: {}
-
   lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
@@ -10487,7 +10495,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.2.2
+      lru-cache: 11.5.2
       minipass: 7.1.2
 
   path-type@4.0.0: {}
@@ -11404,6 +11412,20 @@ snapshots:
       terser: 5.44.0
       yaml: 2.8.1
 
+  vite@7.2.1(@types/node@24.6.0)(terser@5.44.0)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.5
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.6.0
+      fsevents: 2.3.3
+      terser: 5.44.0
+      yaml: 2.8.1
+
   vite@7.2.1(@types/node@24.9.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.12
@@ -11417,6 +11439,46 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.44.0
       yaml: 2.8.1
+
+  vitest@4.0.6(@types/node@24.6.0)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1):
+    dependencies:
+      '@vitest/expect': 4.0.6
+      '@vitest/mocker': 4.0.6(vite@7.2.1(@types/node@24.6.0)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.6
+      '@vitest/runner': 4.0.6
+      '@vitest/snapshot': 4.0.6
+      '@vitest/spy': 4.0.6
+      '@vitest/utils': 4.0.6
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.2.1(@types/node@24.6.0)(terser@5.44.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.6.0
+      '@vitest/ui': 4.0.6(vitest@4.0.6)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.6(@types/node@24.9.1)(@vitest/ui@4.0.6)(jsdom@29.1.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ allowBuilds:
   nx: true
 
 catalog:
+  '@emotion/cache': 11.14.0
   '@emotion/react': 11.14.0
   '@emotion/styled': 11.14.1
   '@eslint/js': 9.39.0
@@ -17,6 +18,8 @@ catalog:
   '@mui/x-date-pickers': 8.16.0
   '@mui/x-tree-view': 8.14.0
   '@mui/utils': 9.0.0
+  '@testing-library/dom': 10.4.1
+  '@testing-library/react': 16.3.2
   '@types/eslint': 9.6.1
   '@types/node': 24.6.0
   '@types/react': 19.2.2
@@ -32,6 +35,7 @@ catalog:
   eslint-plugin-react-refresh: 0.4.24
   glob: 11.0.3
   globals: 16.4.0
+  jsdom: 29.1.1
   lucide-react: 1.16.0
   prettier: 3.6.2
   react: 19.2.3


### PR DESCRIPTION
### Purpose

Adds Content Security Policy (CSP) compatibility so apps with a strict `style-src` policy can use Oxygen UI without blocking injected styles.

- `OxygenUIThemeProvider` accepts a `nonce` prop (Emotion cache with nonce) and an `emotionCache` escape hatch for full cache control.
- Re-exports `createEmotionCache` and `EmotionCache` so consumers can build custom caches without an extra dependency.
- Bundled Inter font style injection resolves a nonce from `__webpack_nonce__` or `<meta property="csp-nonce">`.
- Docs, Storybook stories, unit tests, and a minor changeset included.

### Related Issues

- Fixes #523

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [x] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
