### PR TITLE
fix(accordion): add default expand icon for AccordionSummary

### DIFF
--- a/packages/oxygen-ui-docs/stories/Surfaces/Accordion.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Surfaces/Accordion.stories.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,13 +18,14 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 import { Accordion, AccordionSummary, AccordionDetails, Typography, Stack } from '@wso2/oxygen-ui';
+import { ChevronDown, Minus, Plus } from '@wso2/oxygen-ui-icons-react';
 import React from 'react';
 
 /**
  * The Accordion component allows users to show and hide sections of content.
  * It's useful for grouping related information and reducing visual clutter.
- * 
- * This is a direct import of MUI accordion component. 
+ *
+ * This is a direct import of MUI accordion component.
  * Read more at: https://mui.com/material-ui/react-accordion/
  */
 const meta: Meta<typeof Accordion> = {
@@ -34,9 +35,15 @@ const meta: Meta<typeof Accordion> = {
     layout: 'centered',
     docs: {
       description: {
-        component: 'Oxygen UI accordion component is a direct import of MUI accordion component. \n\n' + 
-        'Read MUI documentation for complete API : ' +
-        '[https://mui.com/material-ui/react-accordion/](https://mui.com/material-ui/react-accordion/)',
+        component:
+          'Oxygen UI accordion component is a direct import of MUI accordion component.\n\n' +
+          'Oxygen supplies a default `expandIcon` (`ChevronDown`) via the theme on ' +
+          '`AccordionSummary`. MUI rotates that icon 180° when expanded, which suits chevrons. ' +
+          'Pass a custom `expandIcon` to override, or `expandIcon={null}` to hide it.\n\n' +
+          'For non-chevron icons (e.g. Plus/Minus), swap the icon from expanded state and disable ' +
+          'the expand-icon wrapper rotation with `sx` — see the CustomExpandIcon story.\n\n' +
+          'Read MUI documentation for complete API: ' +
+          '[https://mui.com/material-ui/react-accordion/](https://mui.com/material-ui/react-accordion/)',
       },
     },
   },
@@ -50,7 +57,10 @@ export const Default: Story = {
   render: () => (
     <div style={{ width: 400 }}>
       <Accordion>
-        <AccordionSummary>
+        <AccordionSummary
+          id="panel1-header"
+          aria-controls="panel1-content"
+        >
           <Typography>Accordion 1</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -61,7 +71,10 @@ export const Default: Story = {
         </AccordionDetails>
       </Accordion>
       <Accordion>
-        <AccordionSummary>
+        <AccordionSummary
+          id="panel2-header"
+          aria-controls="panel2-content"
+        >
           <Typography>Accordion 2</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -79,7 +92,10 @@ export const Expanded: Story = {
   render: () => (
     <div style={{ width: 400 }}>
       <Accordion defaultExpanded>
-        <AccordionSummary>
+        <AccordionSummary
+          id="expanded-header"
+          aria-controls="expanded-content"
+        >
           <Typography>Expanded by Default</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -96,7 +112,10 @@ export const Disabled: Story = {
   render: () => (
     <div style={{ width: 400 }}>
       <Accordion disabled>
-        <AccordionSummary>
+        <AccordionSummary
+          id="disabled-header"
+          aria-controls="disabled-content"
+        >
           <Typography>Disabled Accordion</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -113,7 +132,10 @@ export const Multiple: Story = {
   render: () => (
     <Stack spacing={0} sx={{ width: 400 }}>
       <Accordion>
-        <AccordionSummary>
+        <AccordionSummary
+          id="general-header"
+          aria-controls="general-content"
+        >
           <Typography>General Settings</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -123,7 +145,10 @@ export const Multiple: Story = {
         </AccordionDetails>
       </Accordion>
       <Accordion>
-        <AccordionSummary>
+        <AccordionSummary
+          id="security-header"
+          aria-controls="security-content"
+        >
           <Typography>Security</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -133,7 +158,10 @@ export const Multiple: Story = {
         </AccordionDetails>
       </Accordion>
       <Accordion>
-        <AccordionSummary>
+        <AccordionSummary
+          id="advanced-header"
+          aria-controls="advanced-content"
+        >
           <Typography>Advanced</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -144,4 +172,69 @@ export const Multiple: Story = {
       </Accordion>
     </Stack>
   ),
+};
+
+export const ExpandIcon: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same disclosure icon as the theme default (`ChevronDown`), passed explicitly via ' +
+          '`expandIcon`. Useful when documenting or overriding the prop.',
+      },
+    },
+  },
+  render: () => (
+    <div style={{ width: 400 }}>
+      <Accordion>
+        <AccordionSummary
+          id="explicit-icon-header"
+          aria-controls="explicit-icon-content"
+          expandIcon={<ChevronDown />}
+        >
+          <Typography>Expand Icon</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography>
+            Same disclosure icon as the theme default, passed explicitly via expandIcon.
+            MUI rotates the chevron 180° when expanded.
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  ),
+};
+
+export const CustomExpandIcon: Story = {
+  render: function CustomExpandIconStory() {
+    const [expanded, setExpanded] = React.useState(false);
+
+    return (
+      <div style={{ width: 400 }}>
+        <Accordion
+          expanded={expanded}
+          onChange={(_, isExpanded) => setExpanded(isExpanded)}
+        >
+          <AccordionSummary
+            id="custom-icon-header"
+            aria-controls="custom-icon-content"
+            expandIcon={expanded ? <Minus /> : <Plus />}
+            sx={{
+              '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
+                transform: 'rotate(0deg)',
+              },
+            }}
+          >
+            <Typography>Custom Expand Icon</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>
+              Non-chevron icons should swap by expanded state (Plus/Minus) and disable
+              MUI&apos;s 180° expand-icon rotation.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+      </div>
+    );
+  },
 };

--- a/packages/oxygen-ui/src/styles/OxygenThemeBase.test.tsx
+++ b/packages/oxygen-ui/src/styles/OxygenThemeBase.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Accordion, AccordionSummary } from '@mui/material';
+import OxygenUIThemeProvider from '../contexts/OxygenUIThemeProvider/OxygenUIThemeProvider';
+
+describe('OxygenThemeBase MuiAccordionSummary defaults', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a default ChevronDown expand icon when expandIcon is not provided', () => {
+    const { container } = render(
+      <OxygenUIThemeProvider>
+        <Accordion>
+          <AccordionSummary>Summary</AccordionSummary>
+        </Accordion>
+      </OxygenUIThemeProvider>
+    );
+
+    const expandIconWrapper = container.querySelector(
+      '.MuiAccordionSummary-expandIconWrapper'
+    );
+    expect(expandIconWrapper).not.toBeNull();
+    expect(
+      expandIconWrapper?.querySelector('svg.lucide-chevron-down')
+    ).not.toBeNull();
+  });
+
+  it('allows overriding the default expand icon', () => {
+    const { container, getByTestId } = render(
+      <OxygenUIThemeProvider>
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<span data-testid="custom-expand-icon" />}
+          >
+            Summary
+          </AccordionSummary>
+        </Accordion>
+      </OxygenUIThemeProvider>
+    );
+
+    expect(getByTestId('custom-expand-icon')).toBeTruthy();
+    expect(
+      container.querySelector('svg.lucide-chevron-down')
+    ).toBeNull();
+  });
+
+  it('hides the expand icon when expandIcon is null', () => {
+    const { container } = render(
+      <OxygenUIThemeProvider>
+        <Accordion>
+          <AccordionSummary expandIcon={null}>Summary</AccordionSummary>
+        </Accordion>
+      </OxygenUIThemeProvider>
+    );
+
+    expect(
+      container.querySelector('.MuiAccordionSummary-expandIconWrapper')
+    ).toBeNull();
+  });
+});

--- a/packages/oxygen-ui/src/styles/OxygenThemeBase.ts
+++ b/packages/oxygen-ui/src/styles/OxygenThemeBase.ts
@@ -173,6 +173,20 @@ const OxygenThemeBase = extendTheme({
     },
   },
   components: {
+    MuiAccordionSummary: {
+      defaultProps: {
+        expandIcon: React.createElement(ChevronDown),
+      },
+      styleOverrides: {
+        root: ({ theme }) => ({
+          fontWeight: theme.typography.fontWeightMedium,
+          '&:hover:not(.Mui-disabled)': {
+            backgroundColor: (theme.vars || theme).palette.action.hover,
+            cursor: 'pointer',
+          },
+        }),
+      },
+    },
     MuiAutocomplete: {
       defaultProps: {
         popupIcon: React.createElement(ChevronDown),

--- a/packages/oxygen-ui/src/styles/OxygenThemeBase.ts
+++ b/packages/oxygen-ui/src/styles/OxygenThemeBase.ts
@@ -180,6 +180,9 @@ const OxygenThemeBase = extendTheme({
       styleOverrides: {
         root: ({ theme }) => ({
           fontWeight: theme.typography.fontWeightMedium,
+          '& .MuiTypography-root': {
+            fontWeight: theme.typography.fontWeightMedium,
+          },
           '&:hover:not(.Mui-disabled)': {
             backgroundColor: (theme.vars || theme).palette.action.hover,
             cursor: 'pointer',


### PR DESCRIPTION
### Purpose

Accordions previously had no default disclosure icon, so headers looked like static text and were hard to discover as expandable ([#514](https://github.com/wso2/oxygen-ui/issues/514)).

This PR:

- Sets a theme-default `expandIcon` (`ChevronDown`) on `MuiAccordionSummary`, with medium font weight and hover styles for clearer hierarchy
- Updates Accordion Storybook stories with `id` / `aria-controls`, docs notes, an explicit `ChevronDown` `expandIcon` story, and a Plus/Minus custom expand-icon story

### Related Issues

- Fixes #514

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [x] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?