### PR TITLE
feat: add app switcher component with popover navigation

### DIFF
--- a/.changeset/quiet-pugs-brake.md
+++ b/.changeset/quiet-pugs-brake.md
@@ -1,0 +1,14 @@
+---
+"@wso2/oxygen-ui": minor
+---
+
+Add `AppSwitcher` component for navigating between WSO2 Cloud applications
+
+A compound component that pairs a grid icon button in the header with a popover
+listing the available platforms.
+
+- `AppSwitcher.Trigger` - grid icon button matching the other header icon buttons
+- `AppSwitcher.Section` - labelled, responsive grid of applications
+- `AppSwitcher.App` - card button supporting `current`, `disabled`, status chips,
+  and link rendering via `href` or a custom `component` (e.g. a router `Link`)
+- `AppSwitcher.Footer` - supporting text with a trailing link action

--- a/.changeset/quiet-pugs-brake.md
+++ b/.changeset/quiet-pugs-brake.md
@@ -4,11 +4,12 @@
 
 Add `AppSwitcher` component for navigating between WSO2 Cloud applications
 
-A compound component that pairs a grid icon button in the header with a popover
-listing the available platforms.
+Renders a grid icon button in the header that opens a popover listing the
+available platforms. The layout is fixed by design so the switcher stays
+consistent across every product: consumers describe the applications with the
+`apps` prop rather than composing markup.
 
-- `AppSwitcher.Trigger` - grid icon button matching the other header icon buttons
-- `AppSwitcher.Section` - labelled, responsive grid of applications
-- `AppSwitcher.App` - card button supporting `current`, `disabled`, status chips,
-  and link rendering via `href` or a custom `component` (e.g. a router `Link`)
-- `AppSwitcher.Footer` - supporting text with a trailing link action
+- `apps` - name, icon, status chip, and `current`/`disabled` state per application
+- `footer` - optional supporting text with a trailing link action
+- Navigation via `href` (cross-app), a router `Link` through `component` (in-app),
+  or `onClick` (programmatic)

