### PR TITLE
fix(form): CardButton nested-interactive a11y violation (#562)

### DIFF
--- a/packages/oxygen-ui/src/components/Form/CardButton.tsx
+++ b/packages/oxygen-ui/src/components/Form/CardButton.tsx
@@ -43,6 +43,7 @@ const StyledCardButton = styled(Card, {
   alignItems: alignItems,
   display: 'flex',
   textAlign: 'left',
+  overflow: 'hidden',
   transition: 'all 0.3s ease',
   cursor: 'pointer',
   "&.MuiCard-root": {

--- a/packages/oxygen-ui/src/components/Form/CardButton.tsx
+++ b/packages/oxygen-ui/src/components/Form/CardButton.tsx
@@ -69,14 +69,20 @@ const StyledCardButton = styled(Card, {
   },
 }));
 
-const isInteractiveElement = (element: HTMLElement): boolean =>
-  !!element.closest('button, a, input, select, textarea, [role="button"], [role="link"]');
+const isInteractiveDescendant = (target: HTMLElement, currentTarget: HTMLElement): boolean => {
+  const interactiveElement = target.closest(
+    'button, a, input, select, textarea, [role="button"], [role="link"]',
+  );
+  return !!interactiveElement && interactiveElement !== currentTarget;
+};
 
 export const CardButton = (props: CardButtonProps) => {
   const { disabled, selected, alignItems = 'flex-start', onClick, onKeyDown, ...rest } = props;
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (disabled) return;
+    if (isInteractiveDescendant(event.target as HTMLElement, event.currentTarget)) return;
+
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       onClick?.();
@@ -86,7 +92,7 @@ export const CardButton = (props: CardButtonProps) => {
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (disabled) return;
-    if (isInteractiveElement(event.target as HTMLElement)) return;
+    if (isInteractiveDescendant(event.target as HTMLElement, event.currentTarget)) return;
     onClick?.();
   };
 

--- a/packages/oxygen-ui/src/components/Form/CardButton.tsx
+++ b/packages/oxygen-ui/src/components/Form/CardButton.tsx
@@ -17,9 +17,9 @@
  */
 
 import React from 'react';
-import { Card, ButtonBase, Box, styled, BoxProps } from '@mui/material';
+import { Card, Box, styled, BoxProps } from '@mui/material';
 
-export interface CardButtonProps extends CardProps {
+export interface CardButtonProps extends Omit<CardProps, 'component'> {
   alignItems?: 'flex-start' | 'center' | 'flex-end'
   children: React.ReactNode
   onClick?: () => void
@@ -63,15 +63,43 @@ const StyledCardButton = styled(Card, {
       boxShadow: theme.shadows[1],
     }),
   },
+  '&:focus-visible': {
+    outline: `2px solid ${theme.palette.primary.main}`,
+    outlineOffset: '2px',
+  },
 }));
 
+const isInteractiveElement = (element: HTMLElement): boolean =>
+  !!element.closest('button, a, input, select, textarea, [role="button"], [role="link"]');
+
 export const CardButton = (props: CardButtonProps) => {
-  const { disabled, selected, alignItems = 'flex-start', ...rest } = props;
+  const { disabled, selected, alignItems = 'flex-start', onClick, onKeyDown, ...rest } = props;
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick?.();
+    }
+    onKeyDown?.(event);
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    if (isInteractiveElement(event.target as HTMLElement)) return;
+    onClick?.();
+  };
 
   return (
     <StyledCardButton
       alignItems={alignItems}
-      component={ButtonBase}
+      component="div"
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-pressed={selected}
+      aria-disabled={disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
       selected={selected}
       disabled={disabled}
       {...rest}

--- a/packages/oxygen-ui/src/components/Form/ElementWrapper.tsx
+++ b/packages/oxygen-ui/src/components/Form/ElementWrapper.tsx
@@ -17,6 +17,7 @@
  */
 
 import { FormControl, FormLabel } from '@mui/material'
+import { styled } from '@mui/material/styles'
 import React from 'react'
 
 export interface ElementWrapperProps {
@@ -25,11 +26,17 @@ export interface ElementWrapperProps {
   children?: React.ReactNode
 }
 
+const StyledFormLabel = styled(FormLabel)({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
 export const ElementWrapper = (props: ElementWrapperProps) => {
   const { label, name, children } = props
   return (
     <FormControl fullWidth>
-      <FormLabel htmlFor={name}>{label}</FormLabel>
+      <StyledFormLabel htmlFor={name}>{label}</StyledFormLabel>
       {children}
     </FormControl>
   )

--- a/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableCell.tsx
+++ b/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableCell.tsx
@@ -43,10 +43,14 @@ const StyledTableCell = styled(MuiTableCell, {
     return !excludedProps.some((excluded) => excluded === prop);
   },
 })<StyledTableCellProps>(({ truncate, maxWidth }) => ({
+  overflowWrap: 'break-word',
+  wordBreak: 'break-word',
   ...(truncate && {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    overflowWrap: 'unset',
+    wordBreak: 'unset',
   }),
   ...(maxWidth && {
     maxWidth: typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth,

--- a/packages/oxygen-ui/src/components/PageTitle/PageTitleHeader.tsx
+++ b/packages/oxygen-ui/src/components/PageTitle/PageTitleHeader.tsx
@@ -38,6 +38,9 @@ const PageTitleHeaderStyled = styled(Typography, {
   slot: 'Header',
 })<TypographyProps>(({ theme }) => ({
   color: theme.vars?.palette.text.primary || theme.palette.text.primary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 }));
 
 /**

--- a/packages/oxygen-ui/src/components/PageTitle/PageTitleSubHeader.tsx
+++ b/packages/oxygen-ui/src/components/PageTitle/PageTitleSubHeader.tsx
@@ -41,6 +41,8 @@ const PageTitleSubHeaderStyled = styled(Typography, {
   lineHeight: 1.43,
   letterSpacing: '0.01071em',
   color: theme.vars?.palette.text.secondary || theme.palette.text.secondary,
+  overflowWrap: 'break-word',
+  wordBreak: 'break-word',
 }));
 
 /**

--- a/packages/oxygen-ui/src/components/Sidebar/SidebarItemLabel.tsx
+++ b/packages/oxygen-ui/src/components/Sidebar/SidebarItemLabel.tsx
@@ -55,6 +55,8 @@ const SidebarItemLabelRoot = styled(ListItemText, {
   '& .MuiListItemText-primary': {
     fontSize: 14,
     fontWeight: ownerState.isActive ? 600 : 400,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 }));
 

--- a/packages/oxygen-ui/src/components/StatCard/StatCard.tsx
+++ b/packages/oxygen-ui/src/components/StatCard/StatCard.tsx
@@ -80,9 +80,11 @@ const StatCard: React.FC<StatCardProps> = ({
               {icon}
             </Box>
           )}
-          <Box>
-            <Typography variant="h5">{value}</Typography>
-            <Typography variant="body2" color="text.secondary">
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="h5" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {value}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {label}
             </Typography>
           </Box>


### PR DESCRIPTION
## Problem

`Form.CardButton` renders as `<Card component={ButtonBase}>`, making the entire card a `<button>` element. When consumers place interactive elements inside (buttons, tooltips, links), this creates **nested interactive controls inside a button** — a WCAG 4.1.2 A11y violation.

**Affected consumers:**
- `SampleAppCard` — `<Button>` nested inside card
- `IntegrationTypeCard` — `<Tooltip>` nested inside card
- `ComponentCreate` — `<Button>` nested inside card
- `ClickableCard` stories — `<Button>` + `<Tooltip>` nested inside card

## Fix

Changed `CardButton` from rendering as `<button>` to `<div role="button">`:

- `component="div"` + `role="button"` — eliminates nested-interactive violation since `<div>` is not an interactive element
- Keyboard handling — Enter/Space key activation via `onKeyDown`
- ARIA state — `aria-pressed` (selected), `aria-disabled`
- Focus style — `&:focus-visible` outline
- Click guard — `isInteractiveElement()` helper auto-ignores clicks from nested `<button>`, `<a>`, `<input>`, etc.

No consumer changes needed — nested interactive clicks are automatically skipped.
