### PR TITLE
fix(UserMenu): make chevron indicator opt-in for menu items

### DIFF
--- a/packages/oxygen-ui-docs/stories/AppElements/UserMenu.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/AppElements/UserMenu.stories.tsx
@@ -49,6 +49,7 @@ The UserMenu is a compound component that provides a user profile dropdown menu 
 - Customizable menu items for various actions
 - Dedicated Logout component with destructive styling
 - Role/plan badge display (e.g., "Pro", "Admin")
+- Optional chevron indicator (\`showChevron\`) for items that open a sub-menu or drill-down; omitted by default since most items navigate directly or trigger an immediate action
 
 ### Sub-components
 - \`UserMenu.Trigger\` - Avatar button with optional name display
@@ -208,6 +209,36 @@ export const WithNameVisible: Story = {
           icon={<Settings size={18} />}
           label="Settings"
           onClick={() => console.log('Settings clicked')}
+        />
+        <UserMenu.Divider />
+        <UserMenu.Logout
+          icon={<LogOut size={18} />}
+          onClick={() => console.log('Logout clicked')}
+        />
+      </UserMenu>
+    </Box>
+  ),
+};
+
+export const WithDrillDownItem: Story = {
+  render: () => (
+    <Box sx={{ p: 4 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
+        Only the drill-down item shows a chevron
+      </Typography>
+      <UserMenu>
+        <UserMenu.Trigger name="John Doe" avatar="JD" />
+        <UserMenu.Header name="John Doe" email="john@example.com" avatar="JD" role="Pro" />
+        <UserMenu.Item
+          icon={<ProfileIcon size={18} />}
+          label="Profile"
+          onClick={() => console.log('Profile clicked')}
+        />
+        <UserMenu.Item
+          icon={<Settings size={18} />}
+          label="Settings"
+          showChevron
+          onClick={() => console.log('Opens Settings sub-menu')}
         />
         <UserMenu.Divider />
         <UserMenu.Logout

--- a/packages/oxygen-ui/src/components/UserMenu/UserMenuItem.tsx
+++ b/packages/oxygen-ui/src/components/UserMenu/UserMenuItem.tsx
@@ -36,6 +36,8 @@ export interface UserMenuItemProps {
   label: string;
   /** Optional badge/chip to display on the right */
   badge?: string;
+  /** Show a chevron indicator. Only use for items that open a sub-menu or drill-down; omit for items that navigate directly or trigger an immediate action. Defaults to false. */
+  showChevron?: boolean;
   /** Callback when item is clicked */
   onClick?: () => void;
 }
@@ -70,6 +72,7 @@ export const UserMenuItem: React.FC<UserMenuItemProps> = ({
   icon,
   label,
   badge,
+  showChevron = false,
   onClick,
 }) => {
   const { handleClose } = useUserMenu();
@@ -100,7 +103,13 @@ export const UserMenuItem: React.FC<UserMenuItemProps> = ({
             variant="outlined"
           />
         )}
-        <ChevronRight size={16} style={{ color: 'var(--mui-palette-text-secondary)' }} />
+        {showChevron && (
+          <ChevronRight
+            size={16}
+            aria-hidden="true"
+            style={{ color: 'var(--mui-palette-text-secondary)' }}
+          />
+        )}
       </Box>
     </StyledMenuItem>
   );


### PR DESCRIPTION
### Purpose

Menu items in `UserMenu.Item` (Profile, Settings, Billing, etc.) always rendered a right-pointing chevron, regardless of whether the action navigated to a sub-menu or just triggered an immediate action (onClick/direct link). This is misleading - a chevron conventionally signals drill-down/sub-navigation — and adds redundant noise for screen reader users.

Added a `showChevron` prop (default `false`) to `UserMenu.Item` so the chevron is opt-in, only shown when an item genuinely opens a sub-menu or drill-down. The icon is also marked `aria-hidden="true"` since it's purely decorative. Existing usages
are unaffected since none previously needed the chevron — it disappears by default now, which was the desired behavior.

### Related Issues

- pr closes #522  

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
