### PR TITLE
fix(UserMenu): show initials instead of person icon for non-URL avatars

### DIFF
--- a/packages/oxygen-ui-docs/stories/AppElements/UserMenu.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/AppElements/UserMenu.stories.tsx
@@ -43,7 +43,7 @@ The UserMenu is a compound component that provides a user profile dropdown menu 
 
 ### Features
 - Composable structure with Trigger, Header, Item, Logout, and Divider sub-components
-- User avatar button that opens dropdown (supports image URLs or text fallback)
+- User avatar button that opens dropdown (supports image URLs or initials text)
 - Option to show user name next to avatar with \`showName\` prop
 - User info header with name, email, and role badge
 - Customizable menu items for various actions
@@ -65,13 +65,13 @@ import { User, Settings, CreditCard, LogOut } from '@wso2/oxygen-ui-icons-react'
 <UserMenu>
   <UserMenu.Trigger 
     name="John Doe" 
-    avatar="/avatar.jpg"  // Image URL or null for initials
+    avatar="JD"  // Initials text, or an image URL like "/avatar.jpg"
     showName  // Optional: show name next to avatar
   />
   <UserMenu.Header 
     name="John Doe" 
     email="john@example.com" 
-    avatar="/avatar.jpg"
+    avatar="JD"
     role="Pro"  // Optional role badge
   />
   <UserMenu.Item
@@ -108,7 +108,7 @@ export const Composed: Story = {
   render: () => (
     <Box sx={{ p: 4 }}>
       <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
-        Composition Pattern - Click the avatar to open menu
+        Composition Pattern - Initials avatar on trigger and header
       </Typography>
       <UserMenu>
         <UserMenu.Trigger name="John Doe" avatar="JD" />
@@ -185,7 +185,7 @@ export const WithNameVisible: Story = {
   render: () => (
     <Box sx={{ p: 4 }}>
       <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
-        Avatar with name displayed
+        Initials avatar with name displayed
       </Typography>
       <UserMenu>
         <UserMenu.Trigger 

--- a/packages/oxygen-ui/src/components/UserMenu/UserMenu.tsx
+++ b/packages/oxygen-ui/src/components/UserMenu/UserMenu.tsx
@@ -33,7 +33,11 @@ export interface UserMenuUser {
   name: string;
   /** User email address */
   email: string;
-  /** Avatar text or initials */
+  /**
+   * Avatar image URL or initials text.
+   * Image-like values (`http(s):`, `/`, `data:`, `blob:`) are used as `src`.
+   * Other strings (e.g. `"JD"`) are shown as initials. If omitted, falls back to the first letter of `name`.
+   */
   avatar?: string;
   /** Role or plan badge (e.g., "Pro", "Admin") */
   role?: string;

--- a/packages/oxygen-ui/src/components/UserMenu/UserMenuHeader.tsx
+++ b/packages/oxygen-ui/src/components/UserMenu/UserMenuHeader.tsx
@@ -23,7 +23,7 @@ import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import { styled } from '@mui/material/styles';
-import type { UserMenuUser } from './UserMenu';
+import { getUserMenuAvatarProps } from './getUserMenuAvatarProps';
 
 /**
  * Props for the UserMenu.Header component.
@@ -33,7 +33,11 @@ export interface UserMenuHeaderProps {
   name: string;
   /** User email address */
   email: string;
-  /** Avatar image URL (if null, falls back to initials) */
+  /**
+   * Avatar image URL or initials text.
+   * Image-like values (`http(s):`, `/`, `data:`, `blob:`) are used as `src`.
+   * Other strings (e.g. `"JD"`) are shown as initials. If omitted, falls back to the first letter of `name`.
+   */
   avatar?: string | null;
   /** Role or plan badge (e.g., "Pro", "Admin") */
   role?: string;
@@ -146,12 +150,14 @@ const StyledEmail = styled(Typography, {
  * UserMenu.Header - User info section with name, email, and role badge.
  */
 export const UserMenuHeader: React.FC<UserMenuHeaderProps> = ({ name, email, avatar, role }) => {
+  const avatarProps = getUserMenuAvatarProps(name, avatar);
+
   return (
     <>
       <StyledHeaderBox>
         <StyledHeaderContent>
-          <StyledHeaderAvatar src={avatar || undefined} alt={name}>
-            {!avatar && name.charAt(0)}
+          <StyledHeaderAvatar src={avatarProps.src} alt={name}>
+            {avatarProps.children}
           </StyledHeaderAvatar>
           <StyledUserInfo>
             <StyledNameRow>

--- a/packages/oxygen-ui/src/components/UserMenu/UserMenuTrigger.tsx
+++ b/packages/oxygen-ui/src/components/UserMenu/UserMenuTrigger.tsx
@@ -22,6 +22,7 @@ import IconButton from '@mui/material/IconButton';
 import Avatar from '@mui/material/Avatar';
 import { styled } from '@mui/material/styles';
 import { useUserMenu } from './UserMenuContext';
+import { getUserMenuAvatarProps } from './getUserMenuAvatarProps';
 
 /**
  * Props for the UserMenu.Trigger component.
@@ -29,7 +30,11 @@ import { useUserMenu } from './UserMenuContext';
 export interface UserMenuTriggerProps {
   /** User display name */
   name: string;
-  /** Avatar image URL (if null, falls back to initials) */
+  /**
+   * Avatar image URL or initials text.
+   * Image-like values (`http(s):`, `/`, `data:`, `blob:`) are used as `src`.
+   * Other strings (e.g. `"JD"`) are shown as initials. If omitted, falls back to the first letter of `name`.
+   */
   avatar?: string | null;
   /** Whether to show the name text after the avatar */
   showName?: boolean;
@@ -87,6 +92,7 @@ const StyledNameText = styled('span', {
  */
 export const UserMenuTrigger: React.FC<UserMenuTriggerProps> = ({ name, avatar, showName = false }) => {
   const { open, handleOpen } = useUserMenu();
+  const avatarProps = getUserMenuAvatarProps(name, avatar);
 
   return (
     <Tooltip title="Account">
@@ -99,8 +105,8 @@ export const UserMenuTrigger: React.FC<UserMenuTriggerProps> = ({ name, avatar, 
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
       >
-        <StyledAvatar src={avatar || undefined} alt={name}>
-          {!avatar && name.charAt(0)}
+        <StyledAvatar src={avatarProps.src} alt={name}>
+          {avatarProps.children}
         </StyledAvatar>
         {showName && <StyledNameText>{name}</StyledNameText>}
       </StyledTrigger>

--- a/packages/oxygen-ui/src/components/UserMenu/getUserMenuAvatarProps.test.ts
+++ b/packages/oxygen-ui/src/components/UserMenu/getUserMenuAvatarProps.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  getUserMenuAvatarProps,
+  isUserMenuAvatarImageUrl,
+} from './getUserMenuAvatarProps';
+
+const NAME = 'Jane Doe';
+const NAME_INITIAL = 'J';
+
+describe('isUserMenuAvatarImageUrl', () => {
+  it('returns true for http(s), root-relative, data, and blob URLs', () => {
+    expect(isUserMenuAvatarImageUrl('https://cdn.example.com/a.png')).toBe(true);
+    expect(isUserMenuAvatarImageUrl('http://cdn.example.com/a.png')).toBe(true);
+    expect(isUserMenuAvatarImageUrl('/avatars/x.png')).toBe(true);
+    expect(isUserMenuAvatarImageUrl('data:image/png;base64,abc')).toBe(true);
+    expect(isUserMenuAvatarImageUrl('blob:https://example.com/uuid')).toBe(true);
+  });
+
+  it('returns false for initials and protocol-less hostnames', () => {
+    expect(isUserMenuAvatarImageUrl('JD')).toBe(false);
+    expect(isUserMenuAvatarImageUrl('avatar.example.com/pic.jpg')).toBe(false);
+  });
+});
+
+describe('getUserMenuAvatarProps', () => {
+  it('falls back to the name initial when avatar is omitted, null, or empty', () => {
+    expect(getUserMenuAvatarProps(NAME)).toEqual({ children: NAME_INITIAL });
+    expect(getUserMenuAvatarProps(NAME, null)).toEqual({ children: NAME_INITIAL });
+    expect(getUserMenuAvatarProps(NAME, '')).toEqual({ children: NAME_INITIAL });
+  });
+
+  it('treats non-URL strings as initials children', () => {
+    expect(getUserMenuAvatarProps(NAME, 'JD')).toEqual({ children: 'JD' });
+  });
+
+  it('uses https and http values as image src with name-initial children', () => {
+    const httpsUrl = 'https://cdn.example.com/a.png';
+    const httpUrl = 'http://cdn.example.com/a.png';
+
+    expect(getUserMenuAvatarProps(NAME, httpsUrl)).toEqual({
+      src: httpsUrl,
+      children: NAME_INITIAL,
+    });
+    expect(getUserMenuAvatarProps(NAME, httpUrl)).toEqual({
+      src: httpUrl,
+      children: NAME_INITIAL,
+    });
+  });
+
+  it('uses root-relative paths as image src with name-initial children', () => {
+    const path = '/avatars/x.png';
+
+    expect(getUserMenuAvatarProps(NAME, path)).toEqual({
+      src: path,
+      children: NAME_INITIAL,
+    });
+  });
+
+  it('uses data and blob URLs as image src with name-initial children', () => {
+    const dataUrl = 'data:image/png;base64,abc';
+    const blobUrl = 'blob:https://example.com/uuid';
+
+    expect(getUserMenuAvatarProps(NAME, dataUrl)).toEqual({
+      src: dataUrl,
+      children: NAME_INITIAL,
+    });
+    expect(getUserMenuAvatarProps(NAME, blobUrl)).toEqual({
+      src: blobUrl,
+      children: NAME_INITIAL,
+    });
+  });
+
+  it('does not treat protocol-less hostnames as image URLs', () => {
+    const protocolLess = 'avatar.example.com/pic.jpg';
+
+    expect(getUserMenuAvatarProps(NAME, protocolLess)).toEqual({
+      children: protocolLess,
+    });
+  });
+});

--- a/packages/oxygen-ui/src/components/UserMenu/getUserMenuAvatarProps.ts
+++ b/packages/oxygen-ui/src/components/UserMenu/getUserMenuAvatarProps.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Props resolved for MUI Avatar from a UserMenu `avatar` value.
+ */
+export interface UserMenuAvatarProps {
+  /** Image URL when `avatar` looks like a URL; otherwise undefined */
+  src?: string;
+  /** Initials or fallback letter shown when there is no image (or image fails) */
+  children: string;
+}
+
+const IMAGE_URL_PATTERN = /^(https?:|\/|data:|blob:)/i;
+
+/**
+ * Returns whether a string should be treated as an avatar image URL.
+ */
+export function isUserMenuAvatarImageUrl(value: string): boolean {
+  return IMAGE_URL_PATTERN.test(value);
+}
+
+/**
+ * Resolves MUI Avatar `src` and children from a UserMenu `avatar` value.
+ *
+ * - Image-like values (`http(s):`, `/`, `data:`, `blob:`) are used as `src`,
+ *   with the name initial as children for failed loads.
+ * - Other non-empty strings (e.g. `"JD"`) are treated as initials children.
+ * - Null/undefined falls back to the first character of `name`.
+ */
+export function getUserMenuAvatarProps(
+  name: string,
+  avatar?: string | null,
+): UserMenuAvatarProps {
+  const nameInitial = name.charAt(0);
+
+  if (!avatar) {
+    return { children: nameInitial };
+  }
+
+  if (isUserMenuAvatarImageUrl(avatar)) {
+    return {
+      src: avatar,
+      children: nameInitial,
+    };
+  }
+
+  return { children: avatar };
+}


### PR DESCRIPTION
### Purpose

UserMenu Trigger and Header treated every `avatar` value as an image `src`. Initials like `"JD"` caused a failed image load and MUI’s default person icon. `avatar` is now resolved as an image URL or initials text (with name-initial fallback), so Trigger and Header stay consistent. Fixes #261.

### Related Issues

- Fixes #261

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
