### PR TITLE
fix: drop unused MUI X and Prism from the published barrel

### DIFF
--- a/.changeset/tree-shake-mui-x-prism.md
+++ b/.changeset/tree-shake-mui-x-prism.md
@@ -1,5 +1,5 @@
 ---
-'@wso2/oxygen-ui': minor
+'@wso2/oxygen-ui': major
 ---
 
 Stop re-exporting MUI X from the `@wso2/oxygen-ui` Published entry so Table-only apps do not evaluate Data Grid, Date Pickers, Tree View, or Prism. Import those surfaces from Oxygen subpaths (`@wso2/oxygen-ui/data-grid`, `date-pickers`, `tree-view`). CodeBlock and ListingTable.DataGrid load their heavy deps on mount.

--- a/.changeset/tree-shake-mui-x-prism.md
+++ b/.changeset/tree-shake-mui-x-prism.md
@@ -1,0 +1,7 @@
+---
+'@wso2/oxygen-ui': minor
+---
+
+Stop re-exporting MUI X from the `@wso2/oxygen-ui` Published entry so Table-only apps do not evaluate Data Grid, Date Pickers, Tree View, or Prism. Import those surfaces from Oxygen subpaths (`@wso2/oxygen-ui/data-grid`, `date-pickers`, `tree-view`). CodeBlock and ListingTable.DataGrid load their heavy deps on mount.
+
+Fixes #578

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Refer to [Material-UI documentation](https://mui.com/material-ui/all-components/
 
 ## Using MUI X Components
 
-For DataGrid and DatePickers, use namespace imports:
+Import Data Grid, Date Pickers, and Tree View from Oxygen subpaths. They are not on the main `@wso2/oxygen-ui` entry, so a `Table`-only app does not evaluate that code.
 
 ```jsx
-import { DataGrid } from '@wso2/oxygen-ui';
+import { DataGrid } from '@wso2/oxygen-ui/data-grid';
 
 function MyDataGrid() {
   return (
-    <DataGrid.DataGrid
+    <DataGrid
       rows={rows}
       columns={columns}
     />

--- a/packages/eslint-plugin-oxygen-ui/README.md
+++ b/packages/eslint-plugin-oxygen-ui/README.md
@@ -52,8 +52,6 @@ Prevents direct imports from all MUI packages (`@mui/*`) and suggests using `@ox
 ```javascript
 import { Box, Stack } from '@mui/material';
 import Button from '@mui/material/Button';
-import { DataGrid } from '@mui/x-data-grid';
-import { DatePicker } from '@mui/x-date-pickers';
 ```
 
 ✅ **Correct:**
@@ -61,19 +59,15 @@ import { DatePicker } from '@mui/x-date-pickers';
 // Standard Material-UI components
 import { Box, Stack, Button } from '@wso2/oxygen-ui';
 
-// MUI X Data Grid components (namespace export)
-import { DataGrid } from '@wso2/oxygen-ui';
-// Then destructure specific components:
-const { DataGrid: DataGridComponent, GridColDef } = DataGrid;
-
-// MUI X Date Pickers components (namespace export)
-import { DatePickers } from '@wso2/oxygen-ui';
-// Then destructure specific components:
-const { DatePicker, LocalizationProvider } = DatePickers;
+// MUI X lives on Oxygen subpaths (not the main @wso2/oxygen-ui entry)
+import { DataGrid } from '@wso2/oxygen-ui/data-grid';
+import { DatePicker, LocalizationProvider } from '@wso2/oxygen-ui/date-pickers';
+import { SimpleTreeView } from '@wso2/oxygen-ui/tree-view';
 ```
 
 **Options:**
 - `suggestedPackage` (string): The package to suggest instead of @mui/* (default: '@wso2/oxygen-ui')
+- `suggestedPackageByPrefix` (object): Map of `@mui` prefixes to Oxygen paths (for example `@mui/x-data-grid` → `@wso2/oxygen-ui/data-grid`)
 - `allowedPackages` (array): List of MUI packages that are allowed (default: [])
 
 ### `no-direct-lucide-imports`

--- a/packages/eslint-plugin-oxygen-ui/src/index.ts
+++ b/packages/eslint-plugin-oxygen-ui/src/index.ts
@@ -42,7 +42,11 @@ const recommendedConfig: Linter.Config = {
       'error',
       {
         suggestedPackage: '@oxygen-ui/react',
-        allowedPackages: ['@mui/x-data-grid', '@mui/x-date-pickers'],
+        suggestedPackageByPrefix: {
+          '@mui/x-data-grid': '@wso2/oxygen-ui/data-grid',
+          '@mui/x-date-pickers': '@wso2/oxygen-ui/date-pickers',
+          '@mui/x-tree-view': '@wso2/oxygen-ui/tree-view',
+        },
       },
     ],
     '@oxygen-ui/no-direct-lucide-imports': [

--- a/packages/eslint-plugin-oxygen-ui/src/rules/no-direct-mui-imports.ts
+++ b/packages/eslint-plugin-oxygen-ui/src/rules/no-direct-mui-imports.ts
@@ -22,6 +22,7 @@ import type {ImportDeclaration} from 'estree';
 interface NoDirectMuiImportsOptions {
   allowedPackages?: string[];
   suggestedPackage?: string;
+  suggestedPackageByPrefix?: Record<string, string>;
 }
 
 const noDirectMuiImportsRule: Rule.RuleModule = {
@@ -46,6 +47,11 @@ const noDirectMuiImportsRule: Rule.RuleModule = {
             type: 'string',
             description: 'The package to suggest instead of @mui/material',
           },
+          suggestedPackageByPrefix: {
+            type: 'object',
+            additionalProperties: {type: 'string'},
+            description: 'Map of @mui package prefixes to Oxygen import paths (for example MUI X subpaths)',
+          },
         },
         additionalProperties: false,
       },
@@ -61,6 +67,22 @@ const noDirectMuiImportsRule: Rule.RuleModule = {
     const options: NoDirectMuiImportsOptions = (context.options?.[0] as NoDirectMuiImportsOptions) ?? {};
     const allowedPackages: string[] = options.allowedPackages ?? [];
     const suggestedPackage: string = options.suggestedPackage ?? '@wso2/oxygen-ui';
+    const suggestedPackageByPrefix: Record<string, string> = options.suggestedPackageByPrefix ?? {};
+
+    function suggestedFor(importSource: string): string {
+      const prefixes = Object.keys(suggestedPackageByPrefix).sort((left, right) => right.length - left.length);
+      const match = prefixes.find(
+        (prefix) => importSource === prefix || importSource.startsWith(`${prefix}/`),
+      );
+      if (!match) {
+        return suggestedPackage;
+      }
+      const rest = importSource.slice(match.length);
+      if (match === '@mui/x-date-pickers' && rest.startsWith('/Adapter')) {
+        return `${suggestedPackageByPrefix[match]}${rest}`;
+      }
+      return suggestedPackageByPrefix[match];
+    }
 
     return {
       ImportDeclaration(node: ImportDeclaration) {
@@ -76,6 +98,8 @@ const noDirectMuiImportsRule: Rule.RuleModule = {
           return;
         }
 
+        const replacement = suggestedFor(importSource);
+
         // Extract component name from subpath imports like '@mui/material/Box' or '@mui/x-data-grid/DataGrid'
         const componentMatch = /^@mui\/[^/]+\/(.+)$/.exec(importSource);
         const componentName = componentMatch ? componentMatch[1] : null;
@@ -86,20 +110,20 @@ const noDirectMuiImportsRule: Rule.RuleModule = {
           data: {
             source: importSource,
             component: componentName ?? '',
-            suggestedPackage,
+            suggestedPackage: replacement,
           },
           fix(fixer: Rule.RuleFixer) {
             // For subpath imports like "import Box from '@mui/material/Box'" or "import { DataGrid } from '@mui/x-data-grid'"
             // Convert to: "import {Box} from '@oxygen-ui/react'"
             if (componentName && node.specifiers.length === 1 && node.specifiers[0].type === 'ImportDefaultSpecifier') {
               const importedName = node.specifiers[0].local.name;
-              const newImport = `import {${importedName}} from '${suggestedPackage}'`;
+              const newImport = `import {${importedName}} from '${replacement}'`;
               return fixer.replaceText(node, newImport);
             }
 
             // For all other cases (direct imports from any @mui/* package)
             // Just replace the source with the suggested package
-            const newSource = `'${suggestedPackage}'`;
+            const newSource = `'${replacement}'`;
             return fixer.replaceText(node.source, newSource);
           },
         });

--- a/packages/oxygen-ui-docs/.storybook/main.js
+++ b/packages/oxygen-ui-docs/.storybook/main.js
@@ -46,7 +46,26 @@ export default {
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
-      '@wso2/oxygen-ui': path.resolve(__dirname, '../../oxygen-ui/dist/index.js'),
+      '@wso2/oxygen-ui$': path.resolve(__dirname, '../../oxygen-ui/dist/index.js'),
+      '@wso2/oxygen-ui/data-grid$': path.resolve(__dirname, '../../oxygen-ui/dist/data-grid.js'),
+      '@wso2/oxygen-ui/date-pickers$': path.resolve(__dirname, '../../oxygen-ui/dist/date-pickers.js'),
+      '@wso2/oxygen-ui/tree-view$': path.resolve(__dirname, '../../oxygen-ui/dist/tree-view.js'),
+      ...Object.fromEntries(
+        [
+          'AdapterDateFns',
+          'AdapterDateFnsJalali',
+          'AdapterDateFnsJalaliV2',
+          'AdapterDateFnsV2',
+          'AdapterDayjs',
+          'AdapterLuxon',
+          'AdapterMoment',
+          'AdapterMomentHijri',
+          'AdapterMomentJalaali',
+        ].map((adapter) => [
+          `@wso2/oxygen-ui/date-pickers/${adapter}`,
+          path.resolve(__dirname, `../../oxygen-ui/dist/date-pickers/${adapter}.js`),
+        ]),
+      ),
       '@wso2/oxygen-ui-icons-react': path.resolve(__dirname, '../../oxygen-ui-icons-react/dist/index.js'),
       '@wso2/oxygen-ui-charts-react': path.resolve(__dirname, '../../oxygen-ui-charts-react/dist/index.js'),
     };

--- a/packages/oxygen-ui-docs/stories/AppElements/ListingTable.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/AppElements/ListingTable.stories.tsx
@@ -19,7 +19,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   ListingTable,
-  DataGrid,
   Button,
   Checkbox,
   Chip,
@@ -33,6 +32,7 @@ import {
   TextField,
   useListingTable,
 } from '@wso2/oxygen-ui';
+import { DataGrid } from '@wso2/oxygen-ui/data-grid';
 import type { ListingTableDensity, ListingTableDataGridProps, ListingTableSortDirection, ListingTableVariant } from '@wso2/oxygen-ui';
 import {
   Edit,
@@ -942,9 +942,7 @@ export const DataGridVariant: Story = {
     },
   },
   render: (args) => {
-    const { DataGrid: MuiDataGrid } = DataGrid;
-
-    const columns: React.ComponentProps<typeof MuiDataGrid>['columns'] = [
+    const columns: React.ComponentProps<typeof DataGrid>['columns'] = [
       {
         field: 'name',
         headerName: 'Name',
@@ -1011,14 +1009,12 @@ export const DataGridVariant: Story = {
 export const DataGridRowActions: Story = {
   name: 'DataGrid Row Actions',
   render: () => {
-    const { DataGrid: MuiDataGrid } = DataGrid;
-
     const handleAction = (action: string, id: string, e: React.MouseEvent) => {
       e.stopPropagation();
       console.log(`${action}:`, id);
     };
 
-    const columns: React.ComponentProps<typeof MuiDataGrid>['columns'] = [
+    const columns: React.ComponentProps<typeof DataGrid>['columns'] = [
       {
         field: 'name',
         headerName: 'Name',
@@ -1133,9 +1129,7 @@ export const DataGridCardVariant: Story = {
     },
   },
   render: (args) => {
-    const { DataGrid: MuiDataGrid } = DataGrid;
-
-    const columns: React.ComponentProps<typeof MuiDataGrid>['columns'] = [
+    const columns: React.ComponentProps<typeof DataGrid>['columns'] = [
       {
         field: 'name',
         headerName: 'Name',
@@ -1207,12 +1201,11 @@ export const DataGridCardVariant: Story = {
 export const DataGridWithProvider: Story = {
   name: 'DataGrid With Provider',
   render: () => {
-    const { DataGrid: MuiDataGrid } = DataGrid;
     const [searchValue, setSearchValue] = useState('');
     const [density, setDensity] = useState<ListingTableDensity>('standard');
     const [loading, setLoading] = useState(false);
 
-    const columns: React.ComponentProps<typeof MuiDataGrid>['columns'] = [
+    const columns: React.ComponentProps<typeof DataGrid>['columns'] = [
       {
         field: 'name',
         headerName: 'Name',

--- a/packages/oxygen-ui-docs/stories/DataDisplay/DataGrid.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/DataDisplay/DataGrid.stories.tsx
@@ -18,13 +18,11 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataGrid } from '@wso2/oxygen-ui';
+import { DataGrid } from '@wso2/oxygen-ui/data-grid';
 
-const { DataGrid: DataGridComponent } = DataGrid;
-
-const meta: Meta<typeof DataGridComponent> = {
+const meta: Meta<typeof DataGrid> = {
   title: 'Data Display/DataGrid',
-  component: DataGridComponent,
+  component: DataGrid,
   parameters: {
     layout: 'centered',
     docs: {
@@ -39,7 +37,7 @@ const meta: Meta<typeof DataGridComponent> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof DataGridComponent>;
+type Story = StoryObj<typeof DataGrid>;
 
 const columns = [
   { field: 'id', headerName: 'ID', width: 70 },
@@ -77,7 +75,7 @@ const rows = [
 export const Default: Story = {
   render: () => (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGridComponent rows={rows} columns={columns} />
+      <DataGrid rows={rows} columns={columns} />
     </div>
   ),
 };
@@ -85,7 +83,7 @@ export const Default: Story = {
 export const WithCheckboxSelection: Story = {
   render: () => (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGridComponent
+      <DataGrid
         rows={rows}
         columns={columns}
         checkboxSelection
@@ -97,7 +95,7 @@ export const WithCheckboxSelection: Story = {
 export const WithPagination: Story = {
   render: () => (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGridComponent
+      <DataGrid
         rows={rows}
         columns={columns}
         initialState={{
@@ -114,7 +112,7 @@ export const WithPagination: Story = {
 export const Sortable: Story = {
   render: () => (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGridComponent
+      <DataGrid
         rows={rows}
         columns={columns}
         initialState={{
@@ -130,7 +128,7 @@ export const Sortable: Story = {
 export const DisableRowSelectionOnClick: Story = {
   render: () => (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGridComponent
+      <DataGrid
         rows={rows}
         columns={columns}
         disableRowSelectionOnClick
@@ -142,7 +140,7 @@ export const DisableRowSelectionOnClick: Story = {
 export const Loading: Story = {
   render: () => (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGridComponent
+      <DataGrid
         rows={[]}
         columns={columns}
         loading

--- a/packages/oxygen-ui-docs/stories/DataDisplay/TreeView.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/DataDisplay/TreeView.stories.tsx
@@ -18,9 +18,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { TreeView } from '@wso2/oxygen-ui';
-
-const { SimpleTreeView, TreeItem } = TreeView;
+import { SimpleTreeView, TreeItem } from '@wso2/oxygen-ui/tree-view';
 
 /**
  * MUI X Tree View provides components for displaying hierarchical data.

--- a/packages/oxygen-ui-docs/stories/Inputs/DatePicker.stories.tsx
+++ b/packages/oxygen-ui-docs/stories/Inputs/DatePicker.stories.tsx
@@ -18,9 +18,9 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { DatePickers, AdapterDateFns, OxygenUIThemeProvider } from '@wso2/oxygen-ui';
-
-const { LocalizationProvider, DatePicker, TimePicker, DateTimePicker } = DatePickers;
+import { DatePicker, DateTimePicker, LocalizationProvider, TimePicker } from '@wso2/oxygen-ui/date-pickers';
+import { AdapterDateFns } from '@wso2/oxygen-ui/date-pickers/AdapterDateFns';
+import { OxygenUIThemeProvider } from '@wso2/oxygen-ui';
 
 /**
  * MUI X Date and Time Pickers provide components for selecting dates and times.

--- a/packages/oxygen-ui/README.md
+++ b/packages/oxygen-ui/README.md
@@ -66,17 +66,13 @@ function App() {
 
 ### MUI X Data Grid
 
-Data Grid components are exported as a namespace to avoid naming conflicts:
+**Breaking:** `import { DataGrid } from '@wso2/oxygen-ui'` (the MUI X namespace) is removed. Import from `@wso2/oxygen-ui/data-grid` instead. The same applies to `DatePickers` (`date-pickers`), `AdapterDateFns` (`date-pickers/AdapterDateFns`), and `TreeView` (`tree-view`).
+
+Import Data Grid from the Oxygen subpath. It is not on the main entry, so apps that only use `Table` / `Button` do not evaluate the grid.
 
 ```typescript
-import { DataGrid } from '@wso2/oxygen-ui';
-
-// Destructure the components you need
-const { 
-  DataGrid: DataGridComponent, 
-  GridColDef, 
-  GridToolbarContainer 
-} = DataGrid;
+import { DataGrid } from '@wso2/oxygen-ui/data-grid';
+import type { GridColDef } from '@wso2/oxygen-ui/data-grid';
 
 function MyDataGrid() {
   const columns: GridColDef[] = [
@@ -90,7 +86,7 @@ function MyDataGrid() {
   ];
 
   return (
-    <DataGridComponent
+    <DataGrid
       rows={rows}
       columns={columns}
     />
@@ -98,25 +94,21 @@ function MyDataGrid() {
 }
 ```
 
+For an Oxygen-styled grid inside a listing, use `ListingTable.DataGrid` — it loads `@mui/x-data-grid` when the grid mounts.
+
 ### MUI X Date Pickers
 
-Date Picker components are exported as a namespace:
+Import date pickers from the Oxygen subpath (and the adapter you use):
 
 ```typescript
-import { DatePickers } from '@wso2/oxygen-ui';
-
-// Destructure the components you need
-const { 
-  DatePicker, 
-  LocalizationProvider, 
-  DateTimePicker 
-} = DatePickers;
+import { DatePicker, LocalizationProvider } from '@wso2/oxygen-ui/date-pickers';
+import { AdapterDateFns } from '@wso2/oxygen-ui/date-pickers/AdapterDateFns';
 
 function MyDatePicker() {
   const [value, setValue] = useState<Date | null>(null);
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
       <DatePicker
         label="Select Date"
         value={value}
@@ -158,13 +150,10 @@ function MyChart() {
 
 ### MUI X Tree View
 
-Tree View components are exported as a namespace:
+Import tree view from the Oxygen subpath:
 
 ```typescript
-import { TreeView } from '@wso2/oxygen-ui';
-
-// Destructure the tree components you need
-const { SimpleTreeView, TreeItem } = TreeView;
+import { SimpleTreeView, TreeItem } from '@wso2/oxygen-ui/tree-view';
 
 function MyTreeView() {
   return (
@@ -419,21 +408,15 @@ All components from `@mui/material` are re-exported directly.
 
 ### MUI X Components
 
-- `DataGrid` - Namespace containing all Data Grid components
-- `DatePickers` - Namespace containing all Date Picker components
-- `Charts` - Namespace containing all Chart components
-- `TreeView` - Namespace containing all TreeView components
+Import Data Grid, Date Pickers, and Tree View from `@wso2/oxygen-ui/data-grid`, `@wso2/oxygen-ui/date-pickers`, and `@wso2/oxygen-ui/tree-view`. They are not re-exported from the main `@wso2/oxygen-ui` entry.
 
 ## TypeScript Support
 
-This package includes full TypeScript definitions. All types from Material-UI and MUI X are also available:
+This package includes full TypeScript definitions. Material-UI types are re-exported from `@wso2/oxygen-ui`. MUI X types come from the Oxygen subpaths:
 
 ```typescript
 import type { ButtonProps, BoxProps } from '@wso2/oxygen-ui';
-import { DataGrid } from '@wso2/oxygen-ui';
-
-const { GridColDef } = DataGrid;
-type MyGridColDef = typeof GridColDef;
+import type { GridColDef } from '@wso2/oxygen-ui/data-grid';
 ```
 
 ## AI-Assisted Development

--- a/packages/oxygen-ui/esbuild.config.js
+++ b/packages/oxygen-ui/esbuild.config.js
@@ -22,19 +22,30 @@ import { inlineCSSFontsPlugin } from '@wso2/esbuild-plugin-inline-css-fonts';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
 
-esbuild.build({
+const shared = {
   entryPoints: [
     'src/index.ts',
+    'src/data-grid.ts',
+    'src/date-pickers.ts',
+    'src/tree-view.ts',
+    'src/date-pickers/AdapterDateFns.ts',
+    'src/date-pickers/AdapterDateFnsJalali.ts',
+    'src/date-pickers/AdapterDateFnsJalaliV2.ts',
+    'src/date-pickers/AdapterDateFnsV2.ts',
+    'src/date-pickers/AdapterDayjs.ts',
+    'src/date-pickers/AdapterLuxon.ts',
+    'src/date-pickers/AdapterMoment.ts',
+    'src/date-pickers/AdapterMomentHijri.ts',
+    'src/date-pickers/AdapterMomentJalaali.ts',
   ],
   platform: 'browser',
   outdir: 'dist',
   bundle: true,
-  format: 'esm',
   splitting: false,
   sourcemap: true,
   minify: false,
   target: ['es2017'],
-  plugins: [ 
+  plugins: [
     inlineCSSFontsPlugin({
       styleAttribute: 'data-oxygen-fonts'
     })
@@ -51,7 +62,19 @@ esbuild.build({
     ...Object.keys(pkg.peerDependencies || {})
   ],
   preserveSymlinks: true,
-}).catch((err) => {
+};
+
+Promise.all([
+  esbuild.build({
+    ...shared,
+    format: 'esm',
+  }),
+  esbuild.build({
+    ...shared,
+    format: 'cjs',
+    outExtension: { '.js': '.cjs' },
+  }),
+]).catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/packages/oxygen-ui/package.json
+++ b/packages/oxygen-ui/package.json
@@ -12,6 +12,26 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./data-grid": {
+      "types": "./dist/data-grid.d.ts",
+      "import": "./dist/data-grid.js",
+      "require": "./dist/data-grid.cjs"
+    },
+    "./date-pickers": {
+      "types": "./dist/date-pickers.d.ts",
+      "import": "./dist/date-pickers.js",
+      "require": "./dist/date-pickers.cjs"
+    },
+    "./date-pickers/*": {
+      "types": "./dist/date-pickers/*.d.ts",
+      "import": "./dist/date-pickers/*.js",
+      "require": "./dist/date-pickers/*.cjs"
+    },
+    "./tree-view": {
+      "types": "./dist/tree-view.d.ts",
+      "import": "./dist/tree-view.js",
+      "require": "./dist/tree-view.cjs"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/*.js",

--- a/packages/oxygen-ui/src/components/CodeBlock/CodeBlock.load-error.test.tsx
+++ b/packages/oxygen-ui/src/components/CodeBlock/CodeBlock.load-error.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import OxygenUIThemeProvider from '../../contexts/OxygenUIThemeProvider/OxygenUIThemeProvider';
+import CodeBlock from './CodeBlock';
+
+vi.mock('prismjs', () => {
+  throw new Error('Failed to load Prism');
+});
+
+describe('CodeBlock load failure', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps the unhighlighted sample when Prism fails to load', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { container } = render(
+      <OxygenUIThemeProvider>
+        <CodeBlock code={'const answer: number = 42;'} language="typescript" />
+      </OxygenUIThemeProvider>,
+    );
+
+    expect(container.querySelector('code.language-typescript')?.textContent).toBe(
+      'const answer: number = 42;',
+    );
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/oxygen-ui/src/components/CodeBlock/CodeBlock.test.tsx
+++ b/packages/oxygen-ui/src/components/CodeBlock/CodeBlock.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import OxygenUIThemeProvider from '../../contexts/OxygenUIThemeProvider/OxygenUIThemeProvider';
+import CodeBlock from './CodeBlock';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function staticImportSpecifiers(source: string): string[] {
+  const stripped = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+    .replace(/import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g, '')
+    .replace(/export\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g, '');
+
+  const fromSpecs = [...stripped.matchAll(/\b(?:import|export)\s+[\s\S]*?from\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  );
+  const bareSpecs = [...stripped.matchAll(/(?:^|[;\n])\s*import\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  );
+  return [...fromSpecs, ...bareSpecs];
+}
+
+describe('CodeBlock', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not statically import prismjs', () => {
+    const source = readFileSync(join(here, 'CodeBlock.tsx'), 'utf8');
+    expect(staticImportSpecifiers(source).filter((specifier) => specifier.startsWith('prismjs'))).toEqual(
+      [],
+    );
+  });
+
+  it('highlights typescript after mount', async () => {
+    const { container } = render(
+      <OxygenUIThemeProvider>
+        <CodeBlock code={'const answer: number = 42;'} language="typescript" />
+      </OxygenUIThemeProvider>,
+    );
+
+    expect(container.querySelector('code.language-typescript')).not.toBeNull();
+    const pre = container.querySelector('pre');
+    expect(pre?.getAttribute('tabindex')).toBe('0');
+    expect(pre?.getAttribute('role')).toBe('region');
+    await waitFor(() => {
+      expect(container.querySelector('.token')).not.toBeNull();
+    });
+  });
+});

--- a/packages/oxygen-ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/oxygen-ui/src/components/CodeBlock/CodeBlock.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,15 +18,27 @@
 
 import React, { useEffect } from 'react';
 import { Box, useTheme } from '@mui/material';
-import Prism from 'prismjs';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-typescript';
-import 'prismjs/components/prism-jsx';
-import 'prismjs/components/prism-tsx';
-import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-bash';
-import 'prismjs/components/prism-json';
-import 'prismjs/components/prism-markup';
+import type PrismType from 'prismjs';
+
+let prismPromise: Promise<typeof PrismType> | undefined;
+
+function loadPrism(): Promise<typeof PrismType> {
+  prismPromise ??= (async () => {
+    const { default: Prism } = await import('prismjs');
+    // Language files register on the Prism singleton and some depend on
+    // earlier ones (tsx needs jsx + typescript). Load in that order.
+    await import('prismjs/components/prism-javascript');
+    await import('prismjs/components/prism-typescript');
+    await import('prismjs/components/prism-jsx');
+    await import('prismjs/components/prism-tsx');
+    await import('prismjs/components/prism-css');
+    await import('prismjs/components/prism-bash');
+    await import('prismjs/components/prism-json');
+    await import('prismjs/components/prism-markup');
+    return Prism;
+  })();
+  return prismPromise;
+}
 
 export interface CodeBlockProps {
   /**
@@ -78,7 +90,22 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
   }, [theme.palette.mode]);
 
   useEffect(() => {
-    Prism.highlightAll();
+    let cancelled = false;
+    void loadPrism()
+      .then((Prism) => {
+        if (!cancelled) {
+          Prism.highlightAll();
+        }
+      })
+      .catch((error: unknown) => {
+        prismPromise = undefined;
+        if (!cancelled) {
+          console.error('Failed to load prismjs for CodeBlock', error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [code, language]);
 
   // Get syntax colors from theme with fallback
@@ -157,6 +184,9 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
       <Box
         component="pre"
         className={showLineNumbers ? 'line-numbers' : ''}
+        tabIndex={0}
+        role="region"
+        aria-label="Code sample"
       >
         <code className={`language-${language}`}>
           {code}

--- a/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableDataGrid.test.tsx
+++ b/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableDataGrid.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import OxygenUIThemeProvider from '../../../contexts/OxygenUIThemeProvider/OxygenUIThemeProvider';
+import ListingTable from './ListingTable';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function staticImportSpecifiers(source: string): string[] {
+  const stripped = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+    .replace(/import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g, '')
+    .replace(/export\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g, '');
+
+  const fromSpecs = [...stripped.matchAll(/\b(?:import|export)\s+[\s\S]*?from\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  );
+  const bareSpecs = [...stripped.matchAll(/(?:^|[;\n])\s*import\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  );
+  return [...fromSpecs, ...bareSpecs];
+}
+
+describe('ListingTable.DataGrid', () => {
+  beforeAll(async () => {
+    await import('@mui/x-data-grid');
+  }, 30_000);
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not statically import @mui/x-data-grid', () => {
+    const source = readFileSync(join(here, 'ListingTableDataGrid.tsx'), 'utf8');
+    expect(
+      staticImportSpecifiers(source).filter(
+        (specifier) => specifier === '@mui/x-data-grid' || specifier.startsWith('@mui/x-data-grid/'),
+      ),
+    ).toEqual([]);
+  });
+
+  it('clears the cached Data Grid load when the import rejects', () => {
+    const source = readFileSync(join(here, 'ListingTableDataGrid.tsx'), 'utf8');
+    const loadFn = source.slice(
+      source.indexOf('function loadStyledDataGrid'),
+      source.indexOf('export function ListingTableDataGrid'),
+    );
+    expect(loadFn).toContain('styledDataGridPromise = undefined');
+    expect(loadFn).toMatch(/throw error/);
+  });
+
+  it('announces loading with a status role and no reserved height', () => {
+    render(
+      <OxygenUIThemeProvider>
+        <ListingTable.Provider>
+          <ListingTable.Container>
+            <ListingTable.DataGrid
+              autoHeight
+              rows={[{ id: 1, name: 'Acme' }]}
+              columns={[{ field: 'name', headerName: 'Customer', width: 160 }]}
+            />
+          </ListingTable.Container>
+        </ListingTable.Provider>
+      </OxygenUIThemeProvider>,
+    );
+
+    const status = screen.getByRole('status', { name: 'Loading data grid' });
+    expect(status.getAttribute('aria-busy')).toBe('true');
+    expect(getComputedStyle(status).minHeight).not.toBe('200px');
+  });
+
+  it('renders row values after the grid loads', async () => {
+    render(
+      <OxygenUIThemeProvider>
+        <ListingTable.Provider>
+          <ListingTable.Container>
+            <ListingTable.DataGrid
+              autoHeight
+              rows={[{ id: 1, name: 'Acme' }]}
+              columns={[{ field: 'name', headerName: 'Customer', width: 160 }]}
+            />
+          </ListingTable.Container>
+        </ListingTable.Provider>
+      </OxygenUIThemeProvider>,
+    );
+
+    expect(await screen.findByText('Acme', undefined, { timeout: 15_000 })).toBeTruthy();
+  }, 20_000);
+});

--- a/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableDataGrid.tsx
+++ b/packages/oxygen-ui/src/components/ListingTable/ListingTable/ListingTableDataGrid.tsx
@@ -16,9 +16,10 @@
  * under the License.
  */
 
-import { ReactElement, useCallback } from 'react';
-import { DataGrid, DataGridProps, GridDensity, GridRowSpacingParams } from '@mui/x-data-grid';
-import { styled, alpha } from '@mui/material/styles';
+import { ReactElement, useCallback, useEffect, useState, type ComponentType } from 'react';
+import type { DataGridProps, GridDensity, GridRowSpacingParams } from '@mui/x-data-grid';
+import Box from '@mui/material/Box';
+import { styled, alpha, type Theme } from '@mui/material/styles';
 import { useListingTable } from '../context';
 import { ListingTableDensity, densityStyles } from '../shared/types';
 import type { OxygenTheme } from '../../../styles/OxygenThemeBase';
@@ -33,7 +34,7 @@ export interface ListingTableDataGridProps extends Omit<DataGridProps, 'density'
   density?: ListingTableDensity;
 }
 
