### PR TITLE
fix(a11y): name NotificationPanel drawer and announce new items

### DIFF
--- a/packages/oxygen-ui-docs/ACCESSIBILITY.md
+++ b/packages/oxygen-ui-docs/ACCESSIBILITY.md
@@ -37,7 +37,7 @@
 | `ListingTable.DataGrid` | Cell/header focus outlines were removed with no replacement. | 2.4.7 | `:focus-visible` outline restored using the theme primary color (mouse `:focus` stays clean). |
 | `ListingTable.Toolbar` | Clear-search icon button unlabeled; search input named only by placeholder; container had no toolbar semantics. | 4.1.2 | `aria-label="Clear search"`; input `aria-label`; `role="toolbar"` + label. |
 | `ListingTable.DensityControl` | Icon-only toggle buttons relied on tooltips. | 4.1.2 | `aria-label` per toggle and on the group; icons hidden. |
-| `NotificationPanel` | Header close and item dismiss icon buttons unlabeled. | 4.1.2 | `aria-label="Close notifications"` / `"Dismiss notification"`; icons hidden. |
+| `NotificationPanel` | Header close and item dismiss icon buttons unlabeled. Drawer had no accessible name; new items were not announced. | 4.1.2, 4.1.3 | `aria-label="Close notifications"` / `"Dismiss notification"`; icons hidden. Default drawer `aria-label="Notifications"` (overridable). Polite live region for consumer-published status (`liveAnnouncement` / `setLiveAnnouncement`); list child-count is not auto-announced (avoids filter/tab false positives). Subcomponent `aria-*` prop forwarding remains in [#559](https://github.com/wso2/oxygen-ui/issues/559). |
 | `NotificationBanner` | MUI light-mode filled `info`/`warning` Alerts fail 4.5:1 with white text (3.85:1 / 3.11:1). | 1.4.3 | Light mode: `info` uses `info.dark` background; `warning` switches to black text/icons. |
 | `CodeBlock` + theme `syntax` tokens | Light-mode syntax colors `#d73a49` (4.19:1) and `#6a737d` (4.41:1) fail on `#f5f5f5`. | 1.4.3 | Darkened to `#cf222e` (4.91:1) and `#57606a` (5.86:1) in both the theme tokens and component fallbacks. |
 | `Footer.Version` | `text.disabled` at 11px = 2.67:1 on white. | 1.4.3 | Uses `text.secondary`. |
@@ -64,7 +64,6 @@
 | [#557](https://github.com/wso2/oxygen-ui/issues/557) | **Epic:** Ensure WCAG 2.2 AA compliance across Oxygen UI | — |
 | [#558](https://github.com/wso2/oxygen-ui/issues/558) | Brand primary `#FF7300` fails WCAG AA 4.5:1 text contrast (Classic/WSO2 themes) | High (needs design decision) |
 | [#559](https://github.com/wso2/oxygen-ui/issues/559) | `forwardRef` + full prop forwarding rollout for remaining compound components | Medium |
-| [#560](https://github.com/wso2/oxygen-ui/issues/560) | NotificationPanel live-region announcements and drawer labeling | Medium |
 | [#561](https://github.com/wso2/oxygen-ui/issues/561) | Medium/low severity wrapper-audit follow-ups (SVG roles, landmark guidance, `aria-describedby` for form errors, hardcoded colors, decorative icons) | Medium/Low |
 | [#562](https://github.com/wso2/oxygen-ui/issues/562) | `Form.CardButton` nests interactive controls inside a `<button>` (`nested-interactive`) | High |
 | [#563](https://github.com/wso2/oxygen-ui/issues/563) | Manual AT pass (VoiceOver/NVDA, zoom 200%/400%) | High |
@@ -80,7 +79,7 @@ Counts below are CSF story modules with a meta-level `parameters.a11y.options.ru
 
 These require a human with real assistive technology and are tracked in [#563](https://github.com/wso2/oxygen-ui/issues/563):
 
-1. **Screen reader pass** (VoiceOver on macOS, NVDA on Windows) over: `AppShell` + `Sidebar` navigation, `UserMenu`, `NotificationPanel` (see [#560](https://github.com/wso2/oxygen-ui/issues/560)), `ListingTable` (table semantics and sort announcements), `ComplexSelect`, Form templates (error announcement flow — `aria-describedby` wiring is tracked in [#561](https://github.com/wso2/oxygen-ui/issues/561)).
+1. **Screen reader pass** (VoiceOver on macOS, NVDA on Windows) over: `AppShell` + `Sidebar` navigation, `UserMenu`, `NotificationPanel` (drawer name + consumer-published live region), `ListingTable` (table semantics and sort announcements), `ComplexSelect`, Form templates (error announcement flow — `aria-describedby` wiring is tracked in [#561](https://github.com/wso2/oxygen-ui/issues/561)).
 2. **Zoom/reflow** at 200% and 400% (WCAG 1.4.10) on `AppShell`, `Layout`, `Sidebar`, and the Templates stories.
 3. **Focus visible** (WCAG 2.4.7) — confirm keyboard focus is visible; the theme files do not suppress `:focus-visible` anywhere (verified by source audit), so MUI defaults apply.
 4. **Focus-indicator contrast** (≥ 3:1, WCAG 1.4.11) — spot-checks per theme in both color schemes.

--- a/packages/oxygen-ui-docs/stories/Accessibility.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Accessibility.stories.tsx
@@ -52,7 +52,7 @@ const keyboardMap: Array<{ component: string; interaction: string }> = [
   { component: 'AppBreadcrumbs', interaction: 'Tab reaches each crumb and the "…" overflow button; Enter/Space on "…" opens the hidden-crumbs menu (Arrow keys + Escape supported).' },
   { component: 'Sidebar', interaction: 'Tab/Arrow through items; Enter/Space activates or expands. When collapsed, Enter/Space on a parent opens the nested-items popover.' },
   { component: 'Header.Toggle', interaction: 'Enter/Space toggles the sidebar; the button exposes aria-expanded for the current state.' },
-  { component: 'NotificationPanel', interaction: 'Renders in an MUI Drawer: focus moves into the panel on open, Escape closes it. Tabs inside follow Arrow-key navigation.' },
+  { component: 'NotificationPanel', interaction: 'Named MUI Drawer (default aria-label "Notifications"); focus moves into the panel on open, Escape closes it. Tabs follow Arrow-key navigation. Consumers publish status via liveAnnouncement or useNotificationPanel().setLiveAnnouncement when items arrive (list child-count is not auto-announced).' },
   { component: 'ListingTable', interaction: 'Sort headers are focusable buttons (Enter/Space toggles sort). The DataGrid variant supports full MUI DataGrid keyboard navigation with a visible focus ring.' },
   { component: 'SearchBarWithAdvancedFilter', interaction: 'Filter button is labeled and opens an MUI Popover with focus management; Escape closes it.' },
 ];

--- a/packages/oxygen-ui-docs/stories/AppElements/NotificationPanel.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/AppElements/NotificationPanel.stories.tsx
@@ -98,8 +98,10 @@ import { NotificationPanel } from '@wso2/oxygen-ui';
         
 ### Accessibility
 - Opens in an MUI Drawer with focus management; Escape closes the panel.
+- The drawer is named \`Notifications\` by default (\`aria-label\`, overridable).
 - The header close button and per-item dismiss buttons have accessible names built in.
-- New notifications are not announced automatically yet — see the accessibility audit for the tracked live-region follow-up.
+- New arrivals are not inferred from list child count (filtering/tabs would false-positive). Publish via \`liveAnnouncement\` or \`useNotificationPanel().setLiveAnnouncement\` when items actually arrive.
+- Spreading custom \`aria-*\` onto Header/List/Item subcomponents is tracked in the prop-forwarding follow-up.
 `,
       },
     },
@@ -362,6 +364,87 @@ export const EmptyState: Story = {
             <NotificationPanel.HeaderClose />
           </NotificationPanel.Header>
           <NotificationPanel.EmptyState />
+        </NotificationPanel>
+      </Box>
+    );
+  },
+};
+
+/**
+ * Demonstrates consumer-driven polite live-region announcements.
+ * Useful for assistive-technology smoke checks (drawer name + status updates).
+ */
+export const LiveAnnouncements: Story = {
+  render: () => {
+    const [open, setOpen] = React.useState(true);
+    const [notifications, setNotifications] = React.useState(sampleNotifications.slice(0, 2));
+    const [liveAnnouncement, setLiveAnnouncement] = React.useState<string | undefined>(undefined);
+    const nextIdRef = React.useRef(100);
+
+    const handleAddNotification = () => {
+      const id = String(nextIdRef.current++);
+      setNotifications((prev) => [
+        {
+          id,
+          type: 'info' as const,
+          title: `New notification ${id}`,
+          message: 'Arrived while the panel was open — announced via the polite live region.',
+          timestamp: 'Just now',
+          avatar: 'N',
+          read: false,
+        },
+        ...prev,
+      ]);
+      // Publish explicitly when an item actually arrives (do not rely on list child count).
+      // Clear first so repeated identical messages still reach the panel (React state bailout).
+      setLiveAnnouncement('');
+      queueMicrotask(() => setLiveAnnouncement('1 new notification'));
+    };
+
+    const handleSyncStatus = () => {
+      setLiveAnnouncement(`${notifications.length} notifications synced`);
+    };
+
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, alignItems: 'flex-start' }}>
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          <Button variant="outlined" onClick={() => setOpen(true)}>
+            Open Notifications
+          </Button>
+          <Button variant="contained" onClick={handleAddNotification} disabled={!open}>
+            Add notification
+          </Button>
+          <Button variant="outlined" onClick={handleSyncStatus} disabled={!open}>
+            Sync status
+          </Button>
+        </Box>
+        <Typography variant="body2" color="text.secondary">
+          Open the panel, then use Add notification or Sync status to publish via the
+          `liveAnnouncement` prop. Check the Storybook Accessibility panel / a screen reader.
+        </Typography>
+        <NotificationPanel
+          open={open}
+          onClose={() => setOpen(false)}
+          liveAnnouncement={liveAnnouncement}
+        >
+          <NotificationPanel.Header>
+            <NotificationPanel.HeaderIcon><Bell size={20} /></NotificationPanel.HeaderIcon>
+            <NotificationPanel.HeaderTitle>Notifications</NotificationPanel.HeaderTitle>
+            <NotificationPanel.HeaderBadge>{notifications.length}</NotificationPanel.HeaderBadge>
+            <NotificationPanel.HeaderClose />
+          </NotificationPanel.Header>
+          <NotificationPanel.List>
+            {notifications.map((n) => (
+              <NotificationPanel.Item key={n.id} id={n.id} type={n.type}>
+                <NotificationPanel.ItemAvatar>
+                  <Avatar sx={{ width: 32, height: 32, fontSize: 12 }}>{n.avatar}</Avatar>
+                </NotificationPanel.ItemAvatar>
+                <NotificationPanel.ItemTitle>{n.title}</NotificationPanel.ItemTitle>
+                <NotificationPanel.ItemMessage>{n.message}</NotificationPanel.ItemMessage>
+                <NotificationPanel.ItemTimestamp>{n.timestamp}</NotificationPanel.ItemTimestamp>
+              </NotificationPanel.Item>
+            ))}
+          </NotificationPanel.List>
         </NotificationPanel>
       </Box>
     );

--- a/packages/oxygen-ui/src/components/NotificationPanel/NotificationList.tsx
+++ b/packages/oxygen-ui/src/components/NotificationPanel/NotificationList.tsx
@@ -50,6 +50,9 @@ export interface NotificationListProps {
  * NotificationList - Scrollable container for notification items.
  *
  * Renders a list of NotificationItem components with optional dividers.
+ * Does not auto-announce list changes (filtering/tabs can change child count
+ * without new arrivals). Consumers should publish via `liveAnnouncement` or
+ * `useNotificationPanel().setLiveAnnouncement` when items actually arrive.
  */
 export const NotificationList: React.FC<NotificationListProps> = ({
   children,

--- a/packages/oxygen-ui/src/components/NotificationPanel/NotificationPanel.tsx
+++ b/packages/oxygen-ui/src/components/NotificationPanel/NotificationPanel.tsx
@@ -203,20 +203,39 @@ const NotificationPanel: React.FC<NotificationPanelProps> & {
 
   const [liveAnnouncement, setLiveAnnouncementState] = React.useState('');
   const [liveAnnouncementNonce, setLiveAnnouncementNonce] = React.useState(0);
+  // Start undefined so the first open with a prop still publishes once.
+  const prevLiveAnnouncementPropRef = React.useRef<string | undefined>(undefined);
 
-  const publishLiveAnnouncement = React.useCallback((message: string) => {
-    setLiveAnnouncementState(message);
-    setLiveAnnouncementNonce((n) => n + 1);
-  }, []);
+  // Announcements are events while open only (persistent/permanent keep content mounted when closed).
+  const publishLiveAnnouncement = React.useCallback(
+    (message: string) => {
+      if (!open) return;
+      setLiveAnnouncementState(message);
+      setLiveAnnouncementNonce((n) => n + 1);
+    },
+    [open]
+  );
 
-  // Sync prop ↔ display state while open; clear on close. Re-publish on reopen even when
-  // the prop value is unchanged (deps would otherwise skip the prop-only effect).
+  // Clear on close; publish only when the prop *changes* while open (no reopen repeat).
+  // Clear stale text when the prop becomes undefined while open.
   React.useEffect(() => {
     if (!open) {
       setLiveAnnouncementState('');
+      prevLiveAnnouncementPropRef.current = liveAnnouncementProp;
       return;
     }
-    if (liveAnnouncementProp !== undefined) {
+
+    const prev = prevLiveAnnouncementPropRef.current;
+    prevLiveAnnouncementPropRef.current = liveAnnouncementProp;
+
+    if (liveAnnouncementProp === undefined) {
+      if (prev !== undefined) {
+        setLiveAnnouncementState('');
+      }
+      return;
+    }
+
+    if (liveAnnouncementProp !== prev) {
       publishLiveAnnouncement(liveAnnouncementProp);
     }
   }, [open, liveAnnouncementProp, publishLiveAnnouncement]);

--- a/packages/oxygen-ui/src/components/NotificationPanel/NotificationPanel.tsx
+++ b/packages/oxygen-ui/src/components/NotificationPanel/NotificationPanel.tsx
@@ -209,18 +209,17 @@ const NotificationPanel: React.FC<NotificationPanelProps> & {
     setLiveAnnouncementNonce((n) => n + 1);
   }, []);
 
-  // Prop changes push into the shared display state so context publishes are not silenced.
-  React.useEffect(() => {
-    if (liveAnnouncementProp !== undefined) {
-      publishLiveAnnouncement(liveAnnouncementProp);
-    }
-  }, [liveAnnouncementProp, publishLiveAnnouncement]);
-
+  // Sync prop ↔ display state while open; clear on close. Re-publish on reopen even when
+  // the prop value is unchanged (deps would otherwise skip the prop-only effect).
   React.useEffect(() => {
     if (!open) {
       setLiveAnnouncementState('');
+      return;
     }
-  }, [open]);
+    if (liveAnnouncementProp !== undefined) {
+      publishLiveAnnouncement(liveAnnouncementProp);
+    }
+  }, [open, liveAnnouncementProp, publishLiveAnnouncement]);
 
   const contextValue = React.useMemo(
     () => ({ onClose, open, setLiveAnnouncement: publishLiveAnnouncement }),

--- a/packages/oxygen-ui/src/components/NotificationPanel/NotificationPanel.tsx
+++ b/packages/oxygen-ui/src/components/NotificationPanel/NotificationPanel.tsx
@@ -17,9 +17,11 @@
  */
 
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import { styled } from '@mui/material/styles';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { visuallyHidden } from '@mui/utils';
 import { NotificationPanelContext } from './context';
 import { AppShellContext } from '../AppShell/context';
 import { NotificationHeader } from './NotificationHeader';
@@ -91,6 +93,17 @@ export interface NotificationPanelProps {
   anchor?: 'left' | 'right';
   /** Drawer variant (default: 'temporary') */
   variant?: 'permanent' | 'persistent' | 'temporary';
+  /**
+   * Accessible name for the drawer dialog (default: `"Notifications"`).
+   * Override when the visible header title differs.
+   */
+  'aria-label'?: string;
+  /**
+   * Polite live-region message for status updates (e.g. new arrivals or sync).
+   * List child-count changes are not announced automatically — publish here
+   * (or via `useNotificationPanel().setLiveAnnouncement`) when items arrive.
+   */
+  liveAnnouncement?: string;
   /** Additional sx props */
   sx?: SxProps<Theme>;
 }
@@ -168,6 +181,8 @@ const NotificationPanel: React.FC<NotificationPanelProps> & {
   width = 380,
   anchor = 'right',
   variant = 'temporary',
+  'aria-label': ariaLabelProp,
+  liveAnnouncement: liveAnnouncementProp,
   sx,
 }) => {
   // Try to consume AppShell context (optional - gracefully degrades if not available)
@@ -180,7 +195,37 @@ const NotificationPanel: React.FC<NotificationPanelProps> & {
     [onCloseProp, appShellContext?.actions.toggleNotificationPanel]
   );
 
-  const contextValue = React.useMemo(() => ({ onClose }), [onClose]);
+  // Empty/whitespace labels must not wipe the default accessible name.
+  const ariaLabel =
+    typeof ariaLabelProp === 'string' && ariaLabelProp.trim().length > 0
+      ? ariaLabelProp.trim()
+      : 'Notifications';
+
+  const [liveAnnouncement, setLiveAnnouncementState] = React.useState('');
+  const [liveAnnouncementNonce, setLiveAnnouncementNonce] = React.useState(0);
+
+  const publishLiveAnnouncement = React.useCallback((message: string) => {
+    setLiveAnnouncementState(message);
+    setLiveAnnouncementNonce((n) => n + 1);
+  }, []);
+
+  // Prop changes push into the shared display state so context publishes are not silenced.
+  React.useEffect(() => {
+    if (liveAnnouncementProp !== undefined) {
+      publishLiveAnnouncement(liveAnnouncementProp);
+    }
+  }, [liveAnnouncementProp, publishLiveAnnouncement]);
+
+  React.useEffect(() => {
+    if (!open) {
+      setLiveAnnouncementState('');
+    }
+  }, [open]);
+
+  const contextValue = React.useMemo(
+    () => ({ onClose, open, setLiveAnnouncement: publishLiveAnnouncement }),
+    [onClose, open, publishLiveAnnouncement]
+  );
   const ownerState = { width };
 
   return (
@@ -192,7 +237,23 @@ const NotificationPanel: React.FC<NotificationPanelProps> & {
         ownerState={ownerState}
         sx={sx}
         variant={variant}
+        slotProps={{
+          paper: {
+            'aria-label': ariaLabel,
+          },
+        }}
       >
+        <Box
+          key={liveAnnouncementNonce}
+          component="div"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          sx={visuallyHidden}
+          data-testid="notification-panel-live-region"
+        >
+          {liveAnnouncement}
+        </Box>
         {children}
       </NotificationPanelRoot>
     </NotificationPanelContext.Provider>

--- a/packages/oxygen-ui/src/components/NotificationPanel/context.ts
+++ b/packages/oxygen-ui/src/components/NotificationPanel/context.ts
@@ -24,6 +24,13 @@ import * as React from 'react';
 export interface NotificationPanelContextValue {
   /** Callback to close the panel */
   onClose: () => void;
+  /** Whether the panel drawer is open */
+  open: boolean;
+  /**
+   * Announce a status message via the panel's polite live region.
+   * Use when new notifications arrive (list child-count changes are not auto-announced).
+   */
+  setLiveAnnouncement: (message: string) => void;
 }
 
 /**

--- a/packages/oxygen-ui/src/components/accessibility.test.tsx
+++ b/packages/oxygen-ui/src/components/accessibility.test.tsx
@@ -41,6 +41,8 @@ import HeaderBrand from './Header/HeaderBrand';
 import AppBreadcrumbs from './AppBreadcrumbs/AppBreadcrumbs';
 import ListingTableToolbar from './ListingTable/shared/ListingTableToolbar';
 import UserMenu from './UserMenu/UserMenu';
+import NotificationPanel from './NotificationPanel/NotificationPanel';
+import { useNotificationPanel } from './NotificationPanel/context';
 
 const renderWithTheme = (ui: React.ReactElement) =>
   render(<OxygenUIThemeProvider>{ui}</OxygenUIThemeProvider>);
@@ -239,5 +241,199 @@ describe('AppBreadcrumbs', () => {
   it('forwards aria and data attributes to the root', () => {
     renderWithTheme(<AppBreadcrumbs items={items} data-testid="crumbs" />);
     expect(screen.getByTestId('crumbs')).toBeDefined();
+  });
+});
+
+describe('NotificationPanel', () => {
+  const listChild = (id: string) => (
+    <div key={id} data-testid={`notification-${id}`}>
+      Notification {id}
+    </div>
+  );
+
+  it('names the open drawer dialog Notifications by default', () => {
+    renderWithTheme(
+      <NotificationPanel open onClose={() => {}}>
+        <NotificationPanel.Header>
+          <NotificationPanel.HeaderTitle>Notifications</NotificationPanel.HeaderTitle>
+          <NotificationPanel.HeaderClose />
+        </NotificationPanel.Header>
+      </NotificationPanel>,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Notifications' })).toBeDefined();
+  });
+
+  it('lets consumers override the drawer accessible name', () => {
+    renderWithTheme(
+      <NotificationPanel open onClose={() => {}} aria-label="Inbox">
+        <NotificationPanel.Header>
+          <NotificationPanel.HeaderTitle>Inbox</NotificationPanel.HeaderTitle>
+          <NotificationPanel.HeaderClose />
+        </NotificationPanel.Header>
+      </NotificationPanel>,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Inbox' })).toBeDefined();
+  });
+
+  it('falls back to Notifications when aria-label is empty or whitespace', () => {
+    renderWithTheme(
+      <NotificationPanel open onClose={() => {}} aria-label="   ">
+        <NotificationPanel.Header>
+          <NotificationPanel.HeaderTitle>Notifications</NotificationPanel.HeaderTitle>
+        </NotificationPanel.Header>
+      </NotificationPanel>,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Notifications' })).toBeDefined();
+  });
+
+  it('exposes a polite live region with status semantics', () => {
+    renderWithTheme(
+      <NotificationPanel open onClose={() => {}}>
+        <NotificationPanel.List>{listChild('1')}</NotificationPanel.List>
+      </NotificationPanel>,
+    );
+
+    const liveRegion = screen.getByTestId('notification-panel-live-region');
+    expect(liveRegion.getAttribute('role')).toBe('status');
+    expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+    expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
+  });
+
+  it('does not announce when list children are only rendered on open', () => {
+    renderWithTheme(
+      <NotificationPanel open onClose={() => {}}>
+        <NotificationPanel.List>
+          {listChild('1')}
+          {listChild('2')}
+        </NotificationPanel.List>
+      </NotificationPanel>,
+    );
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe('');
+  });
+
+  it('does not auto-announce when the list child count increases', () => {
+    const Panel = ({ ids }: { ids: string[] }) => (
+      <NotificationPanel open onClose={() => {}}>
+        <NotificationPanel.List>{ids.map((id) => listChild(id))}</NotificationPanel.List>
+      </NotificationPanel>
+    );
+
+    const { rerender } = renderWithTheme(<Panel ids={['1']} />);
+
+    rerender(
+      <OxygenUIThemeProvider>
+        <Panel ids={['1', '2', '3']} />
+      </OxygenUIThemeProvider>,
+    );
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe('');
+  });
+
+  it('surfaces a consumer liveAnnouncement in the polite live region', () => {
+    renderWithTheme(
+      <NotificationPanel open onClose={() => {}} liveAnnouncement="3 notifications synced">
+        <NotificationPanel.List>{listChild('1')}</NotificationPanel.List>
+      </NotificationPanel>,
+    );
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe(
+      '3 notifications synced',
+    );
+  });
+
+  it('lets context setLiveAnnouncement publish after a liveAnnouncement prop was set', () => {
+    const AnnounceButton = () => {
+      const { setLiveAnnouncement } = useNotificationPanel();
+      return (
+        <button type="button" onClick={() => setLiveAnnouncement('1 new notification')}>
+          Announce
+        </button>
+      );
+    };
+
+    const Panel = ({ status }: { status?: string }) => (
+      <NotificationPanel open onClose={() => {}} liveAnnouncement={status}>
+        <AnnounceButton />
+        <NotificationPanel.List>{listChild('1')}</NotificationPanel.List>
+      </NotificationPanel>
+    );
+
+    const { rerender } = renderWithTheme(<Panel status="3 notifications synced" />);
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe(
+      '3 notifications synced',
+    );
+
+    // Stop controlling via prop so subsequent context publishes are not overwritten.
+    rerender(
+      <OxygenUIThemeProvider>
+        <Panel />
+      </OxygenUIThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Announce' }));
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe(
+      '1 new notification',
+    );
+  });
+
+  it('re-publishes the same announcement text for repeated arrivals', () => {
+    const AnnounceButton = () => {
+      const { setLiveAnnouncement } = useNotificationPanel();
+      return (
+        <button type="button" onClick={() => setLiveAnnouncement('1 new notification')}>
+          Announce
+        </button>
+      );
+    };
+
+    renderWithTheme(
+      <NotificationPanel open onClose={() => {}}>
+        <AnnounceButton />
+      </NotificationPanel>,
+    );
+
+    const announce = () => fireEvent.click(screen.getByRole('button', { name: 'Announce' }));
+
+    announce();
+    const firstRegion = screen.getByTestId('notification-panel-live-region');
+    expect(firstRegion.textContent).toBe('1 new notification');
+
+    announce();
+    const secondRegion = screen.getByTestId('notification-panel-live-region');
+    expect(secondRegion.textContent).toBe('1 new notification');
+    // Nonce remounts the live region node so assistive tech can hear repeats.
+    expect(secondRegion).not.toBe(firstRegion);
+  });
+
+  it('clears the live region when the panel closes', () => {
+    const Panel = ({ open }: { open: boolean }) => (
+      <NotificationPanel open={open} onClose={() => {}} liveAnnouncement="1 new notification">
+        <NotificationPanel.List>{listChild('1')}</NotificationPanel.List>
+      </NotificationPanel>
+    );
+
+    const { rerender } = renderWithTheme(<Panel open />);
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe(
+      '1 new notification',
+    );
+
+    rerender(
+      <OxygenUIThemeProvider>
+        <Panel open={false} />
+      </OxygenUIThemeProvider>,
+    );
+
+    // Temporary drawer unmounts content when closed; if present, it must be empty.
+    const liveRegion = screen.queryByTestId('notification-panel-live-region');
+    if (liveRegion) {
+      expect(liveRegion.textContent).toBe('');
+    }
   });
 });

--- a/packages/oxygen-ui/src/components/accessibility.test.tsx
+++ b/packages/oxygen-ui/src/components/accessibility.test.tsx
@@ -436,4 +436,34 @@ describe('NotificationPanel', () => {
       expect(liveRegion.textContent).toBe('');
     }
   });
+
+  it('restores an unchanged liveAnnouncement prop when the panel reopens', () => {
+    const Panel = ({ open }: { open: boolean }) => (
+      <NotificationPanel open={open} onClose={() => {}} liveAnnouncement="1 new notification">
+        <NotificationPanel.List>{listChild('1')}</NotificationPanel.List>
+      </NotificationPanel>
+    );
+
+    const { rerender } = renderWithTheme(<Panel open />);
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe(
+      '1 new notification',
+    );
+
+    rerender(
+      <OxygenUIThemeProvider>
+        <Panel open={false} />
+      </OxygenUIThemeProvider>,
+    );
+
+    rerender(
+      <OxygenUIThemeProvider>
+        <Panel open />
+      </OxygenUIThemeProvider>,
+    );
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe(
+      '1 new notification',
+    );
+  });
 });

--- a/packages/oxygen-ui/src/components/accessibility.test.tsx
+++ b/packages/oxygen-ui/src/components/accessibility.test.tsx
@@ -437,7 +437,7 @@ describe('NotificationPanel', () => {
     }
   });
 
-  it('restores an unchanged liveAnnouncement prop when the panel reopens', () => {
+  it('does not re-announce an unchanged liveAnnouncement prop when the panel reopens', () => {
     const Panel = ({ open }: { open: boolean }) => (
       <NotificationPanel open={open} onClose={() => {}} liveAnnouncement="1 new notification">
         <NotificationPanel.List>{listChild('1')}</NotificationPanel.List>
@@ -462,8 +462,56 @@ describe('NotificationPanel', () => {
       </OxygenUIThemeProvider>,
     );
 
-    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe(
-      '1 new notification',
+    // Announcements are events while open; reopen with the same prop must not replay.
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe('');
+  });
+
+  it('clears the live region when liveAnnouncement becomes undefined while open', () => {
+    const Panel = ({ status }: { status?: string }) => (
+      <NotificationPanel open onClose={() => {}} liveAnnouncement={status}>
+        <NotificationPanel.List>{listChild('1')}</NotificationPanel.List>
+      </NotificationPanel>
     );
+
+    const { rerender } = renderWithTheme(<Panel status="3 notifications synced" />);
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe(
+      '3 notifications synced',
+    );
+
+    rerender(
+      <OxygenUIThemeProvider>
+        <Panel />
+      </OxygenUIThemeProvider>,
+    );
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe('');
+  });
+
+  it('ignores setLiveAnnouncement while a persistent panel is closed', () => {
+    const AnnounceButton = () => {
+      const { setLiveAnnouncement } = useNotificationPanel();
+      return (
+        <button
+          type="button"
+          data-testid="announce-button"
+          onClick={() => setLiveAnnouncement('1 new notification')}
+        >
+          Announce
+        </button>
+      );
+    };
+
+    renderWithTheme(
+      <NotificationPanel open={false} onClose={() => {}} variant="persistent">
+        <AnnounceButton />
+        <NotificationPanel.List>{listChild('1')}</NotificationPanel.List>
+      </NotificationPanel>,
+    );
+
+    // Closed persistent drawers keep content mounted but hide it from the a11y tree.
+    fireEvent.click(screen.getByTestId('announce-button'));
+
+    expect(screen.getByTestId('notification-panel-live-region').textContent).toBe('');
   });
 });


### PR DESCRIPTION
### Purpose

Name the NotificationPanel drawer for assistive tech and add a polite live region for consumer-published status updates (WCAG 4.1.2 / 4.1.3).

- Default drawer `aria-label="Notifications"` (overridable; empty/whitespace falls back)
- Consumer-driven announcements via `liveAnnouncement` / `setLiveAnnouncement` (list child-count is not auto-announced)
- Publishes only while open; clear when prop becomes `undefined`; do not re-announce unchanged prop on reopen
- Regression tests, LiveAnnouncements Storybook story, and accessibility docs updates

### Related Issues

- Closes #560
- Related: #557

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (`packages/oxygen-ui-docs/ACCESSIBILITY.md`, NotificationPanel + Accessibility stories)
- [x] Unit tests provided. (`packages/oxygen-ui/src/components/accessibility.test.tsx`)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?