### PR TITLE
fix(docs): resolve @storybook/react types with bundler moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "pnpm": {
-    "overrides": {}
-  },
   "publishConfig": {
     "access": "restricted"
   }

--- a/packages/oxygen-ui-docs/tsconfig.json
+++ b/packages/oxygen-ui-docs/tsconfig.json
@@ -2,11 +2,14 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "module": "esnext",
+    "moduleResolution": "bundler"
   },
   "include": [
-    "stories/**/*"
-, "vite-env.d.ts"  ],
+    "stories/**/*",
+    "vite-env.d.ts"
+  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
### Purpose

TypeScript could not resolve `@storybook/react` in Storybook stories because `@storybook/react@10` exposes types only via package `exports`, and `packages/oxygen-ui-docs/tsconfig.json` used classic `moduleResolution` (inherited from the root config).

This PR sets `"module": "esnext"` and `"moduleResolution": "bundler"` in the docs tsconfig (same approach as `packages/oxygen-ui`) so story imports like `import type { Meta, StoryObj } from '@storybook/react'` resolve correctly. Also tidies the broken `include` formatting.

### Related Issues

- Fixes #548

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