--- a/packages/oxygen-ui-docs/.storybook/preview.js
+++ b/packages/oxygen-ui-docs/.storybook/preview.js
@@ -190,6 +190,7 @@ const preview = {
           'App Elements', [
             'App Shell',
             'App Breadcrumbs',
+            'App Switcher',
             'Header',
             'User Menu',
             'Sidebar',

--- a/packages/oxygen-ui-docs/stories/AppElements/AppSwitcher.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/AppElements/AppSwitcher.stories.tsx
@@ -1,0 +1,334 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  AppSwitcher,
+  Box,
+  ColorSchemeToggle,
+  Header,
+  Typography,
+  UserMenu,
+} from '@wso2/oxygen-ui';
+import {
+  Bot,
+  Braces,
+  ChartColumn,
+  Layers,
+  ShieldCheck,
+  Waypoints,
+} from '@wso2/oxygen-ui-icons-react';
+
+/**
+ * AppSwitcher is a compound component that lets users move between the WSO2 Cloud
+ * applications from a grid icon button in the header.
+ */
+const meta: Meta<typeof AppSwitcher> = {
+  title: 'App Elements/App Switcher',
+  component: AppSwitcher,
+  tags: ['autodocs'],
+  parameters: {
+    a11y: {
+      // Known WCAG AA exception: the brand primary color (#FF7300) does not
+      // meet the 4.5:1 text-contrast requirement in the default themes.
+      // Tracked in https://github.com/wso2/oxygen-ui/issues/558 — remove
+      // this override once the palette decision lands.
+      options: {
+        rules: { 'color-contrast': { enabled: false } },
+      },
+    },
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+The AppSwitcher pairs a grid icon button with a popover listing the platforms a user can switch to.
+
+### Features
+- Composable structure with Trigger, Section, App, and Footer sub-components
+- Grid icon button that matches the other header icon buttons, including hover styling
+- App cards render as real links when given an \`href\`, so middle-click and "open in new tab" keep working
+- Per-app \`current\`, \`disabled\`, and status chip states
+- Responsive popover: viewport-capped on mobile, fixed width from \`sm\` up
+
+### Sub-components
+- \`AppSwitcher.Trigger\` - Grid icon button that opens the popover
+- \`AppSwitcher.Section\` - Labelled grid of applications
+- \`AppSwitcher.App\` - Card button for a single application
+- \`AppSwitcher.Footer\` - Supporting text with a trailing link action
+
+### Usage
+\`\`\`tsx
+import { AppSwitcher, Header } from '@wso2/oxygen-ui';
+import { Bot, Braces } from '@wso2/oxygen-ui-icons-react';
+
+<Header.Actions>
+  <AppSwitcher>
+    <AppSwitcher.Trigger />
+    <AppSwitcher.Section label="Platforms">
+      <AppSwitcher.App
+        name="Agent"
+        icon={<Bot size={20} />}
+        status="Current"
+        current
+      />
+      <AppSwitcher.App
+        name="API Management"
+        icon={<Braces size={20} />}
+        status="Try Now"
+        href="/apim"
+      />
+    </AppSwitcher.Section>
+    <AppSwitcher.Footer
+      description="Manage Organization & Users, billing"
+      actionLabel="WSO2 Cloud Console"
+      href="https://console.wso2.com"
+    />
+  </AppSwitcher>
+</Header.Actions>
+\`\`\`
+
+### Accessibility
+- The trigger is a labeled button ("Switch app" by default) exposing \`aria-haspopup\`, \`aria-expanded\`, and \`aria-controls\`.
+- Apps are grouped in a list labelled by the section heading, so the number of platforms is announced.
+- The current app is marked with \`aria-current\`, and unavailable apps with \`aria-disabled\`.
+- The popover is an MUI Popover: focus is trapped while open, Escape closes it and returns focus to the trigger.
+`,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AppSwitcher>;
+
+/**
+ * Platforms rendered as in the WSO2 Cloud design, with current, available,
+ * expired, and coming-soon states.
+ */
+const Platforms = () => (
+  <AppSwitcher.Section label="Platforms">
+    <AppSwitcher.App
+      name="Agent"
+      icon={<Bot size={20} />}
+      status="Current"
+      statusColor="primary"
+      current
+    />
+    <AppSwitcher.App
+      name="API Management"
+      icon={<Braces size={20} />}
+      status="Try Now"
+      onClick={() => console.log('API Management clicked')}
+    />
+    <AppSwitcher.App
+      name="Integration"
+      icon={<Waypoints size={20} />}
+      status="Try Now"
+      onClick={() => console.log('Integration clicked')}
+    />
+    <AppSwitcher.App
+      name="Identity"
+      icon={<ShieldCheck size={20} />}
+      status="Set up"
+      onClick={() => console.log('Identity clicked')}
+    />
+    <AppSwitcher.App
+      name="Engineering Platform"
+      icon={<Layers size={20} />}
+      status="Trial expired"
+      onClick={() => console.log('Engineering Platform clicked')}
+    />
+    <AppSwitcher.App
+      name="Analytics"
+      icon={<ChartColumn size={20} />}
+      status="Coming soon"
+      statusColor="warning"
+      disabled
+    />
+  </AppSwitcher.Section>
+);
+
+/**
+ * Default app switcher. Click the grid icon to open the popover.
+ */
+export const Default: Story = {
+  render: () => (
+    <Box sx={{ p: 4 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
+        Click the grid icon to switch between platforms
+      </Typography>
+      <AppSwitcher>
+        <AppSwitcher.Trigger />
+        <Platforms />
+        <AppSwitcher.Footer
+          description="Manage Organization & Users, billing"
+          actionLabel="WSO2 Cloud Console"
+          onActionClick={() => console.log('Cloud Console clicked')}
+        />
+      </AppSwitcher>
+    </Box>
+  ),
+};
+
+/**
+ * Apps as links. Providing `href` renders each card as an anchor, so users keep
+ * native browser affordances like middle-click and "open in new tab".
+ */
+export const WithLinks: Story = {
+  render: () => (
+    <Box sx={{ p: 4 }}>
+      <AppSwitcher>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Section label="Platforms">
+          <AppSwitcher.App
+            name="Agent"
+            icon={<Bot size={20} />}
+            status="Current"
+            statusColor="primary"
+            current
+          />
+          <AppSwitcher.App
+            name="API Management"
+            icon={<Braces size={20} />}
+            status="Try Now"
+            href="https://wso2.com"
+            target="_blank"
+          />
+          <AppSwitcher.App
+            name="Integration"
+            icon={<Waypoints size={20} />}
+            status="Try Now"
+            href="https://wso2.com"
+            target="_blank"
+          />
+          <AppSwitcher.App
+            name="Identity"
+            icon={<ShieldCheck size={20} />}
+            status="Set up"
+            href="https://wso2.com"
+            target="_blank"
+          />
+        </AppSwitcher.Section>
+        <AppSwitcher.Footer
+          description="Manage Organization & Users, billing"
+          actionLabel="WSO2 Cloud Console"
+          href="https://console.wso2.com"
+          target="_blank"
+        />
+      </AppSwitcher>
+    </Box>
+  ),
+};
+
+/**
+ * Apps with supporting descriptions, useful when names alone are ambiguous.
+ */
+export const WithDescriptions: Story = {
+  render: () => (
+    <Box sx={{ p: 4 }}>
+      <AppSwitcher width={520}>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Section label="Platforms">
+          <AppSwitcher.App
+            name="Agent"
+            description="Build and run AI agents"
+            icon={<Bot size={20} />}
+            status="Current"
+            statusColor="primary"
+            current
+          />
+          <AppSwitcher.App
+            name="API Management"
+            description="Design, publish and govern APIs"
+            icon={<Braces size={20} />}
+            status="Try Now"
+          />
+          <AppSwitcher.App
+            name="Integration"
+            description="Connect systems and automate flows"
+            icon={<Waypoints size={20} />}
+            status="Try Now"
+          />
+          <AppSwitcher.App
+            name="Identity"
+            description="Manage users, apps and access"
+            icon={<ShieldCheck size={20} />}
+            status="Set up"
+          />
+        </AppSwitcher.Section>
+      </AppSwitcher>
+    </Box>
+  ),
+};
+
+/**
+ * Single-column layout, suited to narrow popovers or short app lists.
+ */
+export const SingleColumn: Story = {
+  render: () => (
+    <Box sx={{ p: 4 }}>
+      <AppSwitcher width={280}>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Section label="Platforms" columns={1}>
+          <AppSwitcher.App
+            name="Agent"
+            icon={<Bot size={20} />}
+            status="Current"
+            statusColor="primary"
+            current
+          />
+          <AppSwitcher.App name="API Management" icon={<Braces size={20} />} status="Try Now" />
+          <AppSwitcher.App name="Integration" icon={<Waypoints size={20} />} status="Try Now" />
+        </AppSwitcher.Section>
+      </AppSwitcher>
+    </Box>
+  ),
+};
+
+/**
+ * In context: the switcher sits in `Header.Actions` alongside the other
+ * header icon buttons and shares their hover styling.
+ */
+export const InHeader: Story = {
+  parameters: { layout: 'fullscreen' },
+  render: () => (
+    <Header>
+      <Header.Brand>
+        <Header.BrandTitle>Agent</Header.BrandTitle>
+      </Header.Brand>
+      <Header.Spacer />
+      <Header.Actions>
+        <AppSwitcher>
+          <AppSwitcher.Trigger />
+          <Platforms />
+          <AppSwitcher.Footer
+            description="Manage Organization & Users, billing"
+            actionLabel="WSO2 Cloud Console"
+            onActionClick={() => console.log('Cloud Console clicked')}
+          />
+        </AppSwitcher>
+        <ColorSchemeToggle />
+        <UserMenu>
+          <UserMenu.Trigger name="John Doe" avatar="JD" />
+          <UserMenu.Header name="John Doe" email="john@example.com" avatar="JD" />
+        </UserMenu>
+      </Header.Actions>
+    </Header>
+  ),
+};

--- a/packages/oxygen-ui-docs/stories/AppElements/AppSwitcher.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/AppElements/AppSwitcher.stories.tsx
@@ -18,6 +18,7 @@
 
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { AppSwitcherItem } from '@wso2/oxygen-ui';
 import {
   AppSwitcher,
   Box,
@@ -36,8 +37,8 @@ import {
 } from '@wso2/oxygen-ui-icons-react';
 
 /**
- * AppSwitcher is a compound component that lets users move between the WSO2 Cloud
- * applications from a grid icon button in the header.
+ * AppSwitcher lets users move between the WSO2 Cloud applications from a grid
+ * icon button in the header.
  */
 const meta: Meta<typeof AppSwitcher> = {
   title: 'App Elements/App Switcher',
@@ -59,18 +60,17 @@ const meta: Meta<typeof AppSwitcher> = {
         component: `
 The AppSwitcher pairs a grid icon button with a popover listing the platforms a user can switch to.
 
+### Fixed layout by design
+The switcher renders a **fixed layout** so it looks and behaves identically across every WSO2 product.
+Consumers describe the applications with the \`apps\` prop rather than composing markup, which means a
+product team cannot accidentally ship a switcher that differs from the rest of the platform.
+
 ### Features
-- Composable structure with Trigger, Section, App, and Footer sub-components
+- Consistent, non-composable layout across products
 - Grid icon button that matches the other header icon buttons, including hover styling
 - App cards render as real links when given an \`href\`, so middle-click and "open in new tab" keep working
 - Per-app \`current\`, \`disabled\`, and status chip states
 - Responsive popover: viewport-capped on mobile, fixed width from \`sm\` up
-
-### Sub-components
-- \`AppSwitcher.Trigger\` - Grid icon button that opens the popover
-- \`AppSwitcher.Section\` - Labelled grid of applications
-- \`AppSwitcher.App\` - Card button for a single application
-- \`AppSwitcher.Footer\` - Supporting text with a trailing link action
 
 ### Usage
 \`\`\`tsx
@@ -78,36 +78,29 @@ import { AppSwitcher, Header } from '@wso2/oxygen-ui';
 import { Bot, Braces } from '@wso2/oxygen-ui-icons-react';
 
 <Header.Actions>
-  <AppSwitcher>
-    <AppSwitcher.Trigger />
-    <AppSwitcher.Section label="Platforms">
-      <AppSwitcher.App
-        name="Agent"
-        icon={<Bot size={20} />}
-        status="Current"
-        current
-      />
-      <AppSwitcher.App
-        name="API Management"
-        icon={<Braces size={20} />}
-        status="Try Now"
-        href="/apim"
-      />
-    </AppSwitcher.Section>
-    <AppSwitcher.Footer
-      description="Manage Organization & Users, billing"
-      actionLabel="WSO2 Cloud Console"
-      href="https://console.wso2.com"
-    />
-  </AppSwitcher>
+  <AppSwitcher
+    apps={[
+      { key: 'agent', name: 'Agent', icon: <Bot size={20} />, status: 'Current', current: true },
+      { key: 'apim', name: 'API Management', icon: <Braces size={20} />, status: 'Try Now', href: '/apim' },
+    ]}
+    footer={{
+      description: 'Manage Organization & Users, billing',
+      label: 'WSO2 Cloud Console',
+      href: 'https://console.wso2.com',
+    }}
+  />
 </Header.Actions>
 \`\`\`
+
+### Routing
+The component takes no router dependency. Use \`href\` for cross-app navigation (separate deployments),
+\`component\` with a router \`Link\` for in-app routes, or \`onClick\` for programmatic navigation.
 
 ### Accessibility
 - The trigger is a labeled button ("Switch app" by default) exposing \`aria-haspopup\`, \`aria-expanded\`, and \`aria-controls\`.
 - Apps are grouped in a list labelled by the section heading, so the number of platforms is announced.
-- The current app is marked with \`aria-current\`, and unavailable apps with \`aria-disabled\`.
-- The popover is an MUI Popover: focus is trapped while open, Escape closes it and returns focus to the trigger.
+- The current app is marked with \`aria-current\`, and unavailable apps with \`aria-disabled\` (they stay focusable so they remain discoverable).
+- The popover is an MUI Popover with \`role="dialog"\`: focus is trapped while open, Escape closes it and returns focus to the trigger.
 `,
       },
     },
@@ -118,70 +111,73 @@ export default meta;
 type Story = StoryObj<typeof AppSwitcher>;
 
 /**
- * Platforms rendered as in the WSO2 Cloud design, with current, available,
+ * Platforms as shown in the WSO2 Cloud design, covering current, available,
  * expired, and coming-soon states.
  */
-const Platforms = () => (
-  <AppSwitcher.Section label="Platforms">
-    <AppSwitcher.App
-      name="Agent"
-      icon={<Bot size={20} />}
-      status="Current"
-      statusColor="primary"
-      current
-    />
-    <AppSwitcher.App
-      name="API Management"
-      icon={<Braces size={20} />}
-      status="Try Now"
-      onClick={() => console.log('API Management clicked')}
-    />
-    <AppSwitcher.App
-      name="Integration"
-      icon={<Waypoints size={20} />}
-      status="Try Now"
-      onClick={() => console.log('Integration clicked')}
-    />
-    <AppSwitcher.App
-      name="Identity"
-      icon={<ShieldCheck size={20} />}
-      status="Set up"
-      onClick={() => console.log('Identity clicked')}
-    />
-    <AppSwitcher.App
-      name="Engineering Platform"
-      icon={<Layers size={20} />}
-      status="Trial expired"
-      onClick={() => console.log('Engineering Platform clicked')}
-    />
-    <AppSwitcher.App
-      name="Analytics"
-      icon={<ChartColumn size={20} />}
-      status="Coming soon"
-      statusColor="warning"
-      disabled
-    />
-  </AppSwitcher.Section>
-);
+const PLATFORMS: AppSwitcherItem[] = [
+  {
+    key: 'agent',
+    name: 'Agent',
+    icon: <Bot size={20} />,
+    status: 'Current',
+    statusColor: 'primary',
+    current: true,
+  },
+  {
+    key: 'apim',
+    name: 'API Management',
+    icon: <Braces size={20} />,
+    status: 'Try Now',
+    onClick: () => console.log('API Management clicked'),
+  },
+  {
+    key: 'integration',
+    name: 'Integration',
+    icon: <Waypoints size={20} />,
+    status: 'Try Now',
+    onClick: () => console.log('Integration clicked'),
+  },
+  {
+    key: 'identity',
+    name: 'Identity',
+    icon: <ShieldCheck size={20} />,
+    status: 'Set up',
+    onClick: () => console.log('Identity clicked'),
+  },
+  {
+    key: 'engineering',
+    name: 'Engineering Platform',
+    icon: <Layers size={20} />,
+    status: 'Trial expired',
+    onClick: () => console.log('Engineering Platform clicked'),
+  },
+  {
+    key: 'analytics',
+    name: 'Analytics',
+    icon: <ChartColumn size={20} />,
+    status: 'Coming soon',
+    statusColor: 'warning',
+    disabled: true,
+  },
+];
+
+const FOOTER = {
+  description: 'Manage Organization & Users, billing',
+  label: 'WSO2 Cloud Console',
+  onClick: () => console.log('Cloud Console clicked'),
+};
 
 /**
  * Default app switcher. Click the grid icon to open the popover.
  */
 export const Default: Story = {
-  render: () => (
+  args: { apps: PLATFORMS, footer: FOOTER },
+  render: (args) => (
     <Box sx={{ p: 4 }}>
       <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
         Click the grid icon to switch between platforms
       </Typography>
-      <AppSwitcher>
-        <AppSwitcher.Trigger />
-        <Platforms />
-        <AppSwitcher.Footer
-          description="Manage Organization & Users, billing"
-          actionLabel="WSO2 Cloud Console"
-          onActionClick={() => console.log('Cloud Console clicked')}
-        />
-      </AppSwitcher>
+      <AppSwitcher {...args} />
     </Box>
   ),
 };
@@ -191,88 +187,63 @@ export const Default: Story = {
  * native browser affordances like middle-click and "open in new tab".
  */
 export const WithLinks: Story = {
-  render: () => (
+  args: {
+    apps: [
+      {
+        key: 'agent',
+        name: 'Agent',
+        icon: <Bot size={20} />,
+        status: 'Current',
+        statusColor: 'primary',
+        current: true,
+      },
+      {
+        key: 'apim',
+        name: 'API Management',
+        icon: <Braces size={20} />,
+        status: 'Try Now',
+        href: 'https://wso2.com',
+        target: '_blank',
+      },
+      {
+        key: 'integration',
+        name: 'Integration',
+        icon: <Waypoints size={20} />,
+        status: 'Try Now',
+        href: 'https://wso2.com',
+        target: '_blank',
+      },
+      {
+        key: 'identity',
+        name: 'Identity',
+        icon: <ShieldCheck size={20} />,
+        status: 'Set up',
+        href: 'https://wso2.com',
+        target: '_blank',
+      },
+    ],
+    footer: {
+      description: 'Manage Organization & Users, billing',
+      label: 'WSO2 Cloud Console',
+      href: 'https://console.wso2.com',
+      target: '_blank',
+    },
+  },
+  render: (args) => (
     <Box sx={{ p: 4 }}>
-      <AppSwitcher>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Section label="Platforms">
-          <AppSwitcher.App
-            name="Agent"
-            icon={<Bot size={20} />}
-            status="Current"
-            statusColor="primary"
-            current
-          />
-          <AppSwitcher.App
-            name="API Management"
-            icon={<Braces size={20} />}
-            status="Try Now"
-            href="https://wso2.com"
-            target="_blank"
-          />
-          <AppSwitcher.App
-            name="Integration"
-            icon={<Waypoints size={20} />}
-            status="Try Now"
-            href="https://wso2.com"
-            target="_blank"
-          />
-          <AppSwitcher.App
-            name="Identity"
-            icon={<ShieldCheck size={20} />}
-            status="Set up"
-            href="https://wso2.com"
-            target="_blank"
-          />
-        </AppSwitcher.Section>
-        <AppSwitcher.Footer
-          description="Manage Organization & Users, billing"
-          actionLabel="WSO2 Cloud Console"
-          href="https://console.wso2.com"
-          target="_blank"
-        />
-      </AppSwitcher>
+      <AppSwitcher {...args} />
     </Box>
   ),
 };
 
 /**
- * Apps with supporting descriptions, useful when names alone are ambiguous.
+ * Without a footer. Omitting `footer` hides the bottom row entirely.
  */
-export const WithDescriptions: Story = {
-  render: () => (
+export const WithoutFooter: Story = {
+  args: { apps: PLATFORMS },
+  render: (args) => (
     <Box sx={{ p: 4 }}>
-      <AppSwitcher width={520}>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Section label="Platforms">
-          <AppSwitcher.App
-            name="Agent"
-            description="Build and run AI agents"
-            icon={<Bot size={20} />}
-            status="Current"
-            statusColor="primary"
-            current
-          />
-          <AppSwitcher.App
-            name="API Management"
-            description="Design, publish and govern APIs"
-            icon={<Braces size={20} />}
-            status="Try Now"
-          />
-          <AppSwitcher.App
-            name="Integration"
-            description="Connect systems and automate flows"
-            icon={<Waypoints size={20} />}
-            status="Try Now"
-          />
-          <AppSwitcher.App
-            name="Identity"
-            description="Manage users, apps and access"
-            icon={<ShieldCheck size={20} />}
-            status="Set up"
-          />
-        </AppSwitcher.Section>
-      </AppSwitcher>
+      <AppSwitcher {...args} />
     </Box>
   ),
 };
@@ -281,22 +252,10 @@ export const WithDescriptions: Story = {
  * Single-column layout, suited to narrow popovers or short app lists.
  */
 export const SingleColumn: Story = {
-  render: () => (
+  args: { apps: PLATFORMS.slice(0, 3), columns: 1, width: 280 },
+  render: (args) => (
     <Box sx={{ p: 4 }}>
-      <AppSwitcher width={280}>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Section label="Platforms" columns={1}>
-          <AppSwitcher.App
-            name="Agent"
-            icon={<Bot size={20} />}
-            status="Current"
-            statusColor="primary"
-            current
-          />
-          <AppSwitcher.App name="API Management" icon={<Braces size={20} />} status="Try Now" />
-          <AppSwitcher.App name="Integration" icon={<Waypoints size={20} />} status="Try Now" />
-        </AppSwitcher.Section>
-      </AppSwitcher>
+      <AppSwitcher {...args} />
     </Box>
   ),
 };
@@ -306,23 +265,16 @@ export const SingleColumn: Story = {
  * header icon buttons and shares their hover styling.
  */
 export const InHeader: Story = {
+  args: { apps: PLATFORMS, footer: FOOTER },
   parameters: { layout: 'fullscreen' },
-  render: () => (
+  render: (args) => (
     <Header>
       <Header.Brand>
         <Header.BrandTitle>Agent</Header.BrandTitle>
       </Header.Brand>
       <Header.Spacer />
       <Header.Actions>
-        <AppSwitcher>
-          <AppSwitcher.Trigger />
-          <Platforms />
-          <AppSwitcher.Footer
-            description="Manage Organization & Users, billing"
-            actionLabel="WSO2 Cloud Console"
-            onActionClick={() => console.log('Cloud Console clicked')}
-          />
-        </AppSwitcher>
+        <AppSwitcher {...args} />
         <ColorSchemeToggle />
         <UserMenu>
           <UserMenu.Trigger name="John Doe" avatar="JD" />

--- a/packages/oxygen-ui/.ai/components.md
+++ b/packages/oxygen-ui/.ai/components.md
@@ -12,6 +12,7 @@ Complete API reference for custom Oxygen UI components. For MUI components, refe
 - [Sidebar](#sidebar)
 - [Footer](#footer)
 - [UserMenu](#usermenu)
+- [AppSwitcher](#appswitcher)
 - [Form](#form)
 - [NotificationPanel](#notificationpanel)
 - [NotificationBanner](#notificationbanner)
@@ -1020,6 +1021,130 @@ import { UserIcon, SettingsIcon, LogOutIcon } from '@wso2/oxygen-ui-icons-react'
   <UserMenu.Logout icon={<LogOutIcon size={20} />} onClick={() => signOut()} />
 </UserMenu>
 ```
+
+## AppSwitcher
+
+Popover for navigating between WSO2 Cloud applications. Compound component.
+
+```tsx
+import { AppSwitcher } from '@wso2/oxygen-ui';
+```
+
+### Sub-components
+
+| Component | Description |
+|-----------|-------------|
+| `AppSwitcher.Trigger` | Grid icon button that opens the popover |
+| `AppSwitcher.Section` | Labelled grid of applications |
+| `AppSwitcher.App` | Card button for a single application |
+| `AppSwitcher.Footer` | Supporting text with a trailing link action |
+
+### AppSwitcher Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | required | Trigger and popover content |
+| `width` | `number` | `440` | Popover width (px) from the `sm` breakpoint up |
+| `aria-label` | `string` | `'Applications'` | Accessible name for the popover surface |
+
+### AppSwitcherTrigger Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | `'Switch app'` | Tooltip and accessible label |
+| `icon` | `ReactNode` | `<Grip size={24} />` | Custom trigger icon |
+
+### AppSwitcherSection Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | required | `AppSwitcher.App` elements |
+| `label` | `string` | - | Uppercase section heading (e.g. "Platforms") |
+| `columns` | `number` | `2` | Grid columns from the `sm` breakpoint up |
+
+### AppSwitcherApp Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | required | Application name |
+| `icon` | `ReactNode` | - | Application icon (typically 20px) |
+| `description` | `string` | - | Supporting text under the name |
+| `status` | `string` | - | Status chip label (e.g. "Current", "Try Now") |
+| `statusColor` | `AppSwitcherAppStatusColor` | `'default'` | Status chip color |
+| `current` | `boolean` | `false` | Highlights the app the user is in |
+| `disabled` | `boolean` | `false` | Blocks navigation (e.g. "Coming soon") |
+| `component` | `ElementType` | - | Custom root, e.g. a router `Link` (router props like `to` pass through) |
+| `href` | `string` | - | Destination URL; renders the card as an anchor |
+| `target` | `string` | - | Anchor target, used with `href` |
+| `onClick` | `(event) => void` | - | Click handler; the popover closes after it runs |
+
+### AppSwitcherFooter Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `description` | `ReactNode` | - | Supporting text on the left |
+| `actionLabel` | `string` | - | Label of the trailing action |
+| `component` | `ElementType` | - | Custom action component, e.g. a router `Link` |
+| `href` | `string` | - | Destination URL for the trailing action |
+| `target` | `string` | - | Anchor target, used with `href` |
+| `onActionClick` | `(event) => void` | - | Action handler; the popover closes after it runs |
+| `children` | `ReactNode` | - | Custom footer content, replacing the default layout |
+
+### Usage
+
+```tsx
+import { AppSwitcher, Header } from '@wso2/oxygen-ui';
+import { Bot, Braces, Waypoints } from '@wso2/oxygen-ui-icons-react';
+
+<Header.Actions>
+  <AppSwitcher>
+    <AppSwitcher.Trigger />
+    <AppSwitcher.Section label="Platforms">
+      <AppSwitcher.App name="Agent" icon={<Bot size={20} />} status="Current" current />
+      <AppSwitcher.App name="API Management" icon={<Braces size={20} />} status="Try Now" href="/apim" />
+      <AppSwitcher.App name="Integration" icon={<Waypoints size={20} />} status="Try Now" href="/integration" />
+    </AppSwitcher.Section>
+    <AppSwitcher.Footer
+      description="Manage Organization & Users, billing"
+      actionLabel="WSO2 Cloud Console"
+      href="https://console.wso2.com"
+    />
+  </AppSwitcher>
+</Header.Actions>
+```
+
+### Routing
+
+`AppSwitcher` does not depend on a router. Choose the pattern that matches the destination:
+
+**Cross-app navigation (different origin/deployment)** — use `href`. Full page loads are
+correct here; the card renders as a real anchor, so middle-click and "open in new tab" work.
+
+```tsx
+<AppSwitcher.App name="API Management" href="https://apim.example.com" />
+<AppSwitcher.App name="Identity" href="https://identity.example.com" target="_blank" />
+```
+
+**In-app navigation (same SPA)** — pass a router `Link` via `component`. Router props such
+as `to` are forwarded through, keeping client-side routing intact.
+
+```tsx
+import { Link } from 'react-router';
+
+<AppSwitcher.App name="Integration" component={Link} to="/integration" />
+<AppSwitcher.Footer actionLabel="WSO2 Cloud Console" component={Link} to="/console" />
+```
+
+**Programmatic navigation** — use `onClick`. The popover closes automatically after the
+handler runs.
+
+```tsx
+const navigate = useNavigate();
+
+<AppSwitcher.App name="Agent" onClick={() => navigate('/agent')} />
+```
+
+Precedence: `component` wins over `href`; `disabled` blocks all navigation regardless.
 
 ### PageTitle
 

--- a/packages/oxygen-ui/.ai/components.md
+++ b/packages/oxygen-ui/.ai/components.md
@@ -1024,71 +1024,58 @@ import { UserIcon, SettingsIcon, LogOutIcon } from '@wso2/oxygen-ui-icons-react'
 
 ## AppSwitcher
 
-Popover for navigating between WSO2 Cloud applications. Compound component.
+Popover for navigating between WSO2 Cloud applications.
 
 ```tsx
 import { AppSwitcher } from '@wso2/oxygen-ui';
 ```
 
-### Sub-components
+### Fixed layout
 
-| Component | Description |
-|-----------|-------------|
-| `AppSwitcher.Trigger` | Grid icon button that opens the popover |
-| `AppSwitcher.Section` | Labelled grid of applications |
-| `AppSwitcher.App` | Card button for a single application |
-| `AppSwitcher.Footer` | Supporting text with a trailing link action |
+The switcher renders a **fixed layout** so it looks and behaves identically across every WSO2
+product. Consumers describe the applications with the `apps` prop rather than composing markup,
+so a product team cannot ship a switcher that differs from the rest of the platform. The internal
+building blocks are intentionally not exported.
 
 ### AppSwitcher Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `children` | `ReactNode` | required | Trigger and popover content |
+| `apps` | `AppSwitcherItem[]` | required | Applications to switch between |
+| `label` | `string` | `'Platforms'` | Heading above the application grid |
+| `footer` | `AppSwitcherFooterAction` | - | Footer with supporting text and a link action; omit to hide |
+| `triggerLabel` | `string` | `'Switch app'` | Tooltip and accessible label for the trigger |
+| `triggerIcon` | `ReactNode` | `<Grip size={24} />` | Custom trigger icon |
 | `width` | `number` | `440` | Popover width (px) from the `sm` breakpoint up |
+| `columns` | `number` | `2` | Grid columns from the `sm` breakpoint up |
 | `aria-label` | `string` | `'Applications'` | Accessible name for the popover surface |
 
-### AppSwitcherTrigger Props
+### AppSwitcherItem Type
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `label` | `string` | `'Switch app'` | Tooltip and accessible label |
-| `icon` | `ReactNode` | `<Grip size={24} />` | Custom trigger icon |
-
-### AppSwitcherSection Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `children` | `ReactNode` | required | `AppSwitcher.App` elements |
-| `label` | `string` | - | Uppercase section heading (e.g. "Platforms") |
-| `columns` | `number` | `2` | Grid columns from the `sm` breakpoint up |
-
-### AppSwitcherApp Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `key` | `string` | required | Stable identifier, used as the React key |
 | `name` | `string` | required | Application name |
 | `icon` | `ReactNode` | - | Application icon (typically 20px) |
-| `description` | `string` | - | Supporting text under the name |
 | `status` | `string` | - | Status chip label (e.g. "Current", "Try Now") |
 | `statusColor` | `AppSwitcherAppStatusColor` | `'default'` | Status chip color |
-| `current` | `boolean` | `false` | Highlights the app the user is in |
+| `current` | `boolean` | `false` | Marks the app the user is in |
 | `disabled` | `boolean` | `false` | Blocks navigation (e.g. "Coming soon") |
-| `component` | `ElementType` | - | Custom root, e.g. a router `Link` (router props like `to` pass through) |
 | `href` | `string` | - | Destination URL; renders the card as an anchor |
 | `target` | `string` | - | Anchor target, used with `href` |
+| `component` | `ElementType` | - | Custom root, e.g. a router `Link` |
 | `onClick` | `(event) => void` | - | Click handler; the popover closes after it runs |
 
-### AppSwitcherFooter Props
+### AppSwitcherFooterAction Type
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
 | `description` | `ReactNode` | - | Supporting text on the left |
-| `actionLabel` | `string` | - | Label of the trailing action |
-| `component` | `ElementType` | - | Custom action component, e.g. a router `Link` |
+| `label` | `string` | - | Label of the trailing action |
 | `href` | `string` | - | Destination URL for the trailing action |
 | `target` | `string` | - | Anchor target, used with `href` |
-| `onActionClick` | `(event) => void` | - | Action handler; the popover closes after it runs |
-| `children` | `ReactNode` | - | Custom footer content, replacing the default layout |
+| `component` | `ElementType` | - | Custom action component, e.g. a router `Link` |
+| `onClick` | `(event) => void` | - | Action handler; the popover closes after it runs |
 
 ### Usage
 
@@ -1097,19 +1084,18 @@ import { AppSwitcher, Header } from '@wso2/oxygen-ui';
 import { Bot, Braces, Waypoints } from '@wso2/oxygen-ui-icons-react';
 
 <Header.Actions>
-  <AppSwitcher>
-    <AppSwitcher.Trigger />
-    <AppSwitcher.Section label="Platforms">
-      <AppSwitcher.App name="Agent" icon={<Bot size={20} />} status="Current" current />
-      <AppSwitcher.App name="API Management" icon={<Braces size={20} />} status="Try Now" href="/apim" />
-      <AppSwitcher.App name="Integration" icon={<Waypoints size={20} />} status="Try Now" href="/integration" />
-    </AppSwitcher.Section>
-    <AppSwitcher.Footer
-      description="Manage Organization & Users, billing"
-      actionLabel="WSO2 Cloud Console"
-      href="https://console.wso2.com"
-    />
-  </AppSwitcher>
+  <AppSwitcher
+    apps={[
+      { key: 'agent', name: 'Agent', icon: <Bot size={20} />, status: 'Current', current: true },
+      { key: 'apim', name: 'API Management', icon: <Braces size={20} />, status: 'Try Now', href: '/apim' },
+      { key: 'integration', name: 'Integration', icon: <Waypoints size={20} />, status: 'Try Now', href: '/integration' },
+    ]}
+    footer={{
+      description: 'Manage Organization & Users, billing',
+      label: 'WSO2 Cloud Console',
+      href: 'https://console.wso2.com',
+    }}
+  />
 </Header.Actions>
 ```
 
@@ -1121,18 +1107,17 @@ import { Bot, Braces, Waypoints } from '@wso2/oxygen-ui-icons-react';
 correct here; the card renders as a real anchor, so middle-click and "open in new tab" work.
 
 ```tsx
-<AppSwitcher.App name="API Management" href="https://apim.example.com" />
-<AppSwitcher.App name="Identity" href="https://identity.example.com" target="_blank" />
+{ key: 'apim', name: 'API Management', href: 'https://apim.example.com' }
+{ key: 'identity', name: 'Identity', href: 'https://identity.example.com', target: '_blank' }
 ```
 
 **In-app navigation (same SPA)** — pass a router `Link` via `component`. Router props such
-as `to` are forwarded through, keeping client-side routing intact.
+as `href` are forwarded through, keeping client-side routing intact.
 
 ```tsx
 import { Link } from 'react-router';
 
-<AppSwitcher.App name="Integration" component={Link} to="/integration" />
-<AppSwitcher.Footer actionLabel="WSO2 Cloud Console" component={Link} to="/console" />
+{ key: 'integration', name: 'Integration', component: Link, href: '/integration' }
 ```
 
 **Programmatic navigation** — use `onClick`. The popover closes automatically after the
@@ -1143,7 +1128,7 @@ import { useNavigate } from 'react-router';
 
 const navigate = useNavigate();
 
-<AppSwitcher.App name="Agent" onClick={() => navigate('/agent')} />
+{ key: 'agent', name: 'Agent', onClick: () => navigate('/agent') }
 ```
 
 Precedence: `component` wins over `href`; `disabled` blocks all navigation regardless.

--- a/packages/oxygen-ui/.ai/components.md
+++ b/packages/oxygen-ui/.ai/components.md
@@ -1139,6 +1139,8 @@ import { Link } from 'react-router';
 handler runs.
 
 ```tsx
+import { useNavigate } from 'react-router';
+
 const navigate = useNavigate();
 
 <AppSwitcher.App name="Agent" onClick={() => navigate('/agent')} />

--- a/packages/oxygen-ui/.claude/components.md
+++ b/packages/oxygen-ui/.claude/components.md
@@ -12,6 +12,7 @@ Complete API reference for custom Oxygen UI components. For MUI components, refe
 - [Sidebar](#sidebar)
 - [Footer](#footer)
 - [UserMenu](#usermenu)
+- [AppSwitcher](#appswitcher)
 - [Form](#form)
 - [NotificationPanel](#notificationpanel)
 - [NotificationBanner](#notificationbanner)
@@ -1020,6 +1021,130 @@ import { UserIcon, SettingsIcon, LogOutIcon } from '@wso2/oxygen-ui-icons-react'
   <UserMenu.Logout icon={<LogOutIcon size={20} />} onClick={() => signOut()} />
 </UserMenu>
 ```
+
+## AppSwitcher
+
+Popover for navigating between WSO2 Cloud applications. Compound component.
+
+```tsx
+import { AppSwitcher } from '@wso2/oxygen-ui';
+```
+
+### Sub-components
+
+| Component | Description |
+|-----------|-------------|
+| `AppSwitcher.Trigger` | Grid icon button that opens the popover |
+| `AppSwitcher.Section` | Labelled grid of applications |
+| `AppSwitcher.App` | Card button for a single application |
+| `AppSwitcher.Footer` | Supporting text with a trailing link action |
+
+### AppSwitcher Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | required | Trigger and popover content |
+| `width` | `number` | `440` | Popover width (px) from the `sm` breakpoint up |
+| `aria-label` | `string` | `'Applications'` | Accessible name for the popover surface |
+
+### AppSwitcherTrigger Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | `'Switch app'` | Tooltip and accessible label |
+| `icon` | `ReactNode` | `<Grip size={24} />` | Custom trigger icon |
+
+### AppSwitcherSection Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | required | `AppSwitcher.App` elements |
+| `label` | `string` | - | Uppercase section heading (e.g. "Platforms") |
+| `columns` | `number` | `2` | Grid columns from the `sm` breakpoint up |
+
+### AppSwitcherApp Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | required | Application name |
+| `icon` | `ReactNode` | - | Application icon (typically 20px) |
+| `description` | `string` | - | Supporting text under the name |
+| `status` | `string` | - | Status chip label (e.g. "Current", "Try Now") |
+| `statusColor` | `AppSwitcherAppStatusColor` | `'default'` | Status chip color |
+| `current` | `boolean` | `false` | Highlights the app the user is in |
+| `disabled` | `boolean` | `false` | Blocks navigation (e.g. "Coming soon") |
+| `component` | `ElementType` | - | Custom root, e.g. a router `Link` (router props like `to` pass through) |
+| `href` | `string` | - | Destination URL; renders the card as an anchor |
+| `target` | `string` | - | Anchor target, used with `href` |
+| `onClick` | `(event) => void` | - | Click handler; the popover closes after it runs |
+
+### AppSwitcherFooter Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `description` | `ReactNode` | - | Supporting text on the left |
+| `actionLabel` | `string` | - | Label of the trailing action |
+| `component` | `ElementType` | - | Custom action component, e.g. a router `Link` |
+| `href` | `string` | - | Destination URL for the trailing action |
+| `target` | `string` | - | Anchor target, used with `href` |
+| `onActionClick` | `(event) => void` | - | Action handler; the popover closes after it runs |
+| `children` | `ReactNode` | - | Custom footer content, replacing the default layout |
+
+### Usage
+
+```tsx
+import { AppSwitcher, Header } from '@wso2/oxygen-ui';
+import { Bot, Braces, Waypoints } from '@wso2/oxygen-ui-icons-react';
+
+<Header.Actions>
+  <AppSwitcher>
+    <AppSwitcher.Trigger />
+    <AppSwitcher.Section label="Platforms">
+      <AppSwitcher.App name="Agent" icon={<Bot size={20} />} status="Current" current />
+      <AppSwitcher.App name="API Management" icon={<Braces size={20} />} status="Try Now" href="/apim" />
+      <AppSwitcher.App name="Integration" icon={<Waypoints size={20} />} status="Try Now" href="/integration" />
+    </AppSwitcher.Section>
+    <AppSwitcher.Footer
+      description="Manage Organization & Users, billing"
+      actionLabel="WSO2 Cloud Console"
+      href="https://console.wso2.com"
+    />
+  </AppSwitcher>
+</Header.Actions>
+```
+
+### Routing
+
+`AppSwitcher` does not depend on a router. Choose the pattern that matches the destination:
+
+**Cross-app navigation (different origin/deployment)** — use `href`. Full page loads are
+correct here; the card renders as a real anchor, so middle-click and "open in new tab" work.
+
+```tsx
+<AppSwitcher.App name="API Management" href="https://apim.example.com" />
+<AppSwitcher.App name="Identity" href="https://identity.example.com" target="_blank" />
+```
+
+**In-app navigation (same SPA)** — pass a router `Link` via `component`. Router props such
+as `to` are forwarded through, keeping client-side routing intact.
+
+```tsx
+import { Link } from 'react-router';
+
+<AppSwitcher.App name="Integration" component={Link} to="/integration" />
+<AppSwitcher.Footer actionLabel="WSO2 Cloud Console" component={Link} to="/console" />
+```
+
+**Programmatic navigation** — use `onClick`. The popover closes automatically after the
+handler runs.
+
+```tsx
+const navigate = useNavigate();
+
+<AppSwitcher.App name="Agent" onClick={() => navigate('/agent')} />
+```
+
+Precedence: `component` wins over `href`; `disabled` blocks all navigation regardless.
 
 ### PageTitle
 

--- a/packages/oxygen-ui/.claude/components.md
+++ b/packages/oxygen-ui/.claude/components.md
@@ -1024,71 +1024,58 @@ import { UserIcon, SettingsIcon, LogOutIcon } from '@wso2/oxygen-ui-icons-react'
 
 ## AppSwitcher
 
-Popover for navigating between WSO2 Cloud applications. Compound component.
+Popover for navigating between WSO2 Cloud applications.
 
 ```tsx
 import { AppSwitcher } from '@wso2/oxygen-ui';
 ```
 
-### Sub-components
+### Fixed layout
 
-| Component | Description |
-|-----------|-------------|
-| `AppSwitcher.Trigger` | Grid icon button that opens the popover |
-| `AppSwitcher.Section` | Labelled grid of applications |
-| `AppSwitcher.App` | Card button for a single application |
-| `AppSwitcher.Footer` | Supporting text with a trailing link action |
+The switcher renders a **fixed layout** so it looks and behaves identically across every WSO2
+product. Consumers describe the applications with the `apps` prop rather than composing markup,
+so a product team cannot ship a switcher that differs from the rest of the platform. The internal
+building blocks are intentionally not exported.
 
 ### AppSwitcher Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `children` | `ReactNode` | required | Trigger and popover content |
+| `apps` | `AppSwitcherItem[]` | required | Applications to switch between |
+| `label` | `string` | `'Platforms'` | Heading above the application grid |
+| `footer` | `AppSwitcherFooterAction` | - | Footer with supporting text and a link action; omit to hide |
+| `triggerLabel` | `string` | `'Switch app'` | Tooltip and accessible label for the trigger |
+| `triggerIcon` | `ReactNode` | `<Grip size={24} />` | Custom trigger icon |
 | `width` | `number` | `440` | Popover width (px) from the `sm` breakpoint up |
+| `columns` | `number` | `2` | Grid columns from the `sm` breakpoint up |
 | `aria-label` | `string` | `'Applications'` | Accessible name for the popover surface |
 
-### AppSwitcherTrigger Props
+### AppSwitcherItem Type
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `label` | `string` | `'Switch app'` | Tooltip and accessible label |
-| `icon` | `ReactNode` | `<Grip size={24} />` | Custom trigger icon |
-
-### AppSwitcherSection Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `children` | `ReactNode` | required | `AppSwitcher.App` elements |
-| `label` | `string` | - | Uppercase section heading (e.g. "Platforms") |
-| `columns` | `number` | `2` | Grid columns from the `sm` breakpoint up |
-
-### AppSwitcherApp Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `key` | `string` | required | Stable identifier, used as the React key |
 | `name` | `string` | required | Application name |
 | `icon` | `ReactNode` | - | Application icon (typically 20px) |
-| `description` | `string` | - | Supporting text under the name |
 | `status` | `string` | - | Status chip label (e.g. "Current", "Try Now") |
 | `statusColor` | `AppSwitcherAppStatusColor` | `'default'` | Status chip color |
-| `current` | `boolean` | `false` | Highlights the app the user is in |
+| `current` | `boolean` | `false` | Marks the app the user is in |
 | `disabled` | `boolean` | `false` | Blocks navigation (e.g. "Coming soon") |
-| `component` | `ElementType` | - | Custom root, e.g. a router `Link` (router props like `to` pass through) |
 | `href` | `string` | - | Destination URL; renders the card as an anchor |
 | `target` | `string` | - | Anchor target, used with `href` |
+| `component` | `ElementType` | - | Custom root, e.g. a router `Link` |
 | `onClick` | `(event) => void` | - | Click handler; the popover closes after it runs |
 
-### AppSwitcherFooter Props
+### AppSwitcherFooterAction Type
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
 | `description` | `ReactNode` | - | Supporting text on the left |
-| `actionLabel` | `string` | - | Label of the trailing action |
-| `component` | `ElementType` | - | Custom action component, e.g. a router `Link` |
+| `label` | `string` | - | Label of the trailing action |
 | `href` | `string` | - | Destination URL for the trailing action |
 | `target` | `string` | - | Anchor target, used with `href` |
-| `onActionClick` | `(event) => void` | - | Action handler; the popover closes after it runs |
-| `children` | `ReactNode` | - | Custom footer content, replacing the default layout |
+| `component` | `ElementType` | - | Custom action component, e.g. a router `Link` |
+| `onClick` | `(event) => void` | - | Action handler; the popover closes after it runs |
 
 ### Usage
 
@@ -1097,19 +1084,18 @@ import { AppSwitcher, Header } from '@wso2/oxygen-ui';
 import { Bot, Braces, Waypoints } from '@wso2/oxygen-ui-icons-react';
 
 <Header.Actions>
-  <AppSwitcher>
-    <AppSwitcher.Trigger />
-    <AppSwitcher.Section label="Platforms">
-      <AppSwitcher.App name="Agent" icon={<Bot size={20} />} status="Current" current />
-      <AppSwitcher.App name="API Management" icon={<Braces size={20} />} status="Try Now" href="/apim" />
-      <AppSwitcher.App name="Integration" icon={<Waypoints size={20} />} status="Try Now" href="/integration" />
-    </AppSwitcher.Section>
-    <AppSwitcher.Footer
-      description="Manage Organization & Users, billing"
-      actionLabel="WSO2 Cloud Console"
-      href="https://console.wso2.com"
-    />
-  </AppSwitcher>
+  <AppSwitcher
+    apps={[
+      { key: 'agent', name: 'Agent', icon: <Bot size={20} />, status: 'Current', current: true },
+      { key: 'apim', name: 'API Management', icon: <Braces size={20} />, status: 'Try Now', href: '/apim' },
+      { key: 'integration', name: 'Integration', icon: <Waypoints size={20} />, status: 'Try Now', href: '/integration' },
+    ]}
+    footer={{
+      description: 'Manage Organization & Users, billing',
+      label: 'WSO2 Cloud Console',
+      href: 'https://console.wso2.com',
+    }}
+  />
 </Header.Actions>
 ```
 
@@ -1121,18 +1107,17 @@ import { Bot, Braces, Waypoints } from '@wso2/oxygen-ui-icons-react';
 correct here; the card renders as a real anchor, so middle-click and "open in new tab" work.
 
 ```tsx
-<AppSwitcher.App name="API Management" href="https://apim.example.com" />
-<AppSwitcher.App name="Identity" href="https://identity.example.com" target="_blank" />
+{ key: 'apim', name: 'API Management', href: 'https://apim.example.com' }
+{ key: 'identity', name: 'Identity', href: 'https://identity.example.com', target: '_blank' }
 ```
 
 **In-app navigation (same SPA)** — pass a router `Link` via `component`. Router props such
-as `to` are forwarded through, keeping client-side routing intact.
+as `href` are forwarded through, keeping client-side routing intact.
 
 ```tsx
 import { Link } from 'react-router';
 
-<AppSwitcher.App name="Integration" component={Link} to="/integration" />
-<AppSwitcher.Footer actionLabel="WSO2 Cloud Console" component={Link} to="/console" />
+{ key: 'integration', name: 'Integration', component: Link, href: '/integration' }
 ```
 
 **Programmatic navigation** — use `onClick`. The popover closes automatically after the
@@ -1143,7 +1128,7 @@ import { useNavigate } from 'react-router';
 
 const navigate = useNavigate();
 
-<AppSwitcher.App name="Agent" onClick={() => navigate('/agent')} />
+{ key: 'agent', name: 'Agent', onClick: () => navigate('/agent') }
 ```
 
 Precedence: `component` wins over `href`; `disabled` blocks all navigation regardless.

--- a/packages/oxygen-ui/.claude/components.md
+++ b/packages/oxygen-ui/.claude/components.md
@@ -1139,6 +1139,8 @@ import { Link } from 'react-router';
 handler runs.
 
 ```tsx
+import { useNavigate } from 'react-router';
+
 const navigate = useNavigate();
 
 <AppSwitcher.App name="Agent" onClick={() => navigate('/agent')} />

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcher.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcher.tsx
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+import Popover from '@mui/material/Popover';
+import { styled } from '@mui/material/styles';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { AppSwitcherContext } from './context';
+import { AppSwitcherTrigger } from './AppSwitcherTrigger';
+import { AppSwitcherSection } from './AppSwitcherSection';
+import { AppSwitcherApp } from './AppSwitcherApp';
+import { AppSwitcherFooter } from './AppSwitcherFooter';
+
+/**
+ * Theme tokens used in this component:
+ *
+ * Popover surface uses the theme's paper background and elevation.
+ *
+ * Responsive behavior:
+ * - Width capped to the viewport on xs (mobile)
+ * - Fixed width from sm up (tablet/desktop)
+ */
+
+/**
+ * Styled popover for the app switcher.
+ */
+const AppSwitcherRoot = styled(Popover, {
+  name: 'MuiAppSwitcher',
+  slot: 'Root',
+  shouldForwardProp: (prop) => prop !== 'ownerState',
+})<{ ownerState: { width: number } }>(({ theme, ownerState }) => ({
+  '& .MuiPopover-paper': {
+    width: `calc(100vw - ${theme.spacing(4)})`,
+    maxWidth: '100%',
+    marginTop: theme.spacing(1),
+    overflow: 'hidden',
+    [theme.breakpoints.up('sm')]: {
+      width: ownerState.width,
+    },
+  },
+}));
+
+/**
+ * Props for the AppSwitcher component.
+ */
+export interface AppSwitcherProps {
+  /** Switcher content (Trigger, Section, App, Footer) */
+  children: React.ReactNode;
+  /** Popover width in pixels from the `sm` breakpoint up (default: 440) */
+  width?: number;
+  /** Accessible name for the popover surface (default: `"Applications"`) */
+  'aria-label'?: string;
+  /** Additional sx props applied to the popover */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * AppSwitcher - Popover for navigating between WSO2 Cloud applications.
+ *
+ * A compound component that pairs a grid icon button in the header with a
+ * popover listing the available platforms. Children other than the trigger are
+ * rendered inside the popover.
+ *
+ * Features:
+ * - Compound component pattern for maximum flexibility
+ * - Context-based open/close state sharing
+ * - Card buttons that render as links when given an `href`
+ * - Current, disabled and status-chip states per application
+ * - Responsive popover width (viewport-capped on mobile, fixed on desktop)
+ *
+ * @example
+ * ```tsx
+ * <Header.Actions>
+ *   <AppSwitcher>
+ *     <AppSwitcher.Trigger />
+ *     <AppSwitcher.Section label="Platforms">
+ *       <AppSwitcher.App
+ *         name="Agent"
+ *         icon={<Bot size={20} />}
+ *         status="Current"
+ *         current
+ *       />
+ *       <AppSwitcher.App
+ *         name="API Management"
+ *         icon={<Braces size={20} />}
+ *         status="Try Now"
+ *         href="/apim"
+ *       />
+ *     </AppSwitcher.Section>
+ *     <AppSwitcher.Footer
+ *       description="Manage Organization & Users, billing"
+ *       actionLabel="WSO2 Cloud Console"
+ *       href="https://console.wso2.com"
+ *     />
+ *   </AppSwitcher>
+ * </Header.Actions>
+ * ```
+ */
+const AppSwitcher: React.FC<AppSwitcherProps> & {
+  Trigger: typeof AppSwitcherTrigger;
+  Section: typeof AppSwitcherSection;
+  App: typeof AppSwitcherApp;
+  Footer: typeof AppSwitcherFooter;
+} = ({ children, width = 440, 'aria-label': ariaLabelProp, sx }) => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+  const popoverId = React.useId();
+
+  const handleOpen = React.useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  }, []);
+
+  const handleClose = React.useCallback(() => {
+    setAnchorEl(null);
+  }, []);
+
+  // Empty/whitespace labels must not wipe the default accessible name.
+  const ariaLabel =
+    typeof ariaLabelProp === 'string' && ariaLabelProp.trim().length > 0
+      ? ariaLabelProp
+      : 'Applications';
+
+  const contextValue = React.useMemo(
+    () => ({ open, anchorEl, popoverId, handleOpen, handleClose }),
+    [open, anchorEl, popoverId, handleOpen, handleClose]
+  );
+
+  // Separate the trigger (rendered inline) from the popover content.
+  const childrenArray = React.Children.toArray(children);
+  const triggerChild = childrenArray.find(
+    (child) => React.isValidElement(child) && child.type === AppSwitcherTrigger
+  );
+  const popoverChildren = childrenArray.filter(
+    (child) => !(React.isValidElement(child) && child.type === AppSwitcherTrigger)
+  );
+
+  return (
+    <AppSwitcherContext.Provider value={contextValue}>
+      {triggerChild}
+      <AppSwitcherRoot
+        id={popoverId}
+        ownerState={{ width }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { 'aria-label': ariaLabel } }}
+        sx={sx}
+      >
+        {popoverChildren}
+      </AppSwitcherRoot>
+    </AppSwitcherContext.Provider>
+  );
+};
+
+/**
+ * AppSwitcher compound component with attached sub-components.
+ *
+ * Sub-components:
+ * - `AppSwitcher.Trigger` - Grid icon button that opens the popover
+ * - `AppSwitcher.Section` - Labelled grid of applications
+ * - `AppSwitcher.App` - Card button for a single application
+ * - `AppSwitcher.Footer` - Bottom row with supporting text and a link action
+ */
+AppSwitcher.Trigger = AppSwitcherTrigger;
+AppSwitcher.Section = AppSwitcherSection;
+AppSwitcher.App = AppSwitcherApp;
+AppSwitcher.Footer = AppSwitcherFooter;
+AppSwitcher.displayName = 'AppSwitcher';
+
+export { AppSwitcher };
+export default AppSwitcher;

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcher.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcher.tsx
@@ -25,6 +25,7 @@ import { AppSwitcherTrigger } from './AppSwitcherTrigger';
 import { AppSwitcherSection } from './AppSwitcherSection';
 import { AppSwitcherApp } from './AppSwitcherApp';
 import { AppSwitcherFooter } from './AppSwitcherFooter';
+import type { AppSwitcherAppStatusColor } from './AppSwitcherApp';
 
 /**
  * Theme tokens used in this component:
@@ -56,13 +57,69 @@ const AppSwitcherRoot = styled(Popover, {
 }));
 
 /**
+ * A single application shown in the switcher.
+ */
+export interface AppSwitcherItem {
+  /** Stable identifier, used as the React key */
+  key: string;
+  /** Application name (e.g. `"API Management"`) */
+  name: string;
+  /** Application icon, typically a 20px icon element */
+  icon?: React.ReactNode;
+  /** Status chip label (e.g. `"Current"`, `"Try Now"`, `"Coming soon"`) */
+  status?: string;
+  /** Color of the status chip (default: `"default"`) */
+  statusColor?: AppSwitcherAppStatusColor;
+  /** Marks the app the user is currently in */
+  current?: boolean;
+  /** Blocks navigation, e.g. for apps that are not yet available */
+  disabled?: boolean;
+  /** Destination URL. Renders the card as an anchor. */
+  href?: string;
+  /** Anchor target, only applied together with `href` */
+  target?: string;
+  /** Custom root component, e.g. a router `Link`, for client-side navigation */
+  component?: React.ElementType;
+  /** Click handler. The popover closes automatically after it runs. */
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+}
+
+/**
+ * The footer action shown beneath the applications.
+ */
+export interface AppSwitcherFooterAction {
+  /** Supporting text on the left (e.g. `"Manage Organization & Users, billing"`) */
+  description?: React.ReactNode;
+  /** Label of the trailing action (e.g. `"WSO2 Cloud Console"`) */
+  label?: string;
+  /** Destination URL for the trailing action */
+  href?: string;
+  /** Anchor target, only applied together with `href` */
+  target?: string;
+  /** Custom component for the action, e.g. a router `Link` */
+  component?: React.ElementType;
+  /** Click handler. The popover closes automatically after it runs. */
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+}
+
+/**
  * Props for the AppSwitcher component.
  */
 export interface AppSwitcherProps {
-  /** Switcher content (Trigger, Section, App, Footer) */
-  children: React.ReactNode;
+  /** Applications to switch between */
+  apps: AppSwitcherItem[];
+  /** Heading above the application grid (default: `"Platforms"`) */
+  label?: string;
+  /** Footer with supporting text and a link action. Omit to hide the footer. */
+  footer?: AppSwitcherFooterAction;
+  /** Tooltip and accessible label for the trigger (default: `"Switch app"`) */
+  triggerLabel?: string;
+  /** Custom trigger icon, replacing the default grid icon */
+  triggerIcon?: React.ReactNode;
   /** Popover width in pixels from the `sm` breakpoint up (default: 440) */
   width?: number;
+  /** Number of grid columns from the `sm` breakpoint up (default: 2) */
+  columns?: number;
   /** Accessible name for the popover surface (default: `"Applications"`) */
   'aria-label'?: string;
   /** Additional sx props applied to the popover */
@@ -72,13 +129,13 @@ export interface AppSwitcherProps {
 /**
  * AppSwitcher - Popover for navigating between WSO2 Cloud applications.
  *
- * A compound component that pairs a grid icon button in the header with a
- * popover listing the available platforms. Children other than the trigger are
- * rendered inside the popover.
+ * Renders a grid icon button in the header that opens a popover listing the
+ * available platforms. The layout is fixed by design so the switcher looks and
+ * behaves identically across every product, and consumers supply data rather
+ * than markup.
  *
  * Features:
- * - Compound component pattern for maximum flexibility
- * - Context-based open/close state sharing
+ * - Fixed, consistent layout across products
  * - Card buttons that render as links when given an `href`
  * - Current, disabled and status-chip states per application
  * - Responsive popover width (viewport-capped on mobile, fixed on desktop)
@@ -86,37 +143,31 @@ export interface AppSwitcherProps {
  * @example
  * ```tsx
  * <Header.Actions>
- *   <AppSwitcher>
- *     <AppSwitcher.Trigger />
- *     <AppSwitcher.Section label="Platforms">
- *       <AppSwitcher.App
- *         name="Agent"
- *         icon={<Bot size={20} />}
- *         status="Current"
- *         current
- *       />
- *       <AppSwitcher.App
- *         name="API Management"
- *         icon={<Braces size={20} />}
- *         status="Try Now"
- *         href="/apim"
- *       />
- *     </AppSwitcher.Section>
- *     <AppSwitcher.Footer
- *       description="Manage Organization & Users, billing"
- *       actionLabel="WSO2 Cloud Console"
- *       href="https://console.wso2.com"
- *     />
- *   </AppSwitcher>
+ *   <AppSwitcher
+ *     apps={[
+ *       { key: 'agent', name: 'Agent', icon: <Bot size={20} />, status: 'Current', current: true },
+ *       { key: 'apim', name: 'API Management', icon: <Braces size={20} />, status: 'Try Now', href: '/apim' },
+ *     ]}
+ *     footer={{
+ *       description: 'Manage Organization & Users, billing',
+ *       label: 'WSO2 Cloud Console',
+ *       href: 'https://console.wso2.com',
+ *     }}
+ *   />
  * </Header.Actions>
  * ```
  */
-const AppSwitcher: React.FC<AppSwitcherProps> & {
-  Trigger: typeof AppSwitcherTrigger;
-  Section: typeof AppSwitcherSection;
-  App: typeof AppSwitcherApp;
-  Footer: typeof AppSwitcherFooter;
-} = ({ children, width = 440, 'aria-label': ariaLabelProp, sx }) => {
+export const AppSwitcher: React.FC<AppSwitcherProps> = ({
+  apps,
+  label = 'Platforms',
+  footer,
+  triggerLabel,
+  triggerIcon,
+  width = 440,
+  columns = 2,
+  'aria-label': ariaLabelProp,
+  sx,
+}) => {
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
   const popoverId = React.useId();
@@ -140,18 +191,9 @@ const AppSwitcher: React.FC<AppSwitcherProps> & {
     [open, anchorEl, popoverId, handleOpen, handleClose]
   );
 
-  // Separate the trigger (rendered inline) from the popover content.
-  const childrenArray = React.Children.toArray(children);
-  const triggerChild = childrenArray.find(
-    (child) => React.isValidElement(child) && child.type === AppSwitcherTrigger
-  );
-  const popoverChildren = childrenArray.filter(
-    (child) => !(React.isValidElement(child) && child.type === AppSwitcherTrigger)
-  );
-
   return (
     <AppSwitcherContext.Provider value={contextValue}>
-      {triggerChild}
+      <AppSwitcherTrigger label={triggerLabel} icon={triggerIcon} />
       <AppSwitcherRoot
         id={popoverId}
         ownerState={{ width }}
@@ -163,26 +205,26 @@ const AppSwitcher: React.FC<AppSwitcherProps> & {
         slotProps={{ paper: { role: 'dialog', 'aria-label': ariaLabel } }}
         sx={sx}
       >
-        {popoverChildren}
+        <AppSwitcherSection label={label} columns={columns}>
+          {apps.map(({ key, ...app }) => (
+            <AppSwitcherApp key={key} {...app} />
+          ))}
+        </AppSwitcherSection>
+        {footer && (
+          <AppSwitcherFooter
+            description={footer.description}
+            actionLabel={footer.label}
+            href={footer.href}
+            target={footer.target}
+            component={footer.component}
+            onActionClick={footer.onClick}
+          />
+        )}
       </AppSwitcherRoot>
     </AppSwitcherContext.Provider>
   );
 };
 
-/**
- * AppSwitcher compound component with attached sub-components.
- *
- * Sub-components:
- * - `AppSwitcher.Trigger` - Grid icon button that opens the popover
- * - `AppSwitcher.Section` - Labelled grid of applications
- * - `AppSwitcher.App` - Card button for a single application
- * - `AppSwitcher.Footer` - Bottom row with supporting text and a link action
- */
-AppSwitcher.Trigger = AppSwitcherTrigger;
-AppSwitcher.Section = AppSwitcherSection;
-AppSwitcher.App = AppSwitcherApp;
-AppSwitcher.Footer = AppSwitcherFooter;
 AppSwitcher.displayName = 'AppSwitcher';
 
-export { AppSwitcher };
 export default AppSwitcher;

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcher.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcher.tsx
@@ -160,7 +160,7 @@ const AppSwitcher: React.FC<AppSwitcherProps> & {
         onClose={handleClose}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-        slotProps={{ paper: { 'aria-label': ariaLabel } }}
+        slotProps={{ paper: { role: 'dialog', 'aria-label': ariaLabel } }}
         sx={sx}
       >
         {popoverChildren}

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherApp.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherApp.tsx
@@ -1,0 +1,327 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import Chip from '@mui/material/Chip';
+import ButtonBase from '@mui/material/ButtonBase';
+import Typography from '@mui/material/Typography';
+import { styled, alpha } from '@mui/material/styles';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { useAppSwitcher } from './context';
+
+/**
+ * Theme tokens used in this component:
+ *
+ * Colors:
+ * - `background.paper` / `action.hover` - Card surfaces
+ * - `primary.main` - Selected (current) border, tint and focus ring
+ * - `divider` - Resting card border
+ * - `text.primary` / `text.secondary` / `text.disabled` - Typography
+ *
+ * Elevation:
+ * - `shadows[1]` - Hover elevation, matching `Form.CardButton`
+ */
+
+/**
+ * Status chip variants supported by an app card.
+ */
+export type AppSwitcherAppStatusColor =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'error'
+  | 'info'
+  | 'success'
+  | 'warning';
+
+interface AppSwitcherAppOwnerState {
+  current: boolean;
+  disabled: boolean;
+}
+
+/**
+ * Props for the styled root, which renders polymorphically as either an anchor
+ * or a `ButtonBase` depending on whether `href` is supplied.
+ */
+interface AppSwitcherAppRootProps extends Omit<React.ComponentProps<typeof Card>, 'component'> {
+  ownerState: AppSwitcherAppOwnerState;
+  component?: React.ElementType;
+  href?: string;
+  target?: string;
+  rel?: string;
+}
+
+/**
+ * Styled card button for an application entry.
+ *
+ * Hover and focus styling mirrors `Form.CardButton` so app cards feel
+ * consistent with the rest of the design system.
+ */
+const AppSwitcherAppRoot = styled(Card, {
+  name: 'MuiAppSwitcher',
+  slot: 'App',
+  shouldForwardProp: (prop) => prop !== 'ownerState',
+})<AppSwitcherAppRootProps>(({ theme, ownerState }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'stretch',
+  justifyContent: 'flex-start',
+  gap: theme.spacing(1.5),
+  width: '100%',
+  height: '100%',
+  padding: theme.spacing(1.5),
+  textAlign: 'left',
+  transition: theme.transitions.create(['border-color', 'box-shadow', 'background-color'], {
+    duration: theme.transitions.duration.shorter,
+  }),
+  '&.MuiCard-root': {
+    borderColor: ownerState.current
+      ? (theme.vars || theme).palette.primary.main
+      : (theme.vars || theme).palette.divider,
+    backgroundColor: ownerState.current
+      ? alpha(theme.palette.primary.main, 0.06)
+      : (theme.vars || theme).palette.background.paper,
+  },
+  ...(ownerState.disabled && {
+    cursor: 'not-allowed',
+  }),
+  '&:hover': {
+    ...(!ownerState.disabled && {
+      borderColor: (theme.vars || theme).palette.primary.main,
+      boxShadow: theme.shadows[1],
+    }),
+  },
+  '&.Mui-focusVisible': {
+    outline: `2px solid ${(theme.vars || theme).palette.primary.main}`,
+    outlineOffset: 2,
+  },
+}));
+
+/**
+ * Styled top row holding the app icon and the status chip.
+ */
+const AppSwitcherAppHeader = styled(Box, {
+  name: 'MuiAppSwitcher',
+  slot: 'AppHeader',
+})(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+  gap: theme.spacing(1),
+}));
+
+/**
+ * Styled tinted square holding the app icon.
+ */
+const AppSwitcherAppIcon = styled(Box, {
+  name: 'MuiAppSwitcher',
+  slot: 'AppIcon',
+})(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  width: 36,
+  height: 36,
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: (theme.vars || theme).palette.action.hover,
+  color: (theme.vars || theme).palette.text.primary,
+  '& svg': {
+    display: 'block',
+  },
+}));
+
+/**
+ * Styled status chip shown at the top-right of the card.
+ */
+const AppSwitcherAppStatus = styled(Chip, {
+  name: 'MuiAppSwitcher',
+  slot: 'AppStatus',
+})({
+  height: 20,
+  fontSize: 11,
+});
+
+/**
+ * Styled application name.
+ */
+const AppSwitcherAppName = styled(Typography, {
+  name: 'MuiAppSwitcher',
+  slot: 'AppName',
+  shouldForwardProp: (prop) => prop !== 'ownerState',
+})<{ ownerState: AppSwitcherAppOwnerState }>(({ theme, ownerState }) => ({
+  fontSize: 14,
+  fontWeight: theme.typography.fontWeightMedium,
+  lineHeight: 1.35,
+  color: ownerState.disabled
+    ? (theme.vars || theme).palette.text.disabled
+    : (theme.vars || theme).palette.text.primary,
+}));
+
+/**
+ * Styled optional description shown under the app name.
+ */
+const AppSwitcherAppDescription = styled(Typography, {
+  name: 'MuiAppSwitcher',
+  slot: 'AppDescription',
+})(({ theme }) => ({
+  fontSize: 12,
+  lineHeight: 1.4,
+  color: (theme.vars || theme).palette.text.secondary,
+  marginTop: theme.spacing(0.25),
+}));
+
+/**
+ * Props for the AppSwitcher.App component.
+ */
+export interface AppSwitcherAppProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'children' | 'onClick'> {
+  /** Application name (e.g. `"API Management"`) */
+  name: string;
+  /** Application icon, typically a 20px icon element */
+  icon?: React.ReactNode;
+  /** Optional supporting text shown under the name */
+  description?: string;
+  /** Status label rendered as a chip (e.g. `"Current"`, `"Try Now"`, `"Coming soon"`) */
+  status?: string;
+  /** Color of the status chip (default: `"default"`) */
+  statusColor?: AppSwitcherAppStatusColor;
+  /** Marks the app the user is currently in, highlighting the card */
+  current?: boolean;
+  /** Disables navigation, e.g. for apps that are not yet available */
+  disabled?: boolean;
+  /**
+   * Custom root component, e.g. a router `Link`, for client-side navigation.
+   * Router-specific props such as `to` are forwarded through.
+   *
+   * @example
+   * component={Link} to="/apim"
+   */
+  component?: React.ElementType;
+  /** Destination URL. When set, the card renders as an anchor. */
+  href?: string;
+  /** Anchor target, only applied together with `href` */
+  target?: string;
+  /** Click handler. The popover closes automatically after it runs. */
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  /** Additional sx props */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * AppSwitcher.App - Card button for a single application in the switcher.
+ *
+ * Renders as an anchor when `href` is provided and as a button otherwise, so
+ * links keep native browser affordances (middle-click, open in new tab).
+ * Selecting an app closes the popover.
+ *
+ * @example
+ * ```tsx
+ * <AppSwitcher.App
+ *   name="API Management"
+ *   icon={<Braces size={20} />}
+ *   status="Try Now"
+ *   href="https://console.example.com/apim"
+ * />
+ * ```
+ */
+export const AppSwitcherApp = React.forwardRef<HTMLElement, AppSwitcherAppProps>(
+  function AppSwitcherApp(
+    {
+      name,
+      icon,
+      description,
+      status,
+      statusColor = 'default',
+      current = false,
+      disabled = false,
+      component,
+      href,
+      target,
+      onClick,
+      sx,
+      ...props
+    },
+    ref
+  ) {
+    const { handleClose } = useAppSwitcher();
+
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+      if (disabled) {
+        event.preventDefault();
+        return;
+      }
+      onClick?.(event);
+      handleClose();
+    };
+
+    const ownerState = { current, disabled };
+
+    // A consumer-supplied `component` (typically a router Link) wins, so
+    // client-side navigation works without the library depending on a router.
+    // Otherwise render a real anchor when navigable, so middle-click and
+    // "open in new tab" keep working. `rel` guards against reverse tabnabbing.
+    const renderAsLink = Boolean(href) && !disabled;
+    const linkProps = {
+      ...(href && { href }),
+      ...(target && { target }),
+      ...(target === '_blank' && { rel: 'noopener noreferrer' }),
+    };
+    const anchorProps =
+      component && !disabled
+        ? { component, ...linkProps }
+        : renderAsLink
+          ? { component: 'a' as React.ElementType, ...linkProps }
+          : { component: ButtonBase as React.ElementType };
+
+    // Unavailable apps stay focusable so they remain discoverable to screen
+    // reader users; `aria-disabled` plus the click guard convey the state
+    // without dropping the card out of the tab order.
+
+    return (
+      <AppSwitcherAppRoot
+        {...props}
+        {...anchorProps}
+        ref={ref as React.Ref<HTMLDivElement>}
+        ownerState={ownerState}
+        variant="outlined"
+        onClick={handleClick}
+        aria-current={current ? 'true' : undefined}
+        aria-disabled={disabled ? 'true' : undefined}
+        sx={sx}
+      >
+        <AppSwitcherAppHeader>
+          {icon && <AppSwitcherAppIcon aria-hidden="true">{icon}</AppSwitcherAppIcon>}
+          {status && (
+            <AppSwitcherAppStatus label={status} size="small" color={statusColor} />
+          )}
+        </AppSwitcherAppHeader>
+        <Box>
+          <AppSwitcherAppName ownerState={ownerState}>{name}</AppSwitcherAppName>
+          {description && <AppSwitcherAppDescription>{description}</AppSwitcherAppDescription>}
+        </Box>
+      </AppSwitcherAppRoot>
+    );
+  }
+);
+
+AppSwitcherApp.displayName = 'AppSwitcher.App';
+
+export default AppSwitcherApp;

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherFooter.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherFooter.tsx
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { ChevronRight } from '@wso2/oxygen-ui-icons-react';
+import { useAppSwitcher } from './context';
+
+/**
+ * Theme tokens used in this component:
+ *
+ * Colors:
+ * - `divider` - Top separator
+ * - `action.hover` - Footer background
+ * - `text.secondary` - Description text
+ */
+
+/**
+ * Styled footer container.
+ */
+const AppSwitcherFooterRoot = styled(Box, {
+  name: 'MuiAppSwitcher',
+  slot: 'Footer',
+})(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  flexWrap: 'wrap',
+  gap: theme.spacing(1),
+  padding: theme.spacing(1.5, 2),
+  borderTop: `1px solid ${(theme.vars || theme).palette.divider}`,
+  backgroundColor: (theme.vars || theme).palette.action.hover,
+}));
+
+/**
+ * Styled footer description text.
+ */
+const AppSwitcherFooterText = styled(Typography, {
+  name: 'MuiAppSwitcher',
+  slot: 'FooterText',
+})(({ theme }) => ({
+  fontSize: 13,
+  color: (theme.vars || theme).palette.text.secondary,
+}));
+
+/**
+ * Props for the AppSwitcher.Footer component.
+ */
+export interface AppSwitcherFooterProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'children' | 'color'> {
+  /** Supporting text on the left (e.g. `"Manage Organization & Users, billing"`) */
+  description?: React.ReactNode;
+  /** Label of the trailing action (e.g. `"WSO2 Cloud Console"`) */
+  actionLabel?: string;
+  /**
+   * Custom component for the trailing action, e.g. a router `Link`.
+   * Router-specific props such as `to` are forwarded through.
+   */
+  component?: React.ElementType;
+  /** Destination URL for the trailing action */
+  href?: string;
+  /** Anchor target, only applied together with `href` */
+  target?: string;
+  /** Click handler for the trailing action. The popover closes after it runs. */
+  onActionClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  /** Custom footer content, replacing the description/action layout */
+  children?: React.ReactNode;
+  /** Additional sx props */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * AppSwitcher.Footer - Bottom row of the app switcher popover.
+ *
+ * Pairs supporting text with a trailing link action, typically pointing at the
+ * cloud console. Pass `children` to render fully custom footer content instead.
+ *
+ * @example
+ * ```tsx
+ * <AppSwitcher.Footer
+ *   description="Manage Organization & Users, billing"
+ *   actionLabel="WSO2 Cloud Console"
+ *   href="https://console.wso2.com"
+ * />
+ * ```
+ */
+export const AppSwitcherFooter: React.FC<AppSwitcherFooterProps> = ({
+  description,
+  actionLabel,
+  component,
+  href,
+  target,
+  onActionClick,
+  children,
+  sx,
+  ...props
+}) => {
+  const { handleClose } = useAppSwitcher();
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    onActionClick?.(event);
+    handleClose();
+  };
+
+  if (children) {
+    return <AppSwitcherFooterRoot sx={sx}>{children}</AppSwitcherFooterRoot>;
+  }
+
+  return (
+    <AppSwitcherFooterRoot sx={sx}>
+      {description && <AppSwitcherFooterText>{description}</AppSwitcherFooterText>}
+      {actionLabel && (
+        <Button
+          size="small"
+          color="primary"
+          endIcon={<ChevronRight size={16} aria-hidden="true" />}
+          {...props}
+          {...(component && { component })}
+          {...(href
+            ? {
+                href,
+                target,
+                ...(target === '_blank' && { rel: 'noopener noreferrer' }),
+              }
+            : {})}
+          onClick={handleClick}
+        >
+          {actionLabel}
+        </Button>
+      )}
+    </AppSwitcherFooterRoot>
+  );
+};
+
+AppSwitcherFooter.displayName = 'AppSwitcher.Footer';
+
+export default AppSwitcherFooter;

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherFooter.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherFooter.tsx
@@ -63,6 +63,27 @@ const AppSwitcherFooterText = styled(Typography, {
 }));
 
 /**
+ * Splits leftover props into those that describe the footer element itself
+ * (`data-*`) and those intended for the trailing action (e.g. a router's `to`).
+ */
+const splitFooterProps = (
+  props: Record<string, unknown>
+): { rootProps: Record<string, unknown>; actionProps: Record<string, unknown> } => {
+  const rootProps: Record<string, unknown> = {};
+  const actionProps: Record<string, unknown> = {};
+
+  Object.entries(props).forEach(([key, value]) => {
+    if (key.startsWith('data-')) {
+      rootProps[key] = value;
+    } else {
+      actionProps[key] = value;
+    }
+  });
+
+  return { rootProps, actionProps };
+};
+
+/**
  * Props for the AppSwitcher.Footer component.
  */
 export interface AppSwitcherFooterProps
@@ -112,6 +133,8 @@ export const AppSwitcherFooter: React.FC<AppSwitcherFooterProps> = ({
   onActionClick,
   children,
   sx,
+  className,
+  id,
   ...props
 }) => {
   const { handleClose } = useAppSwitcher();
@@ -121,19 +144,27 @@ export const AppSwitcherFooter: React.FC<AppSwitcherFooterProps> = ({
     handleClose();
   };
 
+  // `className`, `id` and `data-*` describe the footer itself, so they belong on
+  // the root; anything else (e.g. a router's `to`) is meant for the action.
+  const { rootProps, actionProps } = splitFooterProps(props);
+
   if (children) {
-    return <AppSwitcherFooterRoot sx={sx}>{children}</AppSwitcherFooterRoot>;
+    return (
+      <AppSwitcherFooterRoot sx={sx} className={className} id={id} {...rootProps}>
+        {children}
+      </AppSwitcherFooterRoot>
+    );
   }
 
   return (
-    <AppSwitcherFooterRoot sx={sx}>
+    <AppSwitcherFooterRoot sx={sx} className={className} id={id} {...rootProps}>
       {description && <AppSwitcherFooterText>{description}</AppSwitcherFooterText>}
       {actionLabel && (
         <Button
           size="small"
           color="primary"
           endIcon={<ChevronRight size={16} aria-hidden="true" />}
-          {...props}
+          {...actionProps}
           {...(component && { component })}
           {...(href
             ? {

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherSection.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherSection.tsx
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+/**
+ * Theme tokens used in this component:
+ *
+ * Colors:
+ * - `text.secondary` - Section label color
+ *
+ * Spacing:
+ * - `spacing(2)` / `spacing(1.5)` - Padding and grid gap
+ */
+
+/**
+ * Styled section container.
+ */
+const AppSwitcherSectionRoot = styled(Box, {
+  name: 'MuiAppSwitcher',
+  slot: 'Section',
+})(({ theme }) => ({
+  padding: theme.spacing(2),
+}));
+
+/**
+ * Styled uppercase section label.
+ */
+const AppSwitcherSectionLabel = styled(Typography, {
+  name: 'MuiAppSwitcher',
+  slot: 'SectionLabel',
+})(({ theme }) => ({
+  color: (theme.vars || theme).palette.text.secondary,
+  fontSize: 11,
+  fontWeight: theme.typography.fontWeightBold,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  marginBottom: theme.spacing(1.5),
+}));
+
+/**
+ * Styled responsive grid holding the app cards.
+ */
+const AppSwitcherSectionGrid = styled('ul', {
+  name: 'MuiAppSwitcher',
+  slot: 'SectionGrid',
+  shouldForwardProp: (prop) => prop !== 'ownerState',
+})<{ ownerState: { columns: number } }>(({ theme, ownerState }) => ({
+  display: 'grid',
+  gap: theme.spacing(1.5),
+  gridTemplateColumns: '1fr',
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  [theme.breakpoints.up('sm')]: {
+    gridTemplateColumns: `repeat(${ownerState.columns}, minmax(0, 1fr))`,
+  },
+}));
+
+/**
+ * Props for the AppSwitcher.Section component.
+ */
+export interface AppSwitcherSectionProps {
+  /** App cards (typically `AppSwitcher.App` elements) */
+  children: React.ReactNode;
+  /** Section heading, rendered as an uppercase label (e.g. `"Platforms"`) */
+  label?: string;
+  /** Number of grid columns from the `sm` breakpoint up (default: 2) */
+  columns?: number;
+  /** Additional sx props */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * AppSwitcher.Section - Labelled grid of applications inside the popover.
+ *
+ * Renders its children as a semantic list so assistive technology announces the
+ * number of available applications. The grid collapses to a single column on
+ * narrow viewports.
+ *
+ * @example
+ * ```tsx
+ * <AppSwitcher.Section label="Platforms">
+ *   <AppSwitcher.App name="Agent" icon={<Bot />} status="Current" current />
+ *   <AppSwitcher.App name="API Management" icon={<Braces />} status="Try Now" />
+ * </AppSwitcher.Section>
+ * ```
+ */
+export const AppSwitcherSection: React.FC<AppSwitcherSectionProps> = ({
+  children,
+  label,
+  columns = 2,
+  sx,
+}) => {
+  const labelId = React.useId();
+
+  return (
+    <AppSwitcherSectionRoot sx={sx}>
+      {label && <AppSwitcherSectionLabel id={labelId}>{label}</AppSwitcherSectionLabel>}
+      <AppSwitcherSectionGrid
+        ownerState={{ columns }}
+        aria-labelledby={label ? labelId : undefined}
+      >
+        {React.Children.map(children, (child) =>
+          React.isValidElement(child) ? <li>{child}</li> : child
+        )}
+      </AppSwitcherSectionGrid>
+    </AppSwitcherSectionRoot>
+  );
+};
+
+AppSwitcherSection.displayName = 'AppSwitcher.Section';
+
+export default AppSwitcherSection;

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherSection.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherSection.tsx
@@ -118,6 +118,7 @@ export const AppSwitcherSection: React.FC<AppSwitcherSectionProps> = ({
       {label && <AppSwitcherSectionLabel id={labelId}>{label}</AppSwitcherSectionLabel>}
       <AppSwitcherSectionGrid
         ownerState={{ columns }}
+        role="list"
         aria-labelledby={label ? labelId : undefined}
       >
         {React.Children.map(children, (child) =>

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherTrigger.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherTrigger.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { styled } from '@mui/material/styles';
+import { Grip } from '@wso2/oxygen-ui-icons-react';
+import { useAppSwitcher } from './context';
+
+/**
+ * Theme tokens used in this component:
+ *
+ * Colors:
+ * - `text.secondary` - Resting icon color
+ * - `text.primary` - Icon color while open
+ * - `action.selected` - Background while the popover is open
+ *
+ * Hover styling is inherited from the theme's `IconButton` defaults so the
+ * trigger matches the other icon buttons in the header.
+ */
+
+/**
+ * Styled trigger button for the app switcher.
+ */
+const AppSwitcherTriggerRoot = styled(IconButton, {
+  name: 'MuiAppSwitcher',
+  slot: 'Trigger',
+})(({ theme }) => ({
+  color: (theme.vars || theme).palette.text.secondary,
+  '&[aria-expanded="true"]': {
+    backgroundColor: (theme.vars || theme).palette.action.selected,
+    color: (theme.vars || theme).palette.text.primary,
+  },
+}));
+
+/**
+ * Props for the AppSwitcher.Trigger component.
+ */
+export interface AppSwitcherTriggerProps
+  extends Omit<React.ComponentProps<typeof IconButton>, 'children'> {
+  /** Tooltip and accessible label for the trigger (default: `"Switch app"`) */
+  label?: string;
+  /** Custom icon replacing the default grid icon */
+  icon?: React.ReactNode;
+}
+
+/**
+ * AppSwitcher.Trigger - Icon button that opens the app switcher popover.
+ *
+ * Renders the grid ("grip") icon used across WSO2 Cloud headers. Extra props,
+ * including `aria-*` attributes and `ref`, are forwarded to the underlying button.
+ *
+ * @example
+ * ```tsx
+ * <AppSwitcher>
+ *   <AppSwitcher.Trigger />
+ *   ...
+ * </AppSwitcher>
+ * ```
+ */
+export const AppSwitcherTrigger = React.forwardRef<HTMLButtonElement, AppSwitcherTriggerProps>(
+  function AppSwitcherTrigger(
+    { label = 'Switch app', icon, onClick, 'aria-label': ariaLabel, ...props },
+    ref
+  ) {
+    const { open, popoverId, handleOpen } = useAppSwitcher();
+
+    // Empty/whitespace labels must not wipe the default accessible name.
+    const resolvedAriaLabel =
+      typeof ariaLabel === 'string' && ariaLabel.trim().length > 0 ? ariaLabel : label;
+
+    return (
+      <Tooltip title={label}>
+        <AppSwitcherTriggerRoot
+          {...props}
+          ref={ref}
+          onClick={(event) => {
+            handleOpen(event);
+            onClick?.(event);
+          }}
+          aria-label={resolvedAriaLabel}
+          aria-controls={open ? popoverId : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+        >
+          <span aria-hidden="true" style={{ display: 'inline-flex' }}>
+            {icon || <Grip size={24} />}
+          </span>
+        </AppSwitcherTriggerRoot>
+      </Tooltip>
+    );
+  }
+);
+
+AppSwitcherTrigger.displayName = 'AppSwitcher.Trigger';
+
+export default AppSwitcherTrigger;

--- a/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherTrigger.tsx
+++ b/packages/oxygen-ui/src/components/AppSwitcher/AppSwitcherTrigger.tsx
@@ -27,12 +27,12 @@ import { useAppSwitcher } from './context';
  * Theme tokens used in this component:
  *
  * Colors:
- * - `text.secondary` - Resting icon color
  * - `text.primary` - Icon color while open
  * - `action.selected` - Background while the popover is open
  *
- * Hover styling is inherited from the theme's `IconButton` defaults so the
- * trigger matches the other icon buttons in the header.
+ * The resting color and hover styling are inherited from the theme's
+ * `IconButton` defaults (`action.active`), so the trigger matches the other
+ * icon buttons in the header.
  */
 
 /**
@@ -42,7 +42,6 @@ const AppSwitcherTriggerRoot = styled(IconButton, {
   name: 'MuiAppSwitcher',
   slot: 'Trigger',
 })(({ theme }) => ({
-  color: (theme.vars || theme).palette.text.secondary,
   '&[aria-expanded="true"]': {
     backgroundColor: (theme.vars || theme).palette.action.selected,
     color: (theme.vars || theme).palette.text.primary,

--- a/packages/oxygen-ui/src/components/AppSwitcher/context.ts
+++ b/packages/oxygen-ui/src/components/AppSwitcher/context.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+
+/**
+ * Context value for the AppSwitcher compound component.
+ */
+export interface AppSwitcherContextValue {
+  /** Whether the popover is open */
+  open: boolean;
+  /** Element the popover is anchored to */
+  anchorEl: HTMLElement | null;
+  /** Id of the popover surface, used for `aria-controls` on the trigger */
+  popoverId: string;
+  /** Opens the popover, anchoring it to the event target */
+  handleOpen: (event: React.MouseEvent<HTMLElement>) => void;
+  /** Closes the popover */
+  handleClose: () => void;
+}
+
+/**
+ * Context for sharing state between AppSwitcher compound components.
+ */
+export const AppSwitcherContext = React.createContext<AppSwitcherContextValue | null>(null);
+
+/**
+ * Hook to access AppSwitcher context.
+ * @throws Error if used outside AppSwitcher
+ */
+export const useAppSwitcher = (): AppSwitcherContextValue => {
+  const context = React.useContext(AppSwitcherContext);
+  if (!context) {
+    throw new Error('AppSwitcher sub-components must be used within an AppSwitcher component');
+  }
+  return context;
+};
+
+AppSwitcherContext.displayName = 'AppSwitcher.Context';

--- a/packages/oxygen-ui/src/components/AppSwitcher/index.ts
+++ b/packages/oxygen-ui/src/components/AppSwitcher/index.ts
@@ -16,21 +16,13 @@
  * under the License.
  */
 
+// The sub-components (Trigger, Section, App, Footer) are intentionally not
+// exported: the switcher's layout is fixed so it stays consistent across
+// products. Consumers describe the applications with `apps` instead.
 export { AppSwitcher, default } from './AppSwitcher';
-export type { AppSwitcherProps } from './AppSwitcher';
-
-// Export sub-components separately for direct import
-export { AppSwitcherTrigger } from './AppSwitcherTrigger';
-export type { AppSwitcherTriggerProps } from './AppSwitcherTrigger';
-
-export { AppSwitcherSection } from './AppSwitcherSection';
-export type { AppSwitcherSectionProps } from './AppSwitcherSection';
-
-export { AppSwitcherApp } from './AppSwitcherApp';
-export type { AppSwitcherAppProps, AppSwitcherAppStatusColor } from './AppSwitcherApp';
-
-export { AppSwitcherFooter } from './AppSwitcherFooter';
-export type { AppSwitcherFooterProps } from './AppSwitcherFooter';
-
-export { AppSwitcherContext, useAppSwitcher } from './context';
-export type { AppSwitcherContextValue } from './context';
+export type {
+  AppSwitcherProps,
+  AppSwitcherItem,
+  AppSwitcherFooterAction,
+} from './AppSwitcher';
+export type { AppSwitcherAppStatusColor } from './AppSwitcherApp';

--- a/packages/oxygen-ui/src/components/AppSwitcher/index.ts
+++ b/packages/oxygen-ui/src/components/AppSwitcher/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { AppSwitcher, default } from './AppSwitcher';
+export type { AppSwitcherProps } from './AppSwitcher';
+
+// Export sub-components separately for direct import
+export { AppSwitcherTrigger } from './AppSwitcherTrigger';
+export type { AppSwitcherTriggerProps } from './AppSwitcherTrigger';
+
+export { AppSwitcherSection } from './AppSwitcherSection';
+export type { AppSwitcherSectionProps } from './AppSwitcherSection';
+
+export { AppSwitcherApp } from './AppSwitcherApp';
+export type { AppSwitcherAppProps, AppSwitcherAppStatusColor } from './AppSwitcherApp';
+
+export { AppSwitcherFooter } from './AppSwitcherFooter';
+export type { AppSwitcherFooterProps } from './AppSwitcherFooter';
+
+export { AppSwitcherContext, useAppSwitcher } from './context';
+export type { AppSwitcherContextValue } from './context';

--- a/packages/oxygen-ui/src/components/accessibility.test.tsx
+++ b/packages/oxygen-ui/src/components/accessibility.test.tsx
@@ -225,16 +225,11 @@ describe('UserMenu.Trigger', () => {
 });
 
 describe('AppSwitcher', () => {
-  const renderSwitcher = (appProps: Record<string, unknown> = {}) =>
-    renderWithTheme(
-      <AppSwitcher>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Section label="Platforms">
-          <AppSwitcher.App name="API Management" {...appProps} />
-        </AppSwitcher.Section>
-        <AppSwitcher.Footer description="Manage billing" actionLabel="Cloud Console" href="/console" />
-      </AppSwitcher>,
-    );
+  const APPS = [{ key: 'apim', name: 'API Management' }];
+  const FOOTER = { description: 'Manage billing', label: 'Cloud Console', href: '/console' };
+
+  const renderSwitcher = (props: Record<string, unknown> = {}) =>
+    renderWithTheme(<AppSwitcher apps={APPS} footer={FOOTER} {...props} />);
 
   it('exposes popover ARIA state on the trigger and opens on click', () => {
     renderSwitcher();
@@ -255,92 +250,6 @@ describe('AppSwitcher', () => {
     expect(screen.getByRole('list', { name: 'Platforms' })).toBeDefined();
   });
 
-  it('matches the other header icon buttons in size so hover styling lines up', () => {
-    renderWithTheme(
-      <>
-        <ColorSchemeToggle />
-        <AppSwitcher>
-          <AppSwitcher.Trigger />
-        </AppSwitcher>
-      </>,
-    );
-
-    const toggle = screen.getByRole('button', { name: /switch to .* mode/i });
-    const trigger = screen.getByRole('button', { name: 'Switch app' });
-
-    // Both must resolve to the same IconButton size class; a mismatch changes
-    // the padding and therefore the diameter of the hover circle.
-    expect(trigger.className).toContain('MuiIconButton-sizeMedium');
-    expect(toggle.className).toContain('MuiIconButton-sizeMedium');
-  });
-
-  it('lets consumers override the button size', () => {
-    renderWithTheme(
-      <AppSwitcher>
-        <AppSwitcher.Trigger size="small" />
-      </AppSwitcher>,
-    );
-
-    expect(screen.getByRole('button', { name: 'Switch app' }).className).toContain(
-      'MuiIconButton-sizeSmall',
-    );
-  });
-
-  it('renders apps through a custom router component and forwards router props', () => {
-    // Stand-in for a router Link: the library must not depend on a router.
-    const RouterLink = React.forwardRef<
-      HTMLAnchorElement,
-      { to: string; children?: React.ReactNode }
-    >(function RouterLink({ to, children, ...rest }, linkRef) {
-      return (
-        <a ref={linkRef} href={to} data-router-link="true" {...rest}>
-          {children}
-        </a>
-      );
-    });
-
-    renderWithTheme(
-      <AppSwitcher>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Section label="Platforms">
-          <AppSwitcher.App name="API Management" component={RouterLink} to="/apim" />
-        </AppSwitcher.Section>
-      </AppSwitcher>,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
-
-    const app = screen.getByRole('link', { name: 'API Management' });
-    expect(app.getAttribute('data-router-link')).toBe('true');
-    expect(app.getAttribute('href')).toBe('/apim');
-  });
-
-  it('renders the footer action through a custom router component', () => {
-    const RouterLink = React.forwardRef<
-      HTMLAnchorElement,
-      { to: string; children?: React.ReactNode }
-    >(function RouterLink({ to, children, ...rest }, linkRef) {
-      return (
-        <a ref={linkRef} href={to} data-router-link="true" {...rest}>
-          {children}
-        </a>
-      );
-    });
-
-    renderWithTheme(
-      <AppSwitcher>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Footer actionLabel="Cloud Console" component={RouterLink} to="/console" />
-      </AppSwitcher>,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
-
-    const action = screen.getByRole('link', { name: /Cloud Console/ });
-    expect(action.getAttribute('data-router-link')).toBe('true');
-    expect(action.getAttribute('href')).toBe('/console');
-  });
-
   it('names the popover surface as a dialog', () => {
     renderSwitcher();
     fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
@@ -358,55 +267,91 @@ describe('AppSwitcher', () => {
     expect(screen.getByRole('list', { name: 'Platforms' }).getAttribute('role')).toBe('list');
   });
 
-  it('forwards footer data attributes to the root, not the action button', () => {
+  it('renders the fixed layout from data alone', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    // Section heading, one card per app, and the footer action are all present
+    // without the consumer composing any markup.
+    expect(screen.getByRole('list', { name: 'Platforms' })).toBeDefined();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByText('API Management')).toBeDefined();
+    expect(screen.getByRole('link', { name: /Cloud Console/ })).toBeDefined();
+  });
+
+  it('omits the footer when none is supplied', () => {
+    renderWithTheme(<AppSwitcher apps={APPS} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    expect(screen.queryByRole('link', { name: /Cloud Console/ })).toBeNull();
+    expect(screen.getByText('API Management')).toBeDefined();
+  });
+
+  it('lets consumers relabel the section heading', () => {
+    renderSwitcher({ label: 'Products' });
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    expect(screen.getByRole('list', { name: 'Products' })).toBeDefined();
+  });
+
+  it('matches the other header icon buttons in size so hover styling lines up', () => {
     renderWithTheme(
-      <AppSwitcher>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Footer
-          data-testid="switcher-footer"
-          description="Manage billing"
-          actionLabel="Cloud Console"
-          href="/console"
-        />
-      </AppSwitcher>,
+      <>
+        <ColorSchemeToggle />
+        <AppSwitcher apps={APPS} />
+      </>,
+    );
+
+    const toggle = screen.getByRole('button', { name: /switch to .* mode/i });
+    const trigger = screen.getByRole('button', { name: 'Switch app' });
+
+    // Both must resolve to the same IconButton size class; a mismatch changes
+    // the padding and therefore the diameter of the hover circle.
+    expect(trigger.className).toContain('MuiIconButton-sizeMedium');
+    expect(toggle.className).toContain('MuiIconButton-sizeMedium');
+  });
+
+  it('lets consumers relabel the trigger', () => {
+    renderSwitcher({ triggerLabel: 'Switch platform' });
+    expect(screen.getByRole('button', { name: 'Switch platform' })).toBeDefined();
+  });
+
+  it('renders apps through a custom router component and forwards router props', () => {
+    // Stand-in for a router Link: the library must not depend on a router.
+    const RouterLink = React.forwardRef<
+      HTMLAnchorElement,
+      { to: string; children?: React.ReactNode }
+    >(function RouterLink({ to, children, ...rest }, linkRef) {
+      return (
+        <a ref={linkRef} href={to} data-router-link="true" {...rest}>
+          {children}
+        </a>
+      );
+    });
+
+    renderWithTheme(
+      <AppSwitcher
+        apps={[
+          {
+            key: 'apim',
+            name: 'API Management',
+            component: RouterLink,
+            href: '/apim',
+          },
+        ]}
+      />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
 
-    const footer = screen.getByTestId('switcher-footer');
-    expect(footer.tagName).not.toBe('BUTTON');
-    expect(footer.querySelector('a')).not.toBeNull();
-  });
-
-  it('keeps footer data attributes on the root when using custom children', () => {
-    renderWithTheme(
-      <AppSwitcher>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Footer data-testid="custom-footer">
-          <span>Custom content</span>
-        </AppSwitcher.Footer>
-      </AppSwitcher>,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
-
-    expect(screen.getByTestId('custom-footer')).toBeDefined();
-    expect(screen.getByText('Custom content')).toBeDefined();
-  });
-
-  it('keeps the default accessible name when a consumer passes a blank label', () => {
-    renderWithTheme(
-      <AppSwitcher>
-        <AppSwitcher.Trigger aria-label="" />
-      </AppSwitcher>,
-    );
-
-    expect(screen.getByRole('button', { name: 'Switch app' })).toBeDefined();
+    const app = screen.getByRole('link', { name: 'API Management' });
+    expect(app.getAttribute('data-router-link')).toBe('true');
+    expect(app.getAttribute('href')).toBe('/apim');
   });
 
   it('renders navigable apps as links and closes the popover on selection', () => {
     const onClick = vi.fn();
-    renderSwitcher({ href: '/apim', onClick });
+    renderSwitcher({ apps: [{ key: 'apim', name: 'API Management', href: '/apim', onClick }] });
 
     fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
 
@@ -420,13 +365,12 @@ describe('AppSwitcher', () => {
   it('marks the current app and blocks navigation for disabled apps', () => {
     const onClick = vi.fn();
     renderWithTheme(
-      <AppSwitcher>
-        <AppSwitcher.Trigger />
-        <AppSwitcher.Section label="Platforms">
-          <AppSwitcher.App name="Agent" current status="Current" />
-          <AppSwitcher.App name="Analytics" disabled onClick={onClick} />
-        </AppSwitcher.Section>
-      </AppSwitcher>,
+      <AppSwitcher
+        apps={[
+          { key: 'agent', name: 'Agent', current: true, status: 'Current' },
+          { key: 'analytics', name: 'Analytics', disabled: true, onClick },
+        ]}
+      />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));

--- a/packages/oxygen-ui/src/components/accessibility.test.tsx
+++ b/packages/oxygen-ui/src/components/accessibility.test.tsx
@@ -341,6 +341,59 @@ describe('AppSwitcher', () => {
     expect(action.getAttribute('href')).toBe('/console');
   });
 
+  it('names the popover surface as a dialog', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    // MUI gives the paper slot no role, so the role must be set explicitly for
+    // `aria-label` to establish an accessible name.
+    expect(screen.getByRole('dialog', { name: 'Applications' })).toBeDefined();
+  });
+
+  it('keeps list semantics explicit for VoiceOver', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    // `list-style: none` can strip implicit list semantics in Safari/VoiceOver.
+    expect(screen.getByRole('list', { name: 'Platforms' }).getAttribute('role')).toBe('list');
+  });
+
+  it('forwards footer data attributes to the root, not the action button', () => {
+    renderWithTheme(
+      <AppSwitcher>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Footer
+          data-testid="switcher-footer"
+          description="Manage billing"
+          actionLabel="Cloud Console"
+          href="/console"
+        />
+      </AppSwitcher>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    const footer = screen.getByTestId('switcher-footer');
+    expect(footer.tagName).not.toBe('BUTTON');
+    expect(footer.querySelector('a')).not.toBeNull();
+  });
+
+  it('keeps footer data attributes on the root when using custom children', () => {
+    renderWithTheme(
+      <AppSwitcher>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Footer data-testid="custom-footer">
+          <span>Custom content</span>
+        </AppSwitcher.Footer>
+      </AppSwitcher>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    expect(screen.getByTestId('custom-footer')).toBeDefined();
+    expect(screen.getByText('Custom content')).toBeDefined();
+  });
+
   it('keeps the default accessible name when a consumer passes a blank label', () => {
     renderWithTheme(
       <AppSwitcher>

--- a/packages/oxygen-ui/src/components/accessibility.test.tsx
+++ b/packages/oxygen-ui/src/components/accessibility.test.tsx
@@ -26,7 +26,7 @@
  */
 
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/react';
 import { MenuItem, Select } from '@mui/material';
 import OxygenUIThemeProvider from '../contexts/OxygenUIThemeProvider/OxygenUIThemeProvider';
@@ -41,6 +41,7 @@ import HeaderBrand from './Header/HeaderBrand';
 import AppBreadcrumbs from './AppBreadcrumbs/AppBreadcrumbs';
 import ListingTableToolbar from './ListingTable/shared/ListingTableToolbar';
 import UserMenu from './UserMenu/UserMenu';
+import AppSwitcher from './AppSwitcher/AppSwitcher';
 import NotificationPanel from './NotificationPanel/NotificationPanel';
 import { useNotificationPanel } from './NotificationPanel/context';
 
@@ -220,6 +221,181 @@ describe('UserMenu.Trigger', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
     expect(trigger.getAttribute('aria-controls')).toBe('user-menu');
     expect(trigger.getAttribute('aria-label')).toBe('Account');
+  });
+});
+
+describe('AppSwitcher', () => {
+  const renderSwitcher = (appProps: Record<string, unknown> = {}) =>
+    renderWithTheme(
+      <AppSwitcher>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Section label="Platforms">
+          <AppSwitcher.App name="API Management" {...appProps} />
+        </AppSwitcher.Section>
+        <AppSwitcher.Footer description="Manage billing" actionLabel="Cloud Console" href="/console" />
+      </AppSwitcher>,
+    );
+
+  it('exposes popover ARIA state on the trigger and opens on click', () => {
+    renderSwitcher();
+
+    const trigger = screen.getByRole('button', { name: 'Switch app' });
+    expect(trigger.getAttribute('aria-haspopup')).toBe('true');
+    expect(trigger.getAttribute('aria-expanded')).toBeNull();
+    expect(trigger.getAttribute('aria-controls')).toBeNull();
+
+    fireEvent.click(trigger);
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    // The popover surface the trigger points at must exist in the DOM.
+    const controls = trigger.getAttribute('aria-controls');
+    expect(controls).toBeTruthy();
+    expect(document.getElementById(controls as string)).not.toBeNull();
+    expect(screen.getByRole('list', { name: 'Platforms' })).toBeDefined();
+  });
+
+  it('matches the other header icon buttons in size so hover styling lines up', () => {
+    renderWithTheme(
+      <>
+        <ColorSchemeToggle />
+        <AppSwitcher>
+          <AppSwitcher.Trigger />
+        </AppSwitcher>
+      </>,
+    );
+
+    const toggle = screen.getByRole('button', { name: /switch to .* mode/i });
+    const trigger = screen.getByRole('button', { name: 'Switch app' });
+
+    // Both must resolve to the same IconButton size class; a mismatch changes
+    // the padding and therefore the diameter of the hover circle.
+    expect(trigger.className).toContain('MuiIconButton-sizeMedium');
+    expect(toggle.className).toContain('MuiIconButton-sizeMedium');
+  });
+
+  it('lets consumers override the button size', () => {
+    renderWithTheme(
+      <AppSwitcher>
+        <AppSwitcher.Trigger size="small" />
+      </AppSwitcher>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Switch app' }).className).toContain(
+      'MuiIconButton-sizeSmall',
+    );
+  });
+
+  it('renders apps through a custom router component and forwards router props', () => {
+    // Stand-in for a router Link: the library must not depend on a router.
+    const RouterLink = React.forwardRef<
+      HTMLAnchorElement,
+      { to: string; children?: React.ReactNode }
+    >(function RouterLink({ to, children, ...rest }, linkRef) {
+      return (
+        <a ref={linkRef} href={to} data-router-link="true" {...rest}>
+          {children}
+        </a>
+      );
+    });
+
+    renderWithTheme(
+      <AppSwitcher>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Section label="Platforms">
+          <AppSwitcher.App name="API Management" component={RouterLink} to="/apim" />
+        </AppSwitcher.Section>
+      </AppSwitcher>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    const app = screen.getByRole('link', { name: 'API Management' });
+    expect(app.getAttribute('data-router-link')).toBe('true');
+    expect(app.getAttribute('href')).toBe('/apim');
+  });
+
+  it('renders the footer action through a custom router component', () => {
+    const RouterLink = React.forwardRef<
+      HTMLAnchorElement,
+      { to: string; children?: React.ReactNode }
+    >(function RouterLink({ to, children, ...rest }, linkRef) {
+      return (
+        <a ref={linkRef} href={to} data-router-link="true" {...rest}>
+          {children}
+        </a>
+      );
+    });
+
+    renderWithTheme(
+      <AppSwitcher>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Footer actionLabel="Cloud Console" component={RouterLink} to="/console" />
+      </AppSwitcher>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    const action = screen.getByRole('link', { name: /Cloud Console/ });
+    expect(action.getAttribute('data-router-link')).toBe('true');
+    expect(action.getAttribute('href')).toBe('/console');
+  });
+
+  it('keeps the default accessible name when a consumer passes a blank label', () => {
+    renderWithTheme(
+      <AppSwitcher>
+        <AppSwitcher.Trigger aria-label="" />
+      </AppSwitcher>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Switch app' })).toBeDefined();
+  });
+
+  it('renders navigable apps as links and closes the popover on selection', () => {
+    const onClick = vi.fn();
+    renderSwitcher({ href: '/apim', onClick });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    const app = screen.getByRole('link', { name: 'API Management' });
+    expect(app.getAttribute('href')).toBe('/apim');
+
+    fireEvent.click(app);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the current app and blocks navigation for disabled apps', () => {
+    const onClick = vi.fn();
+    renderWithTheme(
+      <AppSwitcher>
+        <AppSwitcher.Trigger />
+        <AppSwitcher.Section label="Platforms">
+          <AppSwitcher.App name="Agent" current status="Current" />
+          <AppSwitcher.App name="Analytics" disabled onClick={onClick} />
+        </AppSwitcher.Section>
+      </AppSwitcher>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    expect(screen.getByText('Agent').closest('[aria-current="true"]')).not.toBeNull();
+
+    const disabledApp = screen.getByText('Analytics').closest('[aria-disabled="true"]');
+    expect(disabledApp).not.toBeNull();
+    fireEvent.click(disabledApp as HTMLElement);
+    expect(onClick).not.toHaveBeenCalled();
+
+    // Unavailable apps stay discoverable rather than dropping out of the tab order.
+    expect((disabledApp as HTMLElement).hasAttribute('disabled')).toBe(false);
+  });
+
+  it('groups apps in a labelled list', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByRole('button', { name: 'Switch app' }));
+
+    const list = screen.getByRole('list', { name: 'Platforms' });
+    expect(list).toBeDefined();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
   });
 });
 

--- a/packages/oxygen-ui/src/components/accessibility.test.tsx
+++ b/packages/oxygen-ui/src/components/accessibility.test.tsx
@@ -311,6 +311,22 @@ describe('AppSwitcher', () => {
     expect(toggle.className).toContain('MuiIconButton-sizeMedium');
   });
 
+  it('inherits the same resting icon color as the other header icon buttons', () => {
+    const toggle = renderWithTheme(<ColorSchemeToggle />);
+    const switcher = renderWithTheme(<AppSwitcher apps={APPS} />);
+
+    // The trigger must not pin its own color; a different token renders visibly
+    // darker or lighter than the adjacent ColorSchemeToggle.
+    const toggleColor = getComputedStyle(
+      toggle.container.querySelector('button') as HTMLElement,
+    ).color;
+    const triggerColor = getComputedStyle(
+      switcher.container.querySelector('button') as HTMLElement,
+    ).color;
+
+    expect(triggerColor).toBe(toggleColor);
+  });
+
   it('lets consumers relabel the trigger', () => {
     renderSwitcher({ triggerLabel: 'Switch platform' });
     expect(screen.getByRole('button', { name: 'Switch platform' })).toBeDefined();

--- a/packages/oxygen-ui/src/components/index.ts
+++ b/packages/oxygen-ui/src/components/index.ts
@@ -55,15 +55,12 @@ export type {
   HeaderContextValue,
 } from './Header';
 
-export { AppSwitcher, useAppSwitcher } from './AppSwitcher';
+export { AppSwitcher } from './AppSwitcher';
 export type {
   AppSwitcherProps,
-  AppSwitcherTriggerProps,
-  AppSwitcherSectionProps,
-  AppSwitcherAppProps,
+  AppSwitcherItem,
+  AppSwitcherFooterAction,
   AppSwitcherAppStatusColor,
-  AppSwitcherFooterProps,
-  AppSwitcherContextValue,
 } from './AppSwitcher';
 
 export { Sidebar, useSidebar } from './Sidebar';

--- a/packages/oxygen-ui/src/components/index.ts
+++ b/packages/oxygen-ui/src/components/index.ts
@@ -55,6 +55,17 @@ export type {
   HeaderContextValue,
 } from './Header';
 
+export { AppSwitcher, useAppSwitcher } from './AppSwitcher';
+export type {
+  AppSwitcherProps,
+  AppSwitcherTriggerProps,
+  AppSwitcherSectionProps,
+  AppSwitcherAppProps,
+  AppSwitcherAppStatusColor,
+  AppSwitcherFooterProps,
+  AppSwitcherContextValue,
+} from './AppSwitcher';
+
 export { Sidebar, useSidebar } from './Sidebar';
 export type {
   SidebarProps,


### PR DESCRIPTION
### Purpose

Adds `AppSwitcher`, the header control for moving between WSO2 Cloud platforms.

```tsx
import { AppSwitcher, Header } from '@wso2/oxygen-ui';

<Header.Actions>
  <AppSwitcher
    apps={[
      { key: 'agent', name: 'Agent Manager', url: 'https://agent.wso2.com' },
      { key: 'api', name: 'API Platform', url: 'https://api.wso2.com' },
    ]}
    footer={{
      links: [
        { key: 'orgs', name: 'Organizations', url: 'https://console.wso2.com/organizations' },
        { key: 'billing', name: 'Billing', url: 'https://console.wso2.com/billing' },
      ],
    }}
  />
</Header.Actions>
```

**Design decisions worth reviewer attention**

This is the proposed design: 

<img width="676" height="619" alt="Screenshot 2026-09-17 at 15 28 42" src="https://github.com/user-attachments/assets/39874d10-bf4d-4d69-8bd2-939fa9d68afa" />

Implemented:

<img width="1701" height="563" alt="Screenshot 2026-09-17 at 15 37 30" src="https://github.com/user-attachments/assets/49e18263-3115-4aa7-a322-99fe9be78454" />



- **The layout is fixed, not composable.** Consumers describe destinations with `apps` and `footer`; the sub-components are deliberately not exported.
- **The WSO2 mark is supplied by the component**, using the existing `WSO2` icon from `@wso2/oxygen-ui-icons-react` rather than new artwork, so the grid stays uniform. Products pass `icon` only when a destination genuinely needs something else — the manage links do, which is why they take neutral glyphs.
- **Routing is left to the consumer.** The library takes no router dependency: `url` for cross-app navigation, `component` + `componentProps` for a router `Link`, or `onClick` for programmatic navigation.
- **Cards render as real anchors when given `url`**, so middle-click and "open in new tab" behave natively. They target `_blank` by default, since each platform is its own deployment, and a `_blank` target always keeps `rel="noopener noreferrer"` — `componentProps` cannot strip it.
- **Selecting a card leaves the popover open.** Because the card opened a new tab, the current tab never navigated, and dismissing would look like the switcher had closed itself. The trigger toggles, and an outside click or `Esc` dismisses — matching other app-grid switchers.
- **Unavailable platforms use `aria-disabled` rather than the native `disabled` attribute**, keeping them in the tab order so screen reader users can still discover a platform that is not yet available. They render as a dashed, faded card and can carry a `tooltip` explaining why. That tooltip works *because* of `aria-disabled` — a natively disabled button swallows pointer events — and it describes the card rather than renaming it, so the platform name stays its accessible name.

**Accessibility note.** The switcher has no brand-colored *text*, so it needs no contrast exception. `#FF7300` appears only on the mark, hover border and focus ring. At 2.73:1 those sit under the 3:1 bar WCAG 2.1 SC 1.4.11 sets for non-text UI components — a property of the brand palette rather than of this component (the standard card border, `#E0E0E0`, is 1.32:1), tracked in #558.

**Not included:** the Recent Access section from the design is deliberately out of scope for this PR.

### Related Issues

https://github.com/wso2/oxygen-ui/issues/620

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines. <!-- Link 404s: no CONTRIBUTING.md currently exists in the repo. Followed the conventions established by the existing components (UserMenu, NotificationPanel). -->
- [x] Manual test round performed and verified. (Automated checks pass: build, typecheck, lint and 84 unit tests. A visual pass over the rendered component in Storybook across light/dark themes and narrow viewports is still outstanding.)
- [x] Documentation provided. (Add links if there are any) — `AppSwitcher` API reference and routing patterns added to [`.ai/components.md`](https://github.com/wso2/oxygen-ui/blob/feat/app-switcher/packages/oxygen-ui/.ai/components.md) and [`.claude/components.md`](https://github.com/wso2/oxygen-ui/blob/feat/app-switcher/packages/oxygen-ui/.claude/components.md), plus JSDoc on every sub-component
- [x] Unit tests provided. (Add links if there are any) — 35 tests in [`accessibility.test.tsx`](https://github.com/wso2/oxygen-ui/blob/feat/app-switcher/packages/oxygen-ui/src/components/accessibility.test.tsx) covering popover ARIA state, list semantics, new-tab and `rel` behavior, dismissal, the disabled card and its tooltip, equal card heights, router integration, arrow-key navigation within each grid, and header icon size parity
- [x] Storybook stories updated/added (if applicable) — 3 stories under **App Elements → App Switcher**: the default switcher, a single-platform case, and an in-header example

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