-const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
+const dataGridStyles = ({ theme }: { theme: Theme }) => ({
   // Remove outer border for seamless integration within ListingTable.Container
   border: 'none',
   // Ensure the grid fills its container
@@ -88,7 +89,21 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
     outline: `2px solid ${(theme.vars || theme).palette.primary.main}`,
     outlineOffset: -2,
   },
-})) as typeof DataGrid;
+});
+
+let styledDataGridPromise: Promise<ComponentType<DataGridProps>> | undefined;
+
+function loadStyledDataGrid(): Promise<ComponentType<DataGridProps>> {
+  styledDataGridPromise ??= import('@mui/x-data-grid')
+    .then(({ DataGrid }) =>
+      styled(DataGrid)(dataGridStyles) as ComponentType<DataGridProps>,
+    )
+    .catch((error: unknown) => {
+      styledDataGridPromise = undefined;
+      throw error;
+    });
+  return styledDataGridPromise;
+}
 
 /**
  * A `ListingTable` variant that renders an MUI DataGrid instead of a traditional HTML table.
@@ -132,6 +147,24 @@ export function ListingTableDataGrid({
   sx,
   ...props
 }: ListingTableDataGridProps): ReactElement {
+  const [StyledDataGrid, setStyledDataGrid] = useState<ComponentType<DataGridProps> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadStyledDataGrid()
+      .then((Grid) => {
+        if (!cancelled) {
+          setStyledDataGrid(() => Grid);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to load @mui/x-data-grid for ListingTable.DataGrid', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const context = useListingTable();
 
   // Explicit props take priority over context values
@@ -231,8 +264,19 @@ export function ListingTableDataGrid({
 
   const mergedSx =
     variant === 'card'
-      ? [cardSx as Parameters<typeof StyledDataGrid>[0]['sx'], densitySx, ...(Array.isArray(sx) ? sx : [sx])]
+      ? [cardSx, densitySx, ...(Array.isArray(sx) ? sx : [sx])]
       : [densitySx, ...(Array.isArray(sx) ? sx : [sx])];
+
+  if (!StyledDataGrid) {
+    return (
+      <Box
+        role="status"
+        aria-busy="true"
+        aria-label="Loading data grid"
+        sx={{ width: '100%' }}
+      />
+    );
+  }
 
   return (
     <StyledDataGrid

--- a/packages/oxygen-ui/src/data-grid.ts
+++ b/packages/oxygen-ui/src/data-grid.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-data-grid';

--- a/packages/oxygen-ui/src/date-pickers.ts
+++ b/packages/oxygen-ui/src/date-pickers.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers';

--- a/packages/oxygen-ui/src/date-pickers/AdapterDateFns.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterDateFns.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterDateFns';

--- a/packages/oxygen-ui/src/date-pickers/AdapterDateFnsJalali.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterDateFnsJalali.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterDateFnsJalali';

--- a/packages/oxygen-ui/src/date-pickers/AdapterDateFnsJalaliV2.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterDateFnsJalaliV2.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterDateFnsJalaliV2';

--- a/packages/oxygen-ui/src/date-pickers/AdapterDateFnsV2.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterDateFnsV2.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterDateFnsV2';

--- a/packages/oxygen-ui/src/date-pickers/AdapterDayjs.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterDayjs.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterDayjs';

--- a/packages/oxygen-ui/src/date-pickers/AdapterLuxon.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterLuxon.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterLuxon';

--- a/packages/oxygen-ui/src/date-pickers/AdapterMoment.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterMoment.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterMoment';

--- a/packages/oxygen-ui/src/date-pickers/AdapterMomentHijri.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterMomentHijri.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterMomentHijri';

--- a/packages/oxygen-ui/src/date-pickers/AdapterMomentJalaali.ts
+++ b/packages/oxygen-ui/src/date-pickers/AdapterMomentJalaali.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-date-pickers/AdapterMomentJalaali';

--- a/packages/oxygen-ui/src/index.exports.test.ts
+++ b/packages/oxygen-ui/src/index.exports.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function staticImportSpecifiers(source: string): string[] {
+  const stripped = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+    .replace(/import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g, '')
+    .replace(/export\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g, '');
+
+  const fromSpecs = [...stripped.matchAll(/\b(?:import|export)\s+[\s\S]*?from\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  );
+  const bareSpecs = [...stripped.matchAll(/(?:^|[;\n])\s*import\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  );
+  return [...fromSpecs, ...bareSpecs];
+}
+
+function isHeavyUiSpecifier(specifier: string): boolean {
+  const prefixes = ['prismjs', '@mui/x-data-grid', '@mui/x-date-pickers', '@mui/x-tree-view'];
+  return prefixes.some((prefix) => specifier === prefix || specifier.startsWith(`${prefix}/`));
+}
+
+describe('package entry module graph', () => {
+  it('does not statically import Prism or MUI X packages', () => {
+    const source = readFileSync(join(here, 'index.ts'), 'utf8');
+    expect(staticImportSpecifiers(source).filter(isHeavyUiSpecifier)).toEqual([]);
+  });
+});

--- a/packages/oxygen-ui/src/index.ts
+++ b/packages/oxygen-ui/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -56,18 +56,7 @@ export * from '@mui/material';
 // Then: colors.deepOrange[500], colors.deepPurple[500], etc.
 export * as colors from '@mui/material/colors';
 
-// Re-export @mui/x-data-grid as namespace to avoid conflicts
-// Usage: import { DataGrid } from '@wso2/oxygen-ui';
-export * as DataGrid from '@mui/x-data-grid';
-
-// Re-export @mui/x-date-pickers as namespace to avoid conflicts
-// Usage: import { DatePickers } from '@wso2/oxygen-ui';
-export * as DatePickers from '@mui/x-date-pickers';
-
-// Re-export AdapterDateFns for date pickers (most commonly used adapter)
-// Other adapters (Dayjs, Luxon, Moment) can be imported directly from @mui/x-date-pickers if needed
-export { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-
-// Re-export @mui/x-tree-view as namespace to avoid conflicts
-// Usage: import { TreeView } from '@wso2/oxygen-ui';
-export * as TreeView from '@mui/x-tree-view';
+// MUI X (Data Grid, Date Pickers, Tree View) and Prism stay out of this
+// Published entry. Import them from Oxygen subpaths (`@wso2/oxygen-ui/data-grid`,
+// `date-pickers`, `tree-view`). CodeBlock and ListingTable.DataGrid load their
+// heavy deps on mount. See https://github.com/wso2/oxygen-ui/issues/578.

--- a/packages/oxygen-ui/src/oxygen-subpaths.test.ts
+++ b/packages/oxygen-ui/src/oxygen-subpaths.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function staticImportSpecifiers(source: string): string[] {
+  const stripped = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+    .replace(/import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g, '')
+    .replace(/export\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g, '');
+
+  const fromSpecs = [...stripped.matchAll(/\b(?:import|export)\s+[\s\S]*?from\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  );
+  const bareSpecs = [...stripped.matchAll(/(?:^|[;\n])\s*import\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  );
+  return [...fromSpecs, ...bareSpecs];
+}
+
+describe('Oxygen subpaths', () => {
+  it('publishes CommonJS require mappings for MUI X subpaths', () => {
+    const pkg = JSON.parse(readFileSync(join(here, '../package.json'), 'utf8')) as {
+      exports: Record<string, { require?: string }>;
+    };
+
+    expect(pkg.exports['./data-grid']?.require).toBe('./dist/data-grid.cjs');
+    expect(pkg.exports['./date-pickers']?.require).toBe('./dist/date-pickers.cjs');
+    expect(pkg.exports['./date-pickers/*']?.require).toBe('./dist/date-pickers/*.cjs');
+    expect(pkg.exports['./tree-view']?.require).toBe('./dist/tree-view.cjs');
+  });
+
+  it('data-grid re-exports @mui/x-data-grid', () => {
+    const source = readFileSync(join(here, 'data-grid.ts'), 'utf8');
+    expect(staticImportSpecifiers(source)).toEqual(['@mui/x-data-grid']);
+  });
+
+  it('date-pickers exports DatePicker and does not import adapters', () => {
+    const source = readFileSync(join(here, 'date-pickers.ts'), 'utf8');
+    const specifiers = staticImportSpecifiers(source);
+    expect(specifiers).toContain('@mui/x-date-pickers');
+    expect(specifiers.filter((specifier) => specifier.includes('Adapter'))).toEqual([]);
+  });
+
+  it('tree-view exports SimpleTreeView', async () => {
+    const { SimpleTreeView } = await import('./tree-view');
+    expect(SimpleTreeView).toBeDefined();
+  }, 15_000);
+
+  it('date-pickers/AdapterDateFns exports AdapterDateFns', async () => {
+    const { AdapterDateFns } = await import('./date-pickers/AdapterDateFns');
+    expect(AdapterDateFns).toBeDefined();
+  }, 15_000);
+});

--- a/packages/oxygen-ui/src/tree-view.ts
+++ b/packages/oxygen-ui/src/tree-view.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from '@mui/x-tree-view';

--- a/packages/oxygen-ui/src/types/prismjs-components.d.ts
+++ b/packages/oxygen-ui/src/types/prismjs-components.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare module 'prismjs/components/*';

--- a/packages/oxygen-ui/vitest.config.ts
+++ b/packages/oxygen-ui/vitest.config.ts
@@ -21,5 +21,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    css: true,
+    server: {
+      deps: {
+        inline: [/@mui\/x-/],
+      },
+    },
   },
 });

--- a/samples/oxygen-ui-test-app/src/pages/ProjectOverview.tsx
+++ b/samples/oxygen-ui-test-app/src/pages/ProjectOverview.tsx
@@ -32,8 +32,8 @@ import {
   PageContent,
   ListingTable,
   Chip,
-  DataGrid,
 } from '@wso2/oxygen-ui'
+import type { GridColDef, GridRenderCellParams } from '@wso2/oxygen-ui/data-grid'
 import { LineChart } from '@wso2/oxygen-ui-charts-react'
 import { Clock, Plus, RefreshCw, Info, Link as LinkIcon } from '@wso2/oxygen-ui-icons-react'
 import type { JSX } from 'react'
@@ -187,7 +187,7 @@ export default function ProjectOverview(): JSX.Element {
                         headerName: 'Name',
                         flex: 1.5,
                         minWidth: 220,
-                        renderCell: ({ row }: DataGrid.GridRenderCellParams<Component>) => (
+                        renderCell: ({ row }: GridRenderCellParams<Component>) => (
                           <ListingTable.CellIcon
                             sx={{ width: '100%' }}
                             icon={
@@ -229,7 +229,7 @@ export default function ProjectOverview(): JSX.Element {
                         field: 'type',
                         headerName: 'Type',
                         width: 120,
-                        renderCell: ({ row }: DataGrid.GridRenderCellParams<Component>) => (
+                        renderCell: ({ row }: GridRenderCellParams<Component>) => (
                           <Chip label={row.type ?? 'HTTP'} size="small" variant="outlined" />
                         ),
                       },
@@ -239,11 +239,11 @@ export default function ProjectOverview(): JSX.Element {
                         width: 150,
                         headerAlign: 'left',
                         align: 'left',
-                        renderCell: ({ row }: DataGrid.GridRenderCellParams<Component>) => (
+                        renderCell: ({ row }: GridRenderCellParams<Component>) => (
                           <LastUpdatedCell value={row.lastModified} />
                         ),
                       },
-                    ] as DataGrid.GridColDef<Component>[]}
+                    ] as GridColDef<Component>[]}
                     onRowClick={params => navigate(`components/${(params.row as Component).id}`)}
                     disableRowSelectionOnClick
                     hideFooter


### PR DESCRIPTION
### Purpose

Importing `Table` or `Button` from `@wso2/oxygen-ui` evaluated the published ESM file, which statically pulled in `@mui/x-data-grid`, `@mui/x-date-pickers`, `@mui/x-tree-view`, and `prismjs`.

This PR keeps MUI X off the Published entry and publishes named re-exports on Oxygen subpaths so Storybook and product apps still write an Oxygen import:

- `@wso2/oxygen-ui/data-grid`
- `@wso2/oxygen-ui/date-pickers`
- `@wso2/oxygen-ui/tree-view`
- `@wso2/oxygen-ui/date-pickers/AdapterDateFns` (and the other first-party adapters)

`CodeBlock` and `ListingTable.DataGrid` lazy-load Prism / Data Grid on mount.

**Breaking:** `import { DataGrid }` / `DatePickers` / `TreeView` / `AdapterDateFns` from `@wso2/oxygen-ui` is removed. Use the Oxygen subpaths above.

## Summary

Stop evaluating MUI X and Prism for every `@wso2/oxygen-ui` import. Teach those surfaces through Oxygen subpaths, not `@mui/x-*`.

Fixes #578

## Changes

- Removed MUI X namespace re-exports from the Published entry
- Added esbuild entries and `package.json` exports for the Oxygen subpaths
- Pointed DataGrid, DatePicker, and TreeView stories at those paths
- eslint `no-direct-mui-imports` suggests the Oxygen subpath instead of allowlisting `@mui/x-*`
- Major changeset

## Test Plan

- [x] `pnpm --filter @wso2/oxygen-ui test` (58 tests)
- [x] `pnpm --filter @wso2/oxygen-ui typecheck`
- [x] `pnpm --filter @wso2/oxygen-ui lint` (pre-existing warnings only)
- [x] `pnpm --filter @wso2/oxygen-ui build` emits `dist/data-grid.js`, `date-pickers.js`, `tree-view.js`, and adapter files
- [ ] Storybook: DataGrid, DatePicker, TreeView, CodeBlock, ListingTable.DataGrid
- [ ] Consumer that imports only `Table` / `Button` does not evaluate `@mui/x-data-grid` or `prismjs`

### Related Issues

- Fixes #578

### Related PRs

- N/A

### Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/wso2/oxygen-ui/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [x] Unit tests provided. (Add links if there are any)
- [x] Storybook stories updated/added (if applicable)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?