### PR TITLE
fix(react): prevent text overflow in UI components (#529)

### DIFF
--- a/packages/oxygen-ui/src/components/Form/CardButton.tsx
+++ b/packages/oxygen-ui/src/components/Form/CardButton.tsx
@@ -43,6 +43,7 @@ const StyledCardButton = styled(Card, {
   alignItems: alignItems,
   display: 'flex',
   textAlign: 'left',
+  overflow: 'hidden',
   transition: 'all 0.3s ease',
   cursor: 'pointer',
   "&.MuiCard-root": {

--- a/packages/oxygen-ui/src/components/Form/ElementWrapper.tsx
+++ b/packages/oxygen-ui/src/components/Form/ElementWrapper.tsx
@@ -17,6 +17,7 @@
  */
 
 import { FormControl, FormLabel } from '@mui/material'
+import { styled } from '@mui/material/styles'
 import React from 'react'
 
 export interface ElementWrapperProps {
@@ -25,11 +26,17 @@ export interface ElementWrapperProps {
   children?: React.ReactNode
 }
 
+const StyledFormLabel = styled(FormLabel)({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
 export const ElementWrapper = (props: ElementWrapperProps) => {
   const { label, name, children } = props
   return (
     <FormControl fullWidth>
-      <FormLabel htmlFor={name}>{label}</FormLabel>
+      <StyledFormLabel htmlFor={name}>{label}</StyledFormLabel>
       {children}
     </FormControl>
   )

--- a/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableCell.tsx
+++ b/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableCell.tsx
@@ -43,10 +43,14 @@ const StyledTableCell = styled(MuiTableCell, {
     return !excludedProps.some((excluded) => excluded === prop);
   },
 })<StyledTableCellProps>(({ truncate, maxWidth }) => ({
+  overflowWrap: 'break-word',
+  wordBreak: 'break-word',
   ...(truncate && {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    overflowWrap: 'unset',
+    wordBreak: 'unset',
   }),
   ...(maxWidth && {
     maxWidth: typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth,

--- a/packages/oxygen-ui/src/components/PageTitle/PageTitleHeader.tsx
+++ b/packages/oxygen-ui/src/components/PageTitle/PageTitleHeader.tsx
@@ -38,6 +38,9 @@ const PageTitleHeaderStyled = styled(Typography, {
   slot: 'Header',
 })<TypographyProps>(({ theme }) => ({
   color: theme.vars?.palette.text.primary || theme.palette.text.primary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 }));
 
 /**

--- a/packages/oxygen-ui/src/components/PageTitle/PageTitleSubHeader.tsx
+++ b/packages/oxygen-ui/src/components/PageTitle/PageTitleSubHeader.tsx
@@ -41,6 +41,8 @@ const PageTitleSubHeaderStyled = styled(Typography, {
   lineHeight: 1.43,
   letterSpacing: '0.01071em',
   color: theme.vars?.palette.text.secondary || theme.palette.text.secondary,
+  overflowWrap: 'break-word',
+  wordBreak: 'break-word',
 }));
 
 /**

--- a/packages/oxygen-ui/src/components/Sidebar/SidebarItemLabel.tsx
+++ b/packages/oxygen-ui/src/components/Sidebar/SidebarItemLabel.tsx
@@ -55,6 +55,8 @@ const SidebarItemLabelRoot = styled(ListItemText, {
   '& .MuiListItemText-primary': {
     fontSize: 14,
     fontWeight: ownerState.isActive ? 600 : 400,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 }));
 

--- a/packages/oxygen-ui/src/components/StatCard/StatCard.tsx
+++ b/packages/oxygen-ui/src/components/StatCard/StatCard.tsx
@@ -80,9 +80,11 @@ const StatCard: React.FC<StatCardProps> = ({
               {icon}
             </Box>
           )}
-          <Box>
-            <Typography variant="h5">{value}</Typography>
-            <Typography variant="body2" color="text.secondary">
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="h5" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {value}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {label}
             </Typography>
           </Box>


### PR DESCRIPTION
Add text overflow handling across Oxygen UI components:
- PageTitleHeader: ellipsis truncation for long titles
- PageTitleSubHeader: word-break wrapping for long subheaders
- StatCard: ellipsis truncation on value/label with minWidth:0 flex fix
- Form.CardButton: overflow hidden to contain card content
- Form.ElementWrapper: ellipsis truncation on FormLabel
- SidebarItemLabel: ellipsis truncation on sidebar item primary text
- ListingTableCell: overflow-wrap break-word baseline with truncate override

### Purpose

<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

### Related Issues

- N/A

### Related PRs

- N/A

### Checklist

- [ ] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
