### PR TITLE
fix(Sidebar): increase item touch target size and add hover/focus states

### DIFF
--- a/packages/oxygen-ui/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/oxygen-ui/src/components/Sidebar/SidebarItem.tsx
@@ -69,12 +69,15 @@ const SidebarItemButton = styled(ListItemButton, {
   shouldForwardProp: (prop) => prop !== 'ownerState',
 })<SidebarItemButtonProps>(({ theme, ownerState }) => ({
   minHeight: 44,
+  paddingTop: theme.spacing(1.5),
+  paddingBottom: theme.spacing(1.5),
   paddingRight: theme.spacing(2),
   paddingLeft: ownerState.collapsed ? theme.spacing(2) : theme.spacing(2 + ownerState.depth * 2),
   justifyContent: ownerState.collapsed ? 'center' : 'initial',
   borderRadius: theme.shape.borderRadius,
   marginLeft: theme.spacing(1),
   marginRight: theme.spacing(1),
+  marginBottom: theme.spacing(0.5),
   color: (theme.vars || theme).palette.text.primary,
   transition: theme.transitions.create(['padding-left', 'padding-right'], {
     easing: theme.transitions.easing.sharp,
@@ -82,6 +85,13 @@ const SidebarItemButton = styled(ListItemButton, {
       ? theme.transitions.duration.leavingScreen
       : theme.transitions.duration.enteringScreen,
   }),
+  '&:hover': {
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+  },
+  '&.Mui-focusVisible': {
+    outline: `2px solid ${(theme.vars || theme).palette.primary.main}`,
+    outlineOffset: -2,
+  },
   '&.Mui-selected': {
     backgroundColor: (theme.vars || theme).palette.action.selected,
     '&:hover': {
@@ -131,11 +141,20 @@ const SidebarItemPopoverButton = styled(ListItemButton, {
   name: 'MuiSidebar',
   slot: 'ItemPopoverButton',
 })(({ theme }) => ({
-  minHeight: 40,
+  minHeight: 44,
+  paddingTop: theme.spacing(1.5),
+  paddingBottom: theme.spacing(1.5),
   paddingRight: theme.spacing(2),
   paddingLeft: theme.spacing(2),
   borderRadius: theme.shape.borderRadius,
   gap: theme.spacing(1.5),
+  '&:hover': {
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+  },
+  '&.Mui-focusVisible': {
+    outline: `2px solid ${(theme.vars || theme).palette.primary.main}`,
+    outlineOffset: -2,
+  },
   '&.Mui-selected': {
     backgroundColor: (theme.vars || theme).palette.action.selected,
     '&:hover': {


### PR DESCRIPTION
### Purpose

Sidebar navigation items didn't provide adequate vertical spacing, hit area size, or tap padding, hurting usability on touch devices and failing the ~44px minimum touch target accessibility guideline.

This PR:
- Adds explicit vertical padding (12px top/bottom) to `SidebarItemButton` so the 44px `minHeight` is reliably reached by the rendered box, not just declared
- Adds a small `marginBottom` between items for breathing room
- Raises `SidebarItemPopoverButton` (collapsed-sidebar flyout items) `minHeight` from 40px to 44px to meet the same touch target minimum
- Adds explicit `:hover` and `:focus-visible` styles for unselected items, which previously had no visible hover/focus feedback

### Related Issues
- Closes #535 

### Related PRs

- N/A

### Checklist

- [x] Followed the CONTRIBUTING guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
- [ ] Unit tests provided.
- [ ] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
