### PR TITLE
fix(theme): use black contrastText for warning color to meet WCAG AA

### DIFF
--- a/packages/oxygen-ui/src/styles/Themes/PaleGray.ts
+++ b/packages/oxygen-ui/src/styles/Themes/PaleGray.ts
@@ -77,7 +77,7 @@ const PaleGrayThemeConfig = {
           main: '#ED6C02',
           light: '#FF9800',
           dark: '#E65100',
-          contrastText: '#ffffff',
+          contrastText: '#000000',
         },
         info: {
           main: '#616161',

--- a/packages/oxygen-ui/src/styles/Themes/PaleIndigo.ts
+++ b/packages/oxygen-ui/src/styles/Themes/PaleIndigo.ts
@@ -77,7 +77,7 @@ const PaleIndigoThemeConfig = {
           main: '#ED6C02',
           light: '#FF9800',
           dark: '#E65100',
-          contrastText: '#ffffff',
+          contrastText: '#000000',
         },
         info: {
           main: '#5567d5',

--- a/packages/oxygen-ui/src/styles/Themes/WSO2Theme.ts
+++ b/packages/oxygen-ui/src/styles/Themes/WSO2Theme.ts
@@ -40,8 +40,8 @@ const WSO2ThemeConfig = {
           contrastText: '#ffffff',
         },
         warning: {
-          main: '#e65100', // Darker orange for better contrast with white text
-          contrastText: '#ffffff',
+          main: '#e65100',
+          contrastText: '#000000', // Black text meets WCAG AA contrast on orange; white does not
         },
         error: {
           main: '#c62828', // Darker red for better contrast with white text
@@ -75,8 +75,8 @@ const WSO2ThemeConfig = {
           contrastText: '#ffffff',
         },
         warning: {
-          main: '#f57c00', // Darker orange for better contrast with white text
-          contrastText: '#ffffff',
+          main: '#f57c00',
+          contrastText: '#000000', // Black text meets WCAG AA contrast on orange; white does not
         },
         error: {
           main: '#d32f2f', // Darker red for better contrast with white text


### PR DESCRIPTION
### Purpose

White text on the warning (orange) palette color fails the 4.5:1 contrast ratio required for WCAG 2.1 AA (as low as ~1.9:1 in the worst case), making small Chip/Badge labels like "Beta" nearly illegible. Switch warning.contrastText to black across WSO2Theme, PaleIndigo, and PaleGray, matching the approach HighContrastTheme already used. All affected combinations now exceed 5.5:1.

### Related Issues

- Closes #521

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
