### PR TITLE
style: refactor Modal stories to improve rendering and styling

### DIFF
--- a/packages/oxygen-ui-docs/stories/Utils/Modal.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Utils/Modal.stories.tsx
@@ -17,7 +17,7 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react';
-import { Modal, Box, Button, Typography } from '@wso2/oxygen-ui';
+import { Modal, Box, Button, Paper, Typography } from '@wso2/oxygen-ui';
 import React, { useState } from 'react';
 
 /**
@@ -68,14 +68,14 @@ export const Default: Story = {
           aria-labelledby="modal-title"
           aria-describedby="modal-description"
         >
-          <Box sx={modalStyle}>
+          <Paper sx={modalStyle}>
             <Typography id="modal-title" variant="h6" component="h2">
               Modal Title
             </Typography>
             <Typography id="modal-description" sx={{ mt: 2 }}>
               This is a basic modal with some content.
             </Typography>
-          </Box>
+          </Paper>
         </Modal>
       </>
     );
@@ -95,7 +95,7 @@ export const WithActions: Story = {
           aria-labelledby="modal-title"
           aria-describedby="modal-description"
         >
-          <Box sx={modalStyle}>
+          <Paper sx={modalStyle}>
             <Typography id="modal-title" variant="h6" component="h2">
               Confirm Action
             </Typography>
@@ -108,7 +108,7 @@ export const WithActions: Story = {
                 Confirm
               </Button>
             </Box>
-          </Box>
+          </Paper>
         </Modal>
       </>
     );
@@ -128,7 +128,7 @@ export const Nested: Story = {
           onClose={() => setOpen(false)}
           aria-labelledby="parent-modal-title"
         >
-          <Box sx={modalStyle}>
+          <Paper sx={modalStyle}>
             <Typography id="parent-modal-title" variant="h6" component="h2">
               Parent Modal
             </Typography>
@@ -143,7 +143,7 @@ export const Nested: Story = {
               onClose={() => setChildOpen(false)}
               aria-labelledby="child-modal-title"
             >
-              <Box sx={{ ...modalStyle, width: 300 }}>
+              <Paper sx={{ ...modalStyle, width: 300 }}>
                 <Typography id="child-modal-title" variant="h6" component="h2">
                   Child Modal
                 </Typography>
@@ -153,9 +153,9 @@ export const Nested: Story = {
                 <Button onClick={() => setChildOpen(false)} sx={{ mt: 2 }}>
                   Close
                 </Button>
-              </Box>
+              </Paper>
             </Modal>
-          </Box>
+          </Paper>
         </Modal>
       </>
     );

--- a/packages/oxygen-ui-docs/stories/Utils/Modal.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Utils/Modal.stories.tsx
@@ -52,6 +52,9 @@ const modalStyle = {
   left: '50%',
   transform: 'translate(-50%, -50%)',
   width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
   p: 4,
 };
 

--- a/packages/oxygen-ui-docs/stories/Utils/Modal.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Utils/Modal.stories.tsx
@@ -52,9 +52,6 @@ const modalStyle = {
   left: '50%',
   transform: 'translate(-50%, -50%)',
   width: 400,
-  bgcolor: 'background.paper',
-  border: '2px solid #000',
-  boxShadow: 24,
   p: 4,
 };
 


### PR DESCRIPTION
### Purpose

Fixes the Modal Storybook stories where the story's "Open Modal" trigger button label was faintly visible through the open dialog surface (reported in #540).

#### Root cause:
The stories rendered the modal surface on a plain `Box`. In the acrylic-style themes (WSO2, Acrylic Orange, Acrylic Purple), `background.paper` is intentionally semi-transparent (e.g. `#ffffffc5` in light mode, `#00000026` in WSO2 dark mode) and is designed to be paired with a `backdrop-filter` blur that the themes apply only to themed surface components (`MuiPaper`, `MuiPopover`). A raw `Box` receives the translucent color but not the blur, so page content behind the dialog showed through its surface.

#### Fix:
Render the modal content on `Paper` instead of `Box` in all three stories (`Default`, `WithActions`, `Nested` — including the nested child modal). `Paper` picks up each theme's backdrop blur and surface treatment automatically, so the stories now render correctly in all themes — frosted glass in the acrylic themes, solid surfaces in Classic/High Contrast/Pale themes — and match how the `Dialog` component renders its own surface. The rest of the example's styling is left untouched to keep the diff minimal.

No changes to the `Modal` component or its behavior (backdrop, focus trap, open/close) — this is a docs-only change. No changeset needed since `@wso2/oxygen-ui-docs` is a private package.

#### Before (WSO2 theme, light mode — trigger label visible through the dialog)

<img width="724" height="265" alt="Screenshot 2026-07-11 at 07 04 41" src="https://github.com/user-attachments/assets/e162f09e-0c9a-422b-b509-469772e440bc" />

#### After (WSO2 theme, light mode)

<img width="679" height="244" alt="Screenshot 2026-07-11 at 07 04 59" src="https://github.com/user-attachments/assets/e35d82e7-f811-40ab-b601-69a8a5ebc7ad" />

#### After (WSO2 theme, dark mode)

<img width="659" height="217" alt="Screenshot 2026-07-11 at 07 05 45" src="https://github.com/user-attachments/assets/a31f19ec-47a8-430b-82d5-fffc10211f34" />

### Related Issues

- Fixes https://github.com/wso2/oxygen-ui/issues/540

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?